### PR TITLE
CSCMETAX 197: Alternate records handling

### DIFF
--- a/src/metax_api/api/base/api_schemas/catalogrecord.json
+++ b/src/metax_api/api/base/api_schemas/catalogrecord.json
@@ -30,6 +30,15 @@
                     "description":"Dataset described by this metadata record. Detailed in http://iow.csc.fi/model/mrd/ResearchDataset/",
                     "type":"object"
                 },
+                "alternate_record_set":{
+                    "title":"Alternate Records",
+                    "description":"List of records who share the same preferred_identifier value, but are saved in different data catalogs. The list of contains the urn_identifier values of those records.",
+                    "type":"array",
+                    "items":{
+                        "type":"string"
+                    },
+                    "readonly": true
+                },
                 "preservation_state":{
                     "title":"Preservation state",
                     "description":"state of dataset in PAS cycle: 0 = Not in PAS, 1 = Proposed for midtterm, 2 = Proposed for long term, 3, =in packaging service, 4 = in dissemination, 5 = in midterm preservation, 6 = in longterm preservation, 7 = Rejected long-term preservation, 8 = Rejected mid-term preservation",

--- a/src/metax_api/api/base/views/dataset_view.py
+++ b/src/metax_api/api/base/views/dataset_view.py
@@ -36,12 +36,9 @@ class DatasetViewSet(CommonViewSet):
             return super(DatasetViewSet, self).get_object()
         except Http404:
             if CRS.is_primary_key(self.kwargs.get(self.lookup_field, False)):
-                # fail on pk search is clear, but other identifiers can have matches
-                # in a dataset's other identifier fields
+                # fail on pk search is clear...
                 raise
-        except Exception:
-            raise
-
+        # ...but other identifiers can have matches in a dataset's other identifier fields
         return self._search_using_other_dataset_identifiers()
 
     def get_queryset(self):
@@ -168,18 +165,15 @@ class DatasetViewSet(CommonViewSet):
         preferred_identifier first, and array other_identifier after, if there are matches
         """
         lookup_value = self.kwargs.get(self.lookup_field)
-        try:
-            obj = self._search_from_research_dataset({'urn_identifier': lookup_value}, False)
+        obj = self._search_from_research_dataset({'urn_identifier': lookup_value}, False)
 
-            # allow preferred and other identifier searches only for GET, since their persistence
-            # is not guaranteed over time.
-            if not obj and self.request.method == 'GET':
-                obj = self._search_from_research_dataset({'preferred_identifier': lookup_value}, False)
-                if not obj:
-                    obj = self._search_from_research_dataset(
-                        {'other_identifier': [{'local_identifier': lookup_value}]}, True)
-        except Exception:
-            raise
+        # allow preferred and other identifier searches only for GET, since their persistence
+        # is not guaranteed over time.
+        if not obj and self.request.method == 'GET':
+            obj = self._search_from_research_dataset({'preferred_identifier': lookup_value}, False)
+            if not obj:
+                obj = self._search_from_research_dataset(
+                    {'other_identifier': [{'local_identifier': lookup_value}]}, True)
 
         if not obj:
             raise Http404
@@ -193,10 +187,7 @@ class DatasetViewSet(CommonViewSet):
         except Http404:
             if raise_on_404:
                 raise
-            else:
-                return None
-        except Exception:
-            raise
+            return None
 
     def _get_removed_dataset(self):
         """

--- a/src/metax_api/migrations/0002_create_json_indexes__keep.py
+++ b/src/metax_api/migrations/0002_create_json_indexes__keep.py
@@ -20,7 +20,7 @@ class Migration(migrations.Migration):
     operations = [
         # datasets
         migrations.RunSQL("CREATE UNIQUE INDEX IF NOT EXISTS cat_rec_urn_ident ON metax_api_catalogrecord ((research_dataset->>'urn_identifier'));"),
-        migrations.RunSQL("CREATE UNIQUE INDEX IF NOT EXISTS cat_rec_preferred_ident ON metax_api_catalogrecord ((research_dataset->>'preferred_identifier'));"),
+        migrations.RunSQL("CREATE UNIQUE INDEX IF NOT EXISTS cat_rec_preferred_ident ON metax_api_catalogrecord (data_catalog_id, (research_dataset->>'preferred_identifier'));"),
 
         # data catalogs
         migrations.RunSQL("CREATE UNIQUE INDEX IF NOT EXISTS dat_cat_ident ON metax_api_datacatalog ((catalog_json->>'identifier'));"),

--- a/src/metax_api/models/__init__.py
+++ b/src/metax_api/models/__init__.py
@@ -1,4 +1,4 @@
-from .catalog_record import CatalogRecord
+from .catalog_record import AlternateRecordSet, CatalogRecord
 from .contract import Contract
 from .file import File
 from .file_storage import FileStorage

--- a/src/metax_api/tests/api/base/apitests/catalog_records/write.py
+++ b/src/metax_api/tests/api/base/apitests/catalog_records/write.py
@@ -4,7 +4,7 @@ from django.core.management import call_command
 from rest_framework import status
 from rest_framework.test import APITestCase
 
-from metax_api.models import CatalogRecord, DataCatalog
+from metax_api.models import AlternateRecordSet, CatalogRecord, DataCatalog
 from metax_api.tests.utils import test_data_file_path, TestClassUtils
 from metax_api.utils import RedisSentinelCache
 
@@ -1065,3 +1065,192 @@ class CatalogRecordApiWriteReferenceDataTests(CatalogRecordApiWriteCommon):
         # the black sheep
         self.assertEqual(refs['organization']['label']['default'],     new_rd['is_output_of'][0]['source_organization'][0].get('name', None))
         self.assertEqual(refs['checksum_algorithm']['label'], new_rd['remote_resources'][0]['checksum'].get('checksum_algorithm', None))
+
+
+class CatalogRecordApiWriteAlternateRecords(CatalogRecordApiWriteCommon):
+
+    """
+    Tests related to handling alternate records: Records which have the same
+    preferred_identifier, but are in different data catalogs.
+    """
+
+    def setUp(self):
+        super(CatalogRecordApiWriteAlternateRecords, self).setUp()
+        self.preferred_identifier = self._set_preferred_identifier_to_record(pk=1, data_catalog=1)
+        self.test_new_data['research_dataset']['preferred_identifier'] = self.preferred_identifier
+        self.test_new_data['data_catalog'] = 2
+
+    def test_alternate_record_set_is_created_if_it_doesnt_exist(self):
+        """
+        Add a record, where a record already existed with the same pref_id, but did not have an
+        alternate_record_set yet. Ensure a new set is created, and both records are added to it.
+        """
+        existing_records_count = CatalogRecord.objects.filter(research_dataset__contains={ 'preferred_identifier': self.preferred_identifier }).count()
+        self.assertEqual(existing_records_count, 1, 'in the beginning, there should be only one record with pref id %s' % self.preferred_identifier)
+
+        response = self.client.post('/rest/datasets', self.test_new_data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        records = CatalogRecord.objects.filter(research_dataset__contains={ 'preferred_identifier': self.preferred_identifier })
+        self.assertEqual(len(records), 2, 'after, there should be two records with pref id %s' % self.preferred_identifier)
+
+        # both records are moved to same set
+        ars_id = records[0].alternate_record_set.id
+        self.assertEqual(records[0].alternate_record_set.id, ars_id)
+        self.assertEqual(records[1].alternate_record_set.id, ars_id)
+
+        # records in the set are the ones expected
+        self.assertEqual(records[0].id, 1)
+        self.assertEqual(records[1].id, response.data['id'])
+
+        # records in the set are indeed in different catalogs
+        self.assertEqual(records[0].data_catalog.id, 1)
+        self.assertEqual(records[1].data_catalog.id, 2)
+
+    def test_append_to_existing_alternate_record_set_if_it_exists(self):
+        self._set_preferred_identifier_to_record(pk=2, data_catalog=3)
+
+        existing_records_count = CatalogRecord.objects.filter(research_dataset__contains={ 'preferred_identifier': self.preferred_identifier }).count()
+        self.assertEqual(existing_records_count, 2, 'in the beginning, there should be two records with pref id %s' % self.preferred_identifier)
+
+        response = self.client.post('/rest/datasets', self.test_new_data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        records = CatalogRecord.objects.filter(research_dataset__contains={ 'preferred_identifier': self.preferred_identifier })
+        self.assertEqual(len(records), 3, 'after, there should be three records with pref id %s' % self.preferred_identifier)
+
+        # all records belong to same set
+        ars_id = records[0].alternate_record_set.id
+        self.assertEqual(records[0].alternate_record_set.id, ars_id)
+        self.assertEqual(records[1].alternate_record_set.id, ars_id)
+        self.assertEqual(records[2].alternate_record_set.id, ars_id)
+
+        # records in the set are the ones expected
+        self.assertEqual(records[0].id, 1)
+        self.assertEqual(records[1].id, 2)
+        self.assertEqual(records[2].id, response.data['id'])
+
+        # records in the set are indeed in different catalogs
+        self.assertEqual(records[0].data_catalog.id, 1)
+        self.assertEqual(records[1].data_catalog.id, 3)
+        self.assertEqual(records[2].data_catalog.id, 2)
+
+    def test_record_is_removed_from_alternate_record_set_when_deleted(self):
+        self._set_and_ensure_initial_conditions()
+
+        response = self.client.delete('/rest/datasets/2', format="json")
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        records = CatalogRecord.objects.filter(research_dataset__contains={ 'preferred_identifier': self.preferred_identifier })
+        self.assertEqual(records[0].alternate_record_set.records.count(), 2, 'alternate_record_set should have two records after deleting one')
+
+    def test_record_is_removed_from_alternate_record_set_when_updated(self):
+        self._set_and_ensure_initial_conditions()
+
+        response = self.client.get('/rest/datasets/2', format="json")
+        data = { 'research_dataset': response.data['research_dataset'] }
+        data['research_dataset']['preferred_identifier'] = 'a:new:identifier:here'
+
+        response = self.client.patch('/rest/datasets/2', data=data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        records = CatalogRecord.objects.filter(research_dataset__contains={ 'preferred_identifier': self.preferred_identifier })
+        self.assertEqual(records[0].alternate_record_set.records.count(), 2, 'alternate_record_set should have two records after updating one record')
+
+        # the patched record should not belong to any alt set any longer
+        cr = CatalogRecord.objects.get(pk=2)
+        self.assertEqual(cr.alternate_record_set, None)
+
+    def test_alternate_record_set_is_deleted_if_updating_record_and_only_one_record_left(self):
+        self._set_preferred_identifier_to_record(pk=2, data_catalog=3)
+        old_ars_id = CatalogRecord.objects.get(pk=2).alternate_record_set.id
+
+        response = self.client.get('/rest/datasets/2', format="json")
+        data = { 'research_dataset': response.data['research_dataset'] }
+        data['research_dataset']['preferred_identifier'] = 'a:new:identifier:here'
+
+        response = self.client.patch('/rest/datasets/2', data=data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        records = CatalogRecord.objects.filter(research_dataset__contains={ 'preferred_identifier': self.preferred_identifier })
+        self.assertEqual(records.count(), 1, 'should be only one record with this identifier left now')
+
+        with self.assertRaises(AlternateRecordSet.DoesNotExist, msg='alternate record set should have been deleted'):
+            AlternateRecordSet.objects.get(pk=old_ars_id)
+
+        try:
+            CatalogRecord.objects.get(pk=1)
+        except CatalogRecord.DoesNotExist:
+            self.fail('the other record in the alternate record set should not be deleted alongside the record set')
+
+    def test_alternate_record_set_is_deleted_if_deleting_record_and_only_one_record_left(self):
+        self._set_preferred_identifier_to_record(pk=2, data_catalog=3)
+        old_ars_id = CatalogRecord.objects.get(pk=2).alternate_record_set.id
+
+        response = self.client.delete('/rest/datasets/2', format="json")
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        records = CatalogRecord.objects.filter(research_dataset__contains={ 'preferred_identifier': self.preferred_identifier })
+        self.assertEqual(records.count(), 1, 'should be only record with this identifier left now')
+
+        with self.assertRaises(AlternateRecordSet.DoesNotExist, msg='alternate record set should have been deleted'):
+            AlternateRecordSet.objects.get(pk=old_ars_id)
+
+    def test_alternate_record_set_is_included_in_responses(self):
+        """
+        Details of a dataset should contain field alternate_record_set in it.
+        For a particular record, the set should not contain its own urn_identifier in the set.
+        """
+        msg_self_should_not_be_listed = 'urn_identifier of the record itself should not be listed'
+
+        response_1 = self.client.post('/rest/datasets', self.test_new_data, format="json")
+        response_2 = self.client.get('/rest/datasets/1', format="json")
+        self.assertEqual(response_1.status_code, status.HTTP_201_CREATED)
+        self.assertEqual('alternate_record_set' in response_1.data, True)
+        self.assertEqual(response_1.data['research_dataset']['urn_identifier'] not in response_1.data['alternate_record_set'], True, msg_self_should_not_be_listed)
+        self.assertEqual(response_2.data['research_dataset']['urn_identifier'] in response_1.data['alternate_record_set'], True)
+
+        self.test_new_data.update({ 'data_catalog': 4 })
+        response_3 = self.client.post('/rest/datasets', self.test_new_data, format="json")
+        self.assertEqual(response_3.status_code, status.HTTP_201_CREATED)
+        self.assertEqual('alternate_record_set' in response_3.data, True)
+        self.assertEqual(response_1.data['research_dataset']['urn_identifier'] in response_3.data['alternate_record_set'], True)
+        self.assertEqual(response_2.data['research_dataset']['urn_identifier'] in response_3.data['alternate_record_set'], True)
+        self.assertEqual(response_3.data['research_dataset']['urn_identifier'] not in response_3.data['alternate_record_set'], True, msg_self_should_not_be_listed)
+
+        response_2 = self.client.get('/rest/datasets/1', format="json")
+        self.assertEqual('alternate_record_set' in response_2.data, True)
+        self.assertEqual(response_1.data['research_dataset']['urn_identifier'] in response_2.data['alternate_record_set'], True)
+        self.assertEqual(response_3.data['research_dataset']['urn_identifier'] in response_2.data['alternate_record_set'], True)
+        self.assertEqual(response_2.data['research_dataset']['urn_identifier'] not in response_2.data['alternate_record_set'], True, msg_self_should_not_be_listed)
+
+    def _set_preferred_identifier_to_record(self, pk=1, data_catalog=1):
+        """
+        Set preferred_identifier to an existing record to a value, and return that value,
+        which will then be used by the test to create or update a record.
+
+        Not that this will also create an alternate_record_set, if the unique_identifier
+        is being used more than once.
+        """
+        unique_identifier = 'im unique yo'
+        cr = CatalogRecord.objects.get(pk=pk)
+        cr.research_dataset['preferred_identifier'] = unique_identifier
+        cr.data_catalog_id = data_catalog
+        cr.save()
+        return unique_identifier
+
+    def _set_and_ensure_initial_conditions(self):
+        """
+        Update two existing records to have same pref_id and be in different catalogs,
+        to create an alternate_record_set.
+        """
+        self._set_preferred_identifier_to_record(pk=2, data_catalog=3)
+        self._set_preferred_identifier_to_record(pk=3, data_catalog=4)
+
+        # ensuring initial conditions...
+        records = CatalogRecord.objects.filter(research_dataset__contains={ 'preferred_identifier': self.preferred_identifier })
+        self.assertEqual(len(records), 3, 'in the beginning, there should be three records with pref id %s' % self.preferred_identifier)
+        ars_id = records[0].alternate_record_set.id
+        self.assertEqual(records[0].alternate_record_set.id, ars_id)
+        self.assertEqual(records[1].alternate_record_set.id, ars_id)
+        self.assertEqual(records[2].alternate_record_set.id, ars_id)

--- a/src/metax_api/tests/testdata/generate_test_data.py
+++ b/src/metax_api/tests/testdata/generate_test_data.py
@@ -45,7 +45,7 @@ file_max_rows = 20
 # how many filestorage rows to generate
 file_storage_max_rows = 2
 
-data_catalog_max_rows = 2
+data_catalog_max_rows = 4
 
 contract_max_rows = 5
 
@@ -273,7 +273,7 @@ def generate_data_catalogs(mode, data_catalog_max_rows, validate_json):
         with open('data_catalog_test_data_template.json') as json_file:
             row_template = json_load(json_file)
 
-        for i in range(1, file_storage_max_rows + 1):
+        for i in range(1, data_catalog_max_rows + 1):
 
             new = {
                 'fields': deepcopy(row_template),

--- a/src/metax_api/tests/testdata/test_data.json
+++ b/src/metax_api/tests/testdata/test_data.json
@@ -889,6 +889,208 @@
     },
     {
         "fields": {
+            "catalog_json": {
+                "access_rights": {
+                    "description": [
+                        {
+                            "fi": "K\u00e4ytt\u00f6ehtojen kuvaus"
+                        }
+                    ],
+                    "license": [
+                        {
+                            "identifier": "https://creativecommons.org/licenses/by/4.0/",
+                            "title": [
+                                {
+                                    "en": "CC BY 4.0",
+                                    "fi": "CC BY 4.0"
+                                }
+                            ]
+                        }
+                    ],
+                    "type": [
+                        {
+                            "identifier": "http://purl.org/att/es/reference_data/access_type/access_type_open_access",
+                            "pref_label": {
+                                "en": "Open",
+                                "fi": "Avoin"
+                            }
+                        }
+                    ]
+                },
+                "field_of_science": [
+                    {
+                        "identifier": "http://www.yso.fi/onto/okm-tieteenala/ta1172",
+                        "pref_label": {
+                            "en": "Environmental sciences",
+                            "fi": "Ymp\u00e4rist\u00f6tiede"
+                        }
+                    }
+                ],
+                "harvested": false,
+                "homepage": [
+                    {
+                        "identifier": "http://testing.com",
+                        "title": {
+                            "en": "Test website",
+                            "fi": "Testi-verkkopalvelu"
+                        }
+                    },
+                    {
+                        "identifier": "http://www.testing.fi",
+                        "title": {
+                            "en": "Another website",
+                            "fi": "Toinen verkkopalvelu"
+                        }
+                    }
+                ],
+                "identifier": "pid:urn:catalog3",
+                "issued": "2014-02-27T08:19:58Z",
+                "language": [
+                    {
+                        "identifier": "http://lexvo.org/id/iso639-3/fin",
+                        "title": "fin"
+                    },
+                    {
+                        "identifier": "http://lexvo.org/id/iso639-3/eng",
+                        "title": "eng"
+                    }
+                ],
+                "modified": "2014-01-17T08:19:58Z",
+                "publisher": [
+                    {
+                        "homepage": [
+                            {
+                                "identifier": "http://www.publisher.fi/",
+                                "title": {
+                                    "en": "Publisher website",
+                                    "fi": "Julkaisijan kotisivu"
+                                }
+                            }
+                        ],
+                        "identifier": "http://isni.org/isni/0000000405129137",
+                        "name": {
+                            "en": "Publisher",
+                            "fi": "Julkaisija"
+                        }
+                    }
+                ],
+                "research_dataset_schema": "att",
+                "title": {
+                    "en": "Test data catalog name",
+                    "fi": "Testidatakatalogin nimi"
+                }
+            },
+            "catalog_record_group_create": "default-record-create-group",
+            "catalog_record_group_edit": "default-record-edit-group",
+            "created_by_api": "2017-05-15T10:07:22.559656Z",
+            "modified_by_api": "2017-05-15T10:07:22.559656Z"
+        },
+        "model": "metax_api.datacatalog",
+        "pk": 3
+    },
+    {
+        "fields": {
+            "catalog_json": {
+                "access_rights": {
+                    "description": [
+                        {
+                            "fi": "K\u00e4ytt\u00f6ehtojen kuvaus"
+                        }
+                    ],
+                    "license": [
+                        {
+                            "identifier": "https://creativecommons.org/licenses/by/4.0/",
+                            "title": [
+                                {
+                                    "en": "CC BY 4.0",
+                                    "fi": "CC BY 4.0"
+                                }
+                            ]
+                        }
+                    ],
+                    "type": [
+                        {
+                            "identifier": "http://purl.org/att/es/reference_data/access_type/access_type_open_access",
+                            "pref_label": {
+                                "en": "Open",
+                                "fi": "Avoin"
+                            }
+                        }
+                    ]
+                },
+                "field_of_science": [
+                    {
+                        "identifier": "http://www.yso.fi/onto/okm-tieteenala/ta1172",
+                        "pref_label": {
+                            "en": "Environmental sciences",
+                            "fi": "Ymp\u00e4rist\u00f6tiede"
+                        }
+                    }
+                ],
+                "harvested": false,
+                "homepage": [
+                    {
+                        "identifier": "http://testing.com",
+                        "title": {
+                            "en": "Test website",
+                            "fi": "Testi-verkkopalvelu"
+                        }
+                    },
+                    {
+                        "identifier": "http://www.testing.fi",
+                        "title": {
+                            "en": "Another website",
+                            "fi": "Toinen verkkopalvelu"
+                        }
+                    }
+                ],
+                "identifier": "pid:urn:catalog4",
+                "issued": "2014-02-27T08:19:58Z",
+                "language": [
+                    {
+                        "identifier": "http://lexvo.org/id/iso639-3/fin",
+                        "title": "fin"
+                    },
+                    {
+                        "identifier": "http://lexvo.org/id/iso639-3/eng",
+                        "title": "eng"
+                    }
+                ],
+                "modified": "2014-01-17T08:19:58Z",
+                "publisher": [
+                    {
+                        "homepage": [
+                            {
+                                "identifier": "http://www.publisher.fi/",
+                                "title": {
+                                    "en": "Publisher website",
+                                    "fi": "Julkaisijan kotisivu"
+                                }
+                            }
+                        ],
+                        "identifier": "http://isni.org/isni/0000000405129137",
+                        "name": {
+                            "en": "Publisher",
+                            "fi": "Julkaisija"
+                        }
+                    }
+                ],
+                "research_dataset_schema": "att",
+                "title": {
+                    "en": "Test data catalog name",
+                    "fi": "Testidatakatalogin nimi"
+                }
+            },
+            "catalog_record_group_create": "default-record-create-group",
+            "catalog_record_group_edit": "default-record-edit-group",
+            "created_by_api": "2017-05-15T10:07:22.559656Z",
+            "modified_by_api": "2017-05-15T10:07:22.559656Z"
+        },
+        "model": "metax_api.datacatalog",
+        "pk": 4
+    },
+    {
+        "fields": {
             "contract_json": {
                 "contact": [
                     {


### PR DESCRIPTION
Includes:
- Previous PR about checking that pref_id is unique within a data catalog
- New stuff about storing relations between the alternate records, and retrieving them in http responses

Does NOT include:
- Removing abilitiy to GET using preferred_identifier
- Raising error when preferred_identifier is available in ATT catalog, but already used in other catalogs