### PR TITLE
CSCMETAX-173: [REM] Remove TTL of 2 days when storing reference_data …

### DIFF
--- a/src/metax_api/utils/reference_data_service.py
+++ b/src/metax_api/utils/reference_data_service.py
@@ -9,7 +9,6 @@ import logging
 _logger = logging.getLogger(__name__)
 d = logging.getLogger(__name__).debug
 
-ONE_DAY = 86400
 
 class ReferenceDataService():
 
@@ -38,7 +37,7 @@ class ReferenceDataService():
             _logger.exception('Reference data fetch failed')
             reference_data = {}
 
-        cache.set('reference_data', reference_data, ex=ONE_DAY * 2)
+        cache.set('reference_data', reference_data)
 
         reference_data_check = cache.get('reference_data')
 


### PR DESCRIPTION
…to redis

In metax-test reference_data has disappeared several times, although TTL should
be reset every night when ref data is updated. Removing TTL to see if it has any
effect or if the problem is elsewhere.