### PR TITLE
CSCMETAX-193: [ADD] Reload reference data during requests when ref da…

### DIFF
--- a/src/metax_api/cron/update_reference_data.py
+++ b/src/metax_api/cron/update_reference_data.py
@@ -3,7 +3,7 @@ sys.path.append(path.dirname(path.dirname(path.abspath(__file__))))
 
 from datetime import datetime
 import yaml
-from utils import RedisSentinelCache, ReferenceDataService
+from utils import RedisSentinelCache, ReferenceDataLoader
 
 """
 Script called by cronjob to update reference data from elasticsearch to local cache
@@ -17,7 +17,7 @@ def update_reference_data():
     es_settings = app_config_dict.get('ELASTICSEARCH', None)
 
     cache = RedisSentinelCache(master_only=True, settings=redis_settings)
-    ReferenceDataService.populate_cache_reference_data(cache, settings=es_settings)
+    ReferenceDataLoader.populate_cache_reference_data(cache, settings=es_settings)
 
 def get_time():
     return str(datetime.now().replace(microsecond=0))

--- a/src/metax_api/onappstart.py
+++ b/src/metax_api/onappstart.py
@@ -4,7 +4,7 @@ import sys
 from django.apps import AppConfig
 from django.conf import settings
 
-from metax_api.utils import RedisSentinelCache, executing_test_case, ReferenceDataService
+from metax_api.utils import RedisSentinelCache, executing_test_case, ReferenceDataLoader
 
 import logging
 _logger = logging.getLogger(__name__)
@@ -37,6 +37,7 @@ class OnAppStart(AppConfig):
             return
 
         # actual startup tasks ->
+        _logger.info('Metax API startup tasks executing...')
 
         try:
             if executing_test_case():
@@ -46,7 +47,7 @@ class OnAppStart(AppConfig):
                 cache.set('reference_data', None)
 
             if not cache.get('reference_data'):
-                ReferenceDataService.populate_cache_reference_data(cache)
+                ReferenceDataLoader.populate_cache_reference_data(cache)
             else:
                 # d('cache already populated')
                 pass
@@ -57,3 +58,5 @@ class OnAppStart(AppConfig):
             # before resetting the flag. (on local this method can be quite fast)
             sleep(2)
             cache.delete('on_app_start_executing')
+
+        _logger.info('Metax API startup tasks finished')

--- a/src/metax_api/services/__init__.py
+++ b/src/metax_api/services/__init__.py
@@ -1,3 +1,4 @@
 from .catalog_record_service import CatalogRecordService
 from .common_service import CommonService
 from .data_catalog_service import DataCatalogService
+from .reference_data_mixin import ReferenceDataMixin

--- a/src/metax_api/services/catalog_record_service.py
+++ b/src/metax_api/services/catalog_record_service.py
@@ -193,8 +193,7 @@ class CatalogRecordService(CommonService, ReferenceDataMixin):
         - label (usually to object's field 'pref_label')
 
         """
-
-        reference_data = cache.get('reference_data')
+        reference_data = cls.get_reference_data(cache)
         refdata = reference_data['reference_data']
         orgdata = reference_data['organization_data']
         errors = defaultdict(list)

