### PR TITLE
CSCMETAX-61: [ADD] Redis: Always GET from localhost first, befor…

### DIFF
--- a/src/metax_api/settings.py
+++ b/src/metax_api/settings.py
@@ -275,6 +275,7 @@ if not executing_in_travis:
         'HOSTS':    app_config_dict['REDIS']['HOSTS'],
         'PASSWORD': app_config_dict['REDIS']['PASSWORD'],
         'SERVICE':  app_config_dict['REDIS']['SERVICE'],
+        'LOCALHOST_PORT': app_config_dict['REDIS']['LOCALHOST_PORT'],
 
         # https://github.com/andymccurdy/redis-py/issues/485#issuecomment-44555664
         'SOCKET_TIMEOUT': 0.1,


### PR DESCRIPTION
…e trying out other slaves or master

Rationale: When running the app clustered, the 'randomization' will have already happened
when the request has reached the python code, in which case it is beneficial to always
try reading from localhost first, and only in case of errors try other instances.

Write operations still need to go directly to master.