### PR TITLE
[ADD] .githooks directory to share common hooks

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,13 @@
+#!/bin/python3
+import os
+import sys
+
+from flake8.main import git
+
+if __name__ == '__main__':
+    sys.exit(
+        git.hook(
+            strict=git.config_for('strict'),
+            lazy=git.config_for('lazy'),
+        )
+    )


### PR DESCRIPTION
Requires sym-linking action in metax-ops after clonging metax-api.

Hooks cannot be automatically included in cloned repositories to prevent execution of arbitrary code without user consent. The next best  thing is to include the hook-file, and symlink it to .git/hooks/