--- a/src/metax_api/services/data_catalog_service.py
+++ b/src/metax_api/services/data_catalog_service.py
@@ -21,7 +21,7 @@ class DataCatalogService(ReferenceDataMixin):
         - label (usually to object's field 'pref_label')
 
         """
-        reference_data = cache.get('reference_data')
+        reference_data = cls.get_reference_data(cache)
         refdata = reference_data['reference_data']
         errors = defaultdict(list)
 

--- a/src/metax_api/services/reference_data_mixin.py
+++ b/src/metax_api/services/reference_data_mixin.py
@@ -1,9 +1,22 @@
+from time import sleep
+
+from django.conf import settings as django_settings
+
+from metax_api.exceptions import Http503
+from metax_api.utils import ReferenceDataLoader
+
+import logging
+_logger = logging.getLogger(__name__)
+d = _logger.debug
+
 
 class ReferenceDataMixin():
 
     """
     Helper methods that other service classes can use when dealing with reference data
     """
+
+    REF_DATA_RELOAD_MAX_RETRIES = 4
 
     def check_ref_data(ref_data_type, field_to_check, relation_name, errors):
         """
@@ -26,6 +39,45 @@ class ReferenceDataMixin():
             errors[relation_name].append('Identifier \'%s\' not found in reference data' % field_to_check)
         return None
 
+    @classmethod
+    def get_reference_data(cls, cache):
+        """
+        Return reference data from cache, and attempt to reload it from ES if reference_data key
+        is missing. If reference data reload is in progress by another request, retry for five
+        seconds, and give up.
+        """
+        ref_data = cache.get('reference_data')
+
+        if ref_data:
+            return ref_data
+        else:
+            _logger.info('reference_data missing from cache - attempting to reload')
+
+        try:
+            state = ReferenceDataLoader.populate_cache_reference_data(cache)
+        except Exception as e:
+            cls._raise_reference_data_reload_error(e)
+
+        for retry in range(0, cls.REF_DATA_RELOAD_MAX_RETRIES + 1):
+
+            # when ref data was just populated, always retrieve from master to ensure
+            # data is found, since there is a delay in data flow to slaves
+            ref_data = cache.get('reference_data', master=True)
+
+            if ref_data:
+                return ref_data
+            elif state == 'reload_started_by_other' and retry < cls.REF_DATA_RELOAD_MAX_RETRIES:
+                sleep(1)
+            elif state == 'reload_started_by_other' and retry >= cls.REF_DATA_RELOAD_MAX_RETRIES:
+                cls._raise_reference_data_reload_error(
+                    'Reload in progress by another request. Retried max times, and gave up'
+                )
+            else:
+                cls._raise_reference_data_reload_error(
+                    'Current request tried to reload reference data, but apparently failed,'
+                    ' since key reference_data is still missing'
+                )
+
     def populate_from_ref_data(ref_entry, obj, uri_field='identifier', label_field=None):
         """
         Always populate at least uri field (even if it was alread there, no big deal).
@@ -34,3 +86,17 @@ class ReferenceDataMixin():
         obj[uri_field] = ref_entry['uri']
         if label_field and 'label' in ref_entry:
             obj[label_field] = ref_entry['label']
+
+    def _raise_reference_data_reload_error(error):
+        """
+        Log exception about reference data load failure, and return a user friendly error message
+        with HTTP 503.
+        """
+        _logger.exception(
+            'Failed to reload reference_data from ES - raising 503 temporarily unavailable.'
+            ' Details:\n%s' % error
+        )
+        error_msg = 'Reference data temporarily unavailable. Please try again later'
+        if django_settings.DEBUG:
+            error_msg += ' DEBUG: %s' % str(error)
+        raise Http503(error_msg)

--- a/src/metax_api/tests/services/__init__.py
+++ b/src/metax_api/tests/services/__init__.py
@@ -1,0 +1,1 @@
+from .reference_data_mixin import ReferenceDataMixinTests

--- a/src/metax_api/tests/services/reference_data_mixin.py
+++ b/src/metax_api/tests/services/reference_data_mixin.py
@@ -4,10 +4,22 @@ from django.test import TestCase
 
 from metax_api.tests.utils import TestClassUtils
 from metax_api.services import ReferenceDataMixin as RDM
-from metax_api.utils import _RedisSentinelCache, RedisSentinelCache, ReferenceDataLoader
+from metax_api.utils import (
+    _RedisSentinelCache,
+    _RedisSentinelCacheDummy,
+    executing_travis,
+    RedisSentinelCache,
+    ReferenceDataLoader,
+)
 
 
-class MockRedisSentinelCache(_RedisSentinelCache):
+if executing_travis():
+    _RedisCacheClass = _RedisSentinelCacheDummy
+else:
+    _RedisCacheClass = _RedisSentinelCache
+
+
+class MockRedisSentinelCache(_RedisCacheClass):
 
     def __init__(self, return_data_after_retries=0, *args, **kwargs):
         self.call_count = 0

--- a/src/metax_api/tests/services/reference_data_mixin.py
+++ b/src/metax_api/tests/services/reference_data_mixin.py
@@ -1,0 +1,133 @@
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from metax_api.tests.utils import TestClassUtils
+from metax_api.services import ReferenceDataMixin as RDM
+from metax_api.utils import _RedisSentinelCache, RedisSentinelCache, ReferenceDataLoader
+
+
+class MockRedisSentinelCache(_RedisSentinelCache):
+
+    def __init__(self, return_data_after_retries=0, *args, **kwargs):
+        self.call_count = 0
+        self.return_data_after_retries = return_data_after_retries
+        super(MockRedisSentinelCache, self).__init__(*args, **kwargs)
+
+    def get(self, *args, **kwargs):
+        """
+        Fakes "cache is currently being populated by another process" by returning None
+        until the request has retried return_data_after_retries times
+        """
+        self.call_count += 1
+        if self.call_count <= self.return_data_after_retries - 1:
+            return None
+        return super(MockRedisSentinelCache, self).get(*args, **kwargs)
+
+
+class ReferenceDataMixinTests(TestCase, TestClassUtils):
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        Loaded only once for test cases inside this class.
+        """
+
+        # so that we dont have to wait all day for tests to execute
+        RDM.REF_DATA_RELOAD_MAX_RETRIES = 2
+
+        super(ReferenceDataMixinTests, cls).setUpClass()
+        cls.cache = RedisSentinelCache()
+
+    def setUp(self):
+        self.cache.delete('reference_data')
+
+    def tearDown(self):
+        # re-populate cache with ref data to not disturb other test suites
+        ReferenceDataLoader.populate_cache_reference_data(RedisSentinelCache())
+
+    def test_reference_data_reload_ok(self):
+        """
+        Reference data is deleted from cache in setUp(), but the RDM should
+        try to reload it from ES. No mocking, using original code.
+        """
+        RDM.get_reference_data(self.cache)
+        self._assert_reference_data_ok()
+
+    @patch('metax_api.services.reference_data_mixin.ReferenceDataLoader.populate_cache_reference_data')
+    def test_reference_data_reload_in_progress(self, mock_populate_cache_reference_data):
+        """
+        Ensure the reference data fetch survives when another request has already started
+        reloading the reference data. The method should retry for a few seconds, and finally succeed
+        """
+        return_data_after_retries = 1
+        mock_populate_cache_reference_data.return_value = 'reload_started_by_other'
+        self._populate_cache_reference_data()
+        mock_cache = MockRedisSentinelCache(return_data_after_retries=return_data_after_retries)
+
+        # the method being tested
+        RDM.get_reference_data(mock_cache)
+
+        self._assert_reference_data_ok()
+        self.assertEqual(mock_cache.call_count, return_data_after_retries, 'ref data fetching should have retried a few times before succeeding')
+
+    @patch('metax_api.services.reference_data_mixin.ReferenceDataLoader.populate_cache_reference_data')
+    def test_reference_data_reload_in_progress_times_out(self, mock_populate_cache_reference_data):
+        """
+        Ensure the reference data fetch finally gives up when another request has already started
+        reloading the reference data. The method should retry for a few seconds, and then give up
+        """
+
+        # since get_reference_data() retries MAX_RETRIES times, it should give up
+        return_data_after_retries = 100
+
+        mock_populate_cache_reference_data.return_value = 'reload_started_by_other'
+        self._populate_cache_reference_data()
+        mock_cache = MockRedisSentinelCache(return_data_after_retries=return_data_after_retries)
+
+        try:
+            # the method being tested
+            RDM.get_reference_data(mock_cache)
+        except Exception as e:
+            self.assertEqual(e.__class__.__name__, 'Http503', 'ref data reload should raise Http503 when it gives up')
+
+        self._assert_reference_data_ok()
+
+    @patch('metax_api.services.reference_data_mixin.ReferenceDataLoader.populate_cache_reference_data')
+    def test_reference_data_reload_failed(self, mock_populate_cache_reference_data):
+        """
+        Ensure 503 is raised when reload by the request failed
+        """
+
+        # since get_reference_data() retries MAX_RETRIES times, it should give up
+        return_data_after_retries = 100
+
+        # implies the request itself is reloading the data, and get_reference_data() will not retry
+        # after first fail.
+        mock_populate_cache_reference_data.return_value = None
+
+        self._populate_cache_reference_data()
+        mock_cache = MockRedisSentinelCache(return_data_after_retries=return_data_after_retries)
+
+        try:
+            # the method being tested
+            RDM.get_reference_data(mock_cache)
+        except Exception as e:
+            self.assertEqual(e.__class__.__name__, 'Http503', 'ref data reload should raise Http503 when it gives up')
+
+        self._assert_reference_data_ok()
+
+    def _assert_reference_data_ok(self):
+        self.assertEqual('reference_data' in self.cache.get('reference_data'), True)
+        self.assertEqual('organization_data' in self.cache.get('reference_data'), True)
+
+    def _populate_cache_reference_data(self):
+        """
+        The method ReferenceDataLoader.populate_cache_reference_data always returns a mock value
+        in the tests. Instead, this method is executed to load something in the cache, which
+        get_reference_data() will then try to return
+        """
+        self.cache.set('reference_data', {
+            'reference_data': { 'language': ['stuff'] },
+            'organization_data': { 'organization': ['stuff'] },
+        })

--- a/src/metax_api/utils/__init__.py
+++ b/src/metax_api/utils/__init__.py
@@ -1,4 +1,4 @@
 from .rabbitmq import RabbitMQ
-from .redis import RedisSentinelCache
-from .reference_data_service import ReferenceDataService
+from .redis import _RedisSentinelCache, RedisSentinelCache
+from .reference_data_loader import ReferenceDataLoader
 from .utils import *

--- a/src/metax_api/utils/__init__.py
+++ b/src/metax_api/utils/__init__.py
@@ -1,4 +1,4 @@
 from .rabbitmq import RabbitMQ
-from .redis import _RedisSentinelCache, RedisSentinelCache
+from .redis import _RedisSentinelCache, _RedisSentinelCacheDummy, RedisSentinelCache
 from .reference_data_loader import ReferenceDataLoader
 from .utils import *

--- a/src/metax_api/utils/redis.py
+++ b/src/metax_api/utils/redis.py
@@ -93,11 +93,12 @@ class _RedisSentinelCache():
         """
         return self.set(key, value, nx=True, **kwargs)
 
-    def get(self, key, **kwargs):
+    def get(self, key, master=False, **kwargs):
         """
         Randomly select slave or master for reading. Fallback to master anyway in case of errors.
 
-        Use of master can be forced by using the master_only flag in the constructor.
+        Use of master can be forced by using the master_only flag in the constructor, or passing
+        master=True to this method for single get operations only.
         """
 
         # todo allow reading from cache when master is down? could possibly serve stale data.
@@ -105,7 +106,7 @@ class _RedisSentinelCache():
         if self._DEBUG:
             d('cache: get()...')
 
-        if self._read_from_master_only:
+        if self._read_from_master_only or master:
             return self._get_from_master(key, **kwargs)
         else:
             if self._slave_chosen():


### PR DESCRIPTION
…ta missing from cache

Content of key 'reference_data' still seems to go missing sometimes from cache, so attempt
to reload ref data during requests and continue the request normally. When multiple requests
are trying to access ref data simultaneously, only one request will proceed with the reload,
while other requests will wait for 5 seconds, retrying to access the ref data each second,
and then either succeed or give up with a http 503 error (service temporarily unavailable).