### PR TITLE
CSCMETAX-25: Redis caching

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ psycopg2==2.7.1  # LGPL with exceptions or ZPL
 pycodestyle==2.3.1  # Expat license (same as MIT)
 pyflakes==1.5.0  # MIT-license
 pyyaml==3.12
+redis==2.10.5
 requests==2.13.0  # Apache 2.0-license
 simplejson==3.10.0  # MIT-license
 uritemplate==3.0.0  # BSD 3-Clause License or Apache License, Version 2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ ipdb==0.10.3
 Jinja2==2.9.5  # BSD-license
 jsonschema==2.6.0
 mccabe==0.6.1  # Expat license (same as MIT)
+msgpack-python==0.4.8
 openapi-codec==1.3.1  # BSD-license
 psycopg2==2.7.1  # LGPL with exceptions or ZPL
 pycodestyle==2.3.1  # Expat license (same as MIT)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,7 @@ coreschema==0.0.4  # BSD-license
 coverage==4.4.1
 coveralls==1.1
 Django==1.11.1  # BSD-license
-django-redis-cache==1.7.1
-hiredis==0.2.0 # Used by django-redis-cache for parser class
+hiredis==0.2.0 # Used by redis (redis-py) for parser
 django-rest-swagger==2.1.2  # FreeBSD-license
 djangorestframework==3.6.2  # BSD-license
 django-rainbowtests==0.6.0
@@ -17,7 +16,6 @@ ipdb==0.10.3
 Jinja2==2.9.5  # BSD-license
 jsonschema==2.6.0
 mccabe==0.6.1  # Expat license (same as MIT)
-msgpack-python==0.4.8
 openapi-codec==1.3.1  # BSD-license
 psycopg2==2.7.1  # LGPL with exceptions or ZPL
 pycodestyle==2.3.1  # Expat license (same as MIT)

--- a/src/.coveragerc
+++ b/src/.coveragerc
@@ -13,6 +13,8 @@ exclude_lines =
     # def __repr__
     # def __str__
     if self.debug
+    if self._debug
+    if self._DEBUG
     if settings.DEBUG
     raise AssertionError
     raise NotImplementedError

--- a/src/metax_api/api/base/views/common_view.py
+++ b/src/metax_api/api/base/views/common_view.py
@@ -5,6 +5,7 @@ from rest_framework.response import Response
 from rest_framework.viewsets import ModelViewSet
 
 from metax_api.services import CommonService
+from metax_api.utils import RedisSentinelCache
 
 import logging
 _logger = logging.getLogger(__name__)
@@ -19,6 +20,7 @@ class CommonViewSet(ModelViewSet):
     """
 
     lookup_field_internal = None
+    cache = RedisSentinelCache()
 
     def get_object(self, search_params=None):
         """

--- a/src/metax_api/api/base/views/dataset_view.py
+++ b/src/metax_api/api/base/views/dataset_view.py
@@ -121,3 +121,26 @@ class DatasetViewSet(CommonViewSet):
         self.check_object_permissions(self.request, obj)
 
         return obj
+
+    @detail_route(methods=['get'], url_path="redis")
+    def redis_test(self, request, pk=None): # pragma: no cover
+        try:
+            cached = self.cache.get('cr-1211%s' % pk)
+        except:
+            d('redis: could not connect during read')
+            cached = None
+            raise
+
+        if cached:
+            d('found in cache, returning')
+            return Response(data=cached, status=status.HTTP_200_OK)
+
+        data = self.get_serializer(CatalogRecord.objects.get(pk=1)).data
+
+        try:
+            self.cache.set('cr-1211%s' % pk, data)
+        except:
+            d('redis: could not connect during write')
+            raise
+
+        return Response(data=data, status=status.HTTP_200_OK)

--- a/src/metax_api/settings.py
+++ b/src/metax_api/settings.py
@@ -252,30 +252,27 @@ STATIC_URL = '/static/'
 # https://www.peterbe.com/plog/fastest-redis-optimization-for-django
 # Currently using this (pip: django-redis-cache): https://github.com/sebleier/django-redis-cache
 # Consider alternatively pip:django-redis: https://github.com/niwinz/django-redis
+CACHES = {
+    'default': {
+        'BACKEND': "redis_cache.RedisCache",
+        'LOCATION': [
+            '%s:%s' % (os.getenv('REDIS_MASTER_SERVICE_HOST', '127.0.0.1'),
+                       os.getenv('REDIS_MASTER_SERVICE_PORT', 6379)),
+            '%s:%s' % (os.getenv('REDIS_SLAVE_SERVICE_HOST', '127.0.0.1'),
+                       os.getenv('REDIS_SLAVE_SERVICE_PORT', 6379))
+        ],
+        'OPTIONS': {
+            'DB': 1,
+            'PARSER_CLASS': 'redis.connection.HiredisParser',
+            'SERIALIZER_CLASS': 'redis_cache.serializers.MSGPackSerializer',
+            'COMPRESSOR_CLASS': 'redis_cache.compressors.ZLibCompressor',
+            'MASTER_CACHE': '%s:%s' % (
+                os.getenv('REDIS_MASTER_SERVICE_HOST', '127.0.0.1'),
+                os.getenv('REDIS_MASTER_SERVICE_PORT', 6379))
+        }
+    }
+}
 
 if os.getenv('TRAVIS', None):
-    CACHES = {
-        'default': {
-            'BACKEND': "redis_cache.RedisCache",
-            'LOCATION': 'redis://127.0.0.1:6379/1',
-            'OPTIONS': {
-                'DB': 1,
-                'PARSER_CLASS': 'redis.connection.HiredisParser',
-                'SERIALIZER_CLASS': 'redis_cache.serializers.MSGPackSerializer',
-                'COMPRESSOR_CLASS': 'redis_cache.compressors.ZLibCompressor'
-            }
-        }
-    }
-else:
-    CACHES = {
-        'default': {
-            'BACKEND': "redis_cache.RedisCache",
-            'LOCATION': "/run/redis/redis.sock",
-            'OPTIONS': {
-                'DB': 1,
-                'PARSER_CLASS': 'redis.connection.HiredisParser',
-                'SERIALIZER_CLASS': 'redis_cache.serializers.MSGPackSerializer',
-                'COMPRESSOR_CLASS': 'redis_cache.compressors.ZLibCompressor'
-            }
-        }
-    }
+    CACHES['default']['LOCATION'] = '127.0.0.1:6379'
+    CACHES['default']['OPTIONS']['MASTER_CACHE'] = '127.0.0.1:6379'

--- a/src/metax_api/settings.py
+++ b/src/metax_api/settings.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/1.11/ref/settings/
 
 import logging.config
 import os
+import sys
 import yaml
 
 if not os.getenv('TRAVIS', None):
@@ -273,6 +274,6 @@ CACHES = {
     }
 }
 
-if os.getenv('TRAVIS', None):
-    CACHES['default']['LOCATION'] = '127.0.0.1:6379'
-    CACHES['default']['OPTIONS']['MASTER_CACHE'] = '127.0.0.1:6379'
+# automated tests or travis do not currently use any kind of caching
+if 'test' in sys.argv or os.getenv('TRAVIS', None):
+    CACHES = { 'default': { 'BACKEND': 'django.core.cache.backends.dummy.DummyCache' }}

--- a/src/metax_api/settings.py
+++ b/src/metax_api/settings.py
@@ -248,30 +248,17 @@ PROJECT_DIR = os.path.dirname(os.path.abspath(__file__))
 STATIC_ROOT = os.path.join(os.path.dirname(PROJECT_DIR), 'static')
 STATIC_URL = '/static/'
 
+# settings for custom redis-py cache helper in utils/redis.py
+REDIS_SENTINEL = {
+    # at least three are required
+    'REDIS_SENTINEL_HOSTS': [('127.0.0.1', 5000), ('127.0.0.1', 5001), ('127.0.0.1', 5002)],
+    'REDIS_SENTINEL_SERVICE': 'metax-master',
 
-# Redis Cache
-# https://www.peterbe.com/plog/fastest-redis-optimization-for-django
-# Currently using this (pip: django-redis-cache): https://github.com/sebleier/django-redis-cache
-# Consider alternatively pip:django-redis: https://github.com/niwinz/django-redis
-CACHES = {
-    'default': {
-        'BACKEND': "redis_cache.RedisCache",
-        'LOCATION': [
-            '%s:%s' % (os.getenv('REDIS_MASTER_SERVICE_HOST', '127.0.0.1'),
-                       os.getenv('REDIS_MASTER_SERVICE_PORT', 6379)),
-            '%s:%s' % (os.getenv('REDIS_SLAVE_SERVICE_HOST', '127.0.0.1'),
-                       os.getenv('REDIS_SLAVE_SERVICE_PORT', 6379))
-        ],
-        'OPTIONS': {
-            'DB': 1,
-            'PARSER_CLASS': 'redis.connection.HiredisParser',
-            'SERIALIZER_CLASS': 'redis_cache.serializers.MSGPackSerializer',
-            'COMPRESSOR_CLASS': 'redis_cache.compressors.ZLibCompressor',
-            'MASTER_CACHE': '%s:%s' % (
-                os.getenv('REDIS_MASTER_SERVICE_HOST', '127.0.0.1'),
-                os.getenv('REDIS_MASTER_SERVICE_PORT', 6379))
-        }
-    }
+    # https://github.com/andymccurdy/redis-py/issues/485#issuecomment-44555664
+    'REDIS_SENTINEL_SOCKET_TIMEOUT': 0.1,
+
+    # enables extra logging to console during cache usage
+    'REDIS_SENTINEL_DEBUG': False,
 }
 
 # automated tests or travis do not currently use any kind of caching

--- a/src/metax_api/utils/__init__.py
+++ b/src/metax_api/utils/__init__.py
@@ -1,0 +1,1 @@
+from .redis import RedisSentinelCache

--- a/src/metax_api/utils/redis.py
+++ b/src/metax_api/utils/redis.py
@@ -1,0 +1,88 @@
+from pickle import dumps as pickle_dumps, loads as pickle_loads
+
+from django.conf import settings
+from redis.sentinel import Sentinel
+from redis.exceptions import TimeoutError
+from redis.sentinel import MasterNotFoundError
+
+import logging
+_logger = logging.getLogger(__name__)
+d = logging.getLogger(__name__).debug
+
+class RedisSentinelCache():
+
+    def __init__(self):
+        if not hasattr(settings, 'REDIS_SENTINEL'):
+            raise Exception('Missing configuration from settings.py: REDIS_SENTINEL')
+        if not settings.REDIS_SENTINEL.get('REDIS_SENTINEL_HOSTS', None):
+            raise Exception('Missing configuration from settings.py for REDIS_SENTINEL: REDIS_SENTINEL_HOSTS')
+        if not settings.REDIS_SENTINEL.get('REDIS_SENTINEL_SERVICE', None):
+            raise Exception('Missing configuration from settings.py for REDIS_SENTINEL: REDIS_SENTINEL_SERVICE')
+        if len(settings.REDIS_SENTINEL['REDIS_SENTINEL_HOSTS']) < 3:
+            raise Exception('Invaling configuration in settings.py for REDIS_SENTINEL: REDIS_SENTINEL_HOSTS minimum number of hosts is 3')
+
+        self._sentinel = Sentinel(settings.REDIS_SENTINEL['REDIS_SENTINEL_HOSTS'],
+            socket_timeout=settings.REDIS_SENTINEL.get('SOCKET_TIMEOUT', 0.1))
+        self._service_name = settings.REDIS_SENTINEL['REDIS_SENTINEL_SERVICE']
+        self._DEBUG = settings.REDIS_SENTINEL.get('REDIS_SENTINEL_DEBUG', False)
+
+    def set(self, key, value, **kwargs):
+        if self._DEBUG:
+            d('cache: set()...')
+        pickled_data = pickle_dumps(value)
+        master = self._get_master()
+
+        try:
+            master.set(key, pickled_data, **kwargs)
+        except (TimeoutError, MasterNotFoundError):
+            if self._DEBUG:
+                d('cache: master timed out or not found. no write instances available. raising error')
+            # no master available
+            return
+
+        if self._DEBUG:
+            test = master.get(key)
+            if test:
+                d('cache: set() successful')
+            else:
+                d('cache: set() unsuccessful, could not get saved data?')
+
+    def get(self, key, **kwargs):
+        if self._DEBUG:
+            d('cache: get()...')
+
+        slave = self._get_slave()
+
+        try:
+            res = slave.get(key, **kwargs)
+        except TimeoutError:
+            if self._DEBUG:
+                d('cache: slave.get() timed out, trying from master instead. fail-over in process?')
+            # fail-over propbably happened, and the old slave is now a master
+            # (in case there was only one slave). # try master instead
+            pass
+        else:
+            return pickle_loads(res)
+
+        master = self._get_master()
+
+        try:
+            res = master.get(key, **kwargs)
+        except (TimeoutError, MasterNotFoundError):
+            if self._DEBUG:
+                d('cache: master timed out also. no read instances available. returning None')
+            # uh oh, no master available either. either all redis instances have hit the bucket,
+            # or there is a fail-over in process, and a new master will be in line in a moment
+            return None
+
+        return pickle_loads(res)
+
+    def _get_master(self):
+        if self._DEBUG:
+            d('cache: getting master')
+        return self._sentinel.master_for(self._service_name, socket_timeout=0.1)
+
+    def _get_slave(self):
+        if self._DEBUG:
+            d('cache: getting slave')
+        return self._sentinel.slave_for(self._service_name, socket_timeout=0.1)

--- a/src/metax_api/utils/redis.py
+++ b/src/metax_api/utils/redis.py
@@ -62,7 +62,7 @@ class RedisSentinelCache():
             # (in case there was only one slave). # try master instead
             pass
         else:
-            return pickle_loads(res)
+            return pickle_loads(res) if res is not None else None
 
         master = self._get_master()
 
@@ -75,7 +75,7 @@ class RedisSentinelCache():
             # or there is a fail-over in process, and a new master will be in line in a moment
             return None
 
-        return pickle_loads(res)
+        return pickle_loads(res) if res is not None else None
 
     def _get_master(self):
         if self._DEBUG:

--- a/src/metax_api/utils/redis.py
+++ b/src/metax_api/utils/redis.py
@@ -48,6 +48,9 @@ class RedisSentinelCache():
                 d('cache: set() unsuccessful, could not get saved data?')
 
     def get(self, key, **kwargs):
+        # todo randomly select slave or master for max profit
+        # todo allow reading from cache when master is down? could possibly serve stale data.
+        # see redis.conf setting: slave-serve-stale-data
         if self._DEBUG:
             d('cache: get()...')
 


### PR DESCRIPTION
Groundwork for using redis caching in the future. Helper methods to utilize redis sentinels using redis-py https://github.com/andymccurdy/redis-py.

Django redis-cache only supports master-slave setup for load balancing, where master failing renders cache unable to do new writes. Proper fail-over requires use of sentinels. redis-cache currently does not support them.

django-redis-sentinel-redux attempts to add support for sentinels, but has not been updated in 9 months, and does not work with latest versions of redis-cache.