### PR TITLE
CSCMETAX-207: [REF] Change es label 'default' key to 'und'. Otherwise…

### DIFF
--- a/src/metax_api/api/base/schemas/att_dataset_schema.json
+++ b/src/metax_api/api/base/schemas/att_dataset_schema.json
@@ -600,6 +600,10 @@
             "@id":"http://xmlns.com/foaf/0.1/Organization",
             "description":"An organization.",
             "properties":{
+                "@type":{
+            		"type":"string",
+            		"enum":["Organization"]
+            	},
                 "identifier":{
                     "title":"Identifier",
                     "description":"An unambiguous reference to the resource within a given context.",
@@ -652,6 +656,7 @@
                 }
             },
             "required":[
+                "@type",
                 "name"
             ]
         },
@@ -685,6 +690,10 @@
             "@id":"http://xmlns.com/foaf/0.1/Person",
             "description":"A person.",
             "properties":{
+                "@type":{
+            		"type":"string",
+            		"enum":["Person"]
+            	},
                 "identifier":{
                     "title":"Identifier",
                     "description":"An unambiguous reference to the resource within a given context.",
@@ -736,7 +745,9 @@
                 }
             },
             "required":[
-                "name"
+                "@type",
+                "name",
+                "member_of"
             ]
         },
         "Project":{
@@ -861,16 +872,61 @@
 			"type":"object",
             "title":"Agent",
             "@id":"http://xmlns.com/foaf/0.1/Agent",
-			"anyOf":[{"$ref": "#/definitions/Person"},{"$ref": "#/definitions/Organization"}],
-            "description":"An agent (eg. person, group, software or physical artifact).",
+			"oneOf":[
+                {"$ref": "#/definitions/Person"},
+                {"$ref": "#/definitions/Organization"},
+                {"$ref": "#/definitions/Agent"}
+            ],
+            "description":"An agent (eg. person, group, software or physical artifact)."
+        },
+        "Agent":{
+			"type":"object",
+            "title":"Generic Agent",
+            "@id":"http://xmlns.com/foaf/0.1/Agent",
+            "description":"Generic agent type",
             "properties":{
 				"@type":{
             		"type":"string",
-            		"enum":["Person","Organization"]
-            	}
+            		"enum":["Agent"]
+            	},
+                "identifier":{
+                    "title":"Identifier",
+                    "description":"An unambiguous reference to the resource within a given context.",
+                    "@id":"http://purl.org/dc/terms/identifier",
+                    "@type":"@id",
+                    "maxItems":1
+                },
+                "name":{
+                    "title":"Name",
+                    "description":"This property contains a name of the agent. This property can be repeated for different versions of the name (e.g. the name in different languages)",
+                    "@id":"http://xmlns.com/foaf/0.1/name",
+                    "@type":"http://www.w3.org/2001/XMLSchema#string",
+                    "minItems":1,
+                    "maxItems":1,
+                    "type":"string"
+                },
+                "email":{
+                    "title":"Email",
+                    "description":"Email address.",
+                    "@id":"http://schema.org/email",
+                    "@type":"http://www.w3.org/2001/XMLSchema#string",
+                    "maxItems":1,
+                    "type":"string"
+                },
+                "telephone":{
+                    "title":"Phone",
+                    "description":"The telephone number.",
+                    "@id":"http://schema.org/telephone",
+                    "@type":"http://www.w3.org/2001/XMLSchema#string",
+                    "type":"array",
+                    "items":{
+                        "type":"string"
+                    }
+                }
             },
             "required":[
-			    "@type"
+			    "@type",
+                "name"
             ]
         },
         "ResearchDataLicenseDocument":{

--- a/src/metax_api/api/base/schemas/att_dataset_schema.json
+++ b/src/metax_api/api/base/schemas/att_dataset_schema.json
@@ -195,6 +195,14 @@
                     "type":"string",
                     "format":"date-time"
                 },
+                "deprecated":{
+                    "title":"Deprecated",
+                    "description":"Catalog record is deprecated because files are removed",
+                    "@id":"http://iow.csc.fi/ns/mrd#readystatus",
+                    "@type":"http://www.w3.org/2001/XMLSchema#boolean",
+                    "maxItems":1,
+                    "type":"boolean"
+                },
                 "alternate_record":{
                     "title":"Alternate record",
                     "description":"Refers to alternate catalog record in different catalog. This reference is created if two datasets in different catalogs have the same preferred identifier",
@@ -328,8 +336,8 @@
             ]
         },
         "Directory":{
-			"type":"object",
-            "title":"Directory",
+            "type":"object",
+            "title":"Directory in IDA",
             "@id":"http://www.w3.org/ns/ldp#BasicContainer",
             "description":"Directory that links to its contained resources.",
             "properties":{
@@ -356,6 +364,22 @@
                     "@type":"http://www.w3.org/2001/XMLSchema#string",
                     "maxItems":1,
                     "type":"string"
+                },
+                "type":{
+                    "title":"Type",
+                    "description":"Recommended best practice is to use a controlled vocabulary such as the DCMI Type Vocabulary [DCMITYPE]. To describe the file format, physical medium, or dimensions of the resource, use the Format element.\n\nThe nature or genre of the resource.",
+                    "@id":"http://purl.org/dc/terms/type",
+                    "@type":"@id",
+                    "type":"object",
+                    "$ref":"#/definitions/Concept"
+                },
+                "access_url":{
+                    "title":"Access URL",
+                    "description":"Could be any kind of URL that gives access to a distribution of the dataset. E.g. landing page download, feed URL, SPARQL endpoint. Use when your catalog does not have information on which it is or when it is definitely not a download.",
+                    "@id":"http://www.w3.org/ns/dcat#accessURL",
+                    "@type":"@id",
+                    "type":"object",
+                    "$ref":"#/definitions/Document"
                 }
             },
             "required":[
@@ -474,7 +498,7 @@
                     "type":"string"
                 },
                 "access_url":{
-                    "title":"access URL",
+                    "title":"Access URL",
                     "description":"Could be any kind of URL that gives access to a distribution of the dataset. E.g. landing page download, feed URL, SPARQL endpoint. Use when your catalog does not have information on which it is or when it is definitely not a download.",
                     "@id":"http://www.w3.org/ns/dcat#accessURL",
                     "@type":"@id",
@@ -587,10 +611,11 @@
                     "title":"Name",
                     "description":"This property contains a name of the agent. This property can be repeated for different versions of the name (e.g. the name in different languages)",
                     "@id":"http://xmlns.com/foaf/0.1/name",
-                    "@type":"http://www.w3.org/2001/XMLSchema#string",
+                    "@type":"http://www.w3.org/1999/02/22-rdf-syntax-ns#langString",
                     "minItems":1,
                     "maxItems":1,
-                    "type":"string"
+                    "type":"object",
+                    "$ref":"#/definitions/langString"
                 },
                 "email":{
                     "title":"Email",
@@ -711,8 +736,7 @@
                 }
             },
             "required":[
-                "name",
-                "member_of"
+                "name"
             ]
         },
         "Project":{
@@ -843,45 +867,10 @@
 				"@type":{
             		"type":"string",
             		"enum":["Person","Organization"]
-            	},
-                "identifier":{
-                    "title":"Identifier",
-                    "description":"An unambiguous reference to the resource within a given context.",
-                    "@id":"http://purl.org/dc/terms/identifier",
-                    "@type":"@id",
-                    "maxItems":1
-                },
-                "name":{
-                    "title":"Name",
-                    "description":"This property contains a name of the agent. This property can be repeated for different versions of the name (e.g. the name in different languages)",
-                    "@id":"http://xmlns.com/foaf/0.1/name",
-                    "@type":"http://www.w3.org/2001/XMLSchema#string",
-                    "minItems":1,
-                    "maxItems":1,
-                    "type":"string"
-                },
-                "email":{
-                    "title":"Email",
-                    "description":"Email address.",
-                    "@id":"http://schema.org/email",
-                    "@type":"http://www.w3.org/2001/XMLSchema#string",
-                    "maxItems":1,
-                    "type":"string"
-                },
-                "telephone":{
-                    "title":"Phone",
-                    "description":"The telephone number.",
-                    "@id":"http://schema.org/telephone",
-                    "@type":"http://www.w3.org/2001/XMLSchema#string",
-                    "type":"array",
-                    "items":{
-                        "type":"string"
-                    }
-                }
+            	}
             },
             "required":[
-			    "@type",
-                "name"
+			    "@type"
             ]
         },
         "ResearchDataLicenseDocument":{

--- a/src/metax_api/api/base/schemas/datacatalog_schema.json
+++ b/src/metax_api/api/base/schemas/datacatalog_schema.json
@@ -381,7 +381,7 @@
                         "$ref":"#/definitions/Concept"
                     }
                 },
-                "has_right_related_agent":{
+                "has_rights_related_agent":{
                     "title":"Related agent",
                     "@id":"http://www.loc.gov/premis/rdf/v1#hasRightRelatedAgent",
                     "@type":"@id",

--- a/src/metax_api/api/base/schemas/kielipankki_harvester_dataset_schema.json
+++ b/src/metax_api/api/base/schemas/kielipankki_harvester_dataset_schema.json
@@ -600,6 +600,10 @@
             "@id":"http://xmlns.com/foaf/0.1/Organization",
             "description":"An organization.",
             "properties":{
+                "@type":{
+            		"type":"string",
+            		"enum":["Organization"]
+            	},
                 "identifier":{
                     "title":"Identifier",
                     "description":"An unambiguous reference to the resource within a given context.",
@@ -652,6 +656,7 @@
                 }
             },
             "required":[
+                "@type",
                 "name"
             ]
         },
@@ -685,6 +690,10 @@
             "@id":"http://xmlns.com/foaf/0.1/Person",
             "description":"A person.",
             "properties":{
+                "@type":{
+            		"type":"string",
+            		"enum":["Person"]
+            	},
                 "identifier":{
                     "title":"Identifier",
                     "description":"An unambiguous reference to the resource within a given context.",
@@ -736,6 +745,7 @@
                 }
             },
             "required":[
+                "@type",
                 "name"
             ]
         },
@@ -861,16 +871,61 @@
 			"type":"object",
             "title":"Agent",
             "@id":"http://xmlns.com/foaf/0.1/Agent",
-			"anyOf":[{"$ref": "#/definitions/Person"},{"$ref": "#/definitions/Organization"}],
-            "description":"An agent (eg. person, group, software or physical artifact).",
+			"anyOf":[
+                {"$ref": "#/definitions/Person"},
+                {"$ref": "#/definitions/Organization"},
+                {"$ref": "#/definitions/Agent"}
+            ],
+            "description":"An agent (eg. person, group, software or physical artifact)."
+        },
+        "Agent":{
+			"type":"object",
+            "title":"Generic Agent",
+            "@id":"http://xmlns.com/foaf/0.1/Agent",
+            "description":"Generic agent type",
             "properties":{
 				"@type":{
             		"type":"string",
-            		"enum":["Person","Organization"]
-            	}
+            		"enum":["Agent"]
+            	},
+                "identifier":{
+                    "title":"Identifier",
+                    "description":"An unambiguous reference to the resource within a given context.",
+                    "@id":"http://purl.org/dc/terms/identifier",
+                    "@type":"@id",
+                    "maxItems":1
+                },
+                "name":{
+                    "title":"Name",
+                    "description":"This property contains a name of the agent. This property can be repeated for different versions of the name (e.g. the name in different languages)",
+                    "@id":"http://xmlns.com/foaf/0.1/name",
+                    "@type":"http://www.w3.org/2001/XMLSchema#string",
+                    "minItems":1,
+                    "maxItems":1,
+                    "type":"string"
+                },
+                "email":{
+                    "title":"Email",
+                    "description":"Email address.",
+                    "@id":"http://schema.org/email",
+                    "@type":"http://www.w3.org/2001/XMLSchema#string",
+                    "maxItems":1,
+                    "type":"string"
+                },
+                "telephone":{
+                    "title":"Phone",
+                    "description":"The telephone number.",
+                    "@id":"http://schema.org/telephone",
+                    "@type":"http://www.w3.org/2001/XMLSchema#string",
+                    "type":"array",
+                    "items":{
+                        "type":"string"
+                    }
+                }
             },
             "required":[
-			    "@type"
+			    "@type",
+                "name"
             ]
         },
         "ResearchDataLicenseDocument":{

--- a/src/metax_api/api/base/schemas/kielipankki_harvester_dataset_schema.json
+++ b/src/metax_api/api/base/schemas/kielipankki_harvester_dataset_schema.json
@@ -195,6 +195,14 @@
                     "type":"string",
                     "format":"date-time"
                 },
+                "deprecated":{
+                    "title":"Deprecated",
+                    "description":"Catalog record is deprecated because files are removed",
+                    "@id":"http://iow.csc.fi/ns/mrd#readystatus",
+                    "@type":"http://www.w3.org/2001/XMLSchema#boolean",
+                    "maxItems":1,
+                    "type":"boolean"
+                },
                 "alternate_record":{
                     "title":"Alternate record",
                     "description":"Refers to alternate catalog record in different catalog. This reference is created if two datasets in different catalogs have the same preferred identifier",
@@ -328,8 +336,8 @@
             ]
         },
         "Directory":{
-			"type":"object",
-            "title":"Directory",
+            "type":"object",
+            "title":"Directory in IDA",
             "@id":"http://www.w3.org/ns/ldp#BasicContainer",
             "description":"Directory that links to its contained resources.",
             "properties":{
@@ -356,6 +364,22 @@
                     "@type":"http://www.w3.org/2001/XMLSchema#string",
                     "maxItems":1,
                     "type":"string"
+                },
+                "type":{
+                    "title":"Type",
+                    "description":"Recommended best practice is to use a controlled vocabulary such as the DCMI Type Vocabulary [DCMITYPE]. To describe the file format, physical medium, or dimensions of the resource, use the Format element.\n\nThe nature or genre of the resource.",
+                    "@id":"http://purl.org/dc/terms/type",
+                    "@type":"@id",
+                    "type":"object",
+                    "$ref":"#/definitions/Concept"
+                },
+                "access_url":{
+                    "title":"Access URL",
+                    "description":"Could be any kind of URL that gives access to a distribution of the dataset. E.g. landing page download, feed URL, SPARQL endpoint. Use when your catalog does not have information on which it is or when it is definitely not a download.",
+                    "@id":"http://www.w3.org/ns/dcat#accessURL",
+                    "@type":"@id",
+                    "type":"object",
+                    "$ref":"#/definitions/Document"
                 }
             },
             "required":[
@@ -474,7 +498,7 @@
                     "type":"string"
                 },
                 "access_url":{
-                    "title":"access URL",
+                    "title":"Access URL",
                     "description":"Could be any kind of URL that gives access to a distribution of the dataset. E.g. landing page download, feed URL, SPARQL endpoint. Use when your catalog does not have information on which it is or when it is definitely not a download.",
                     "@id":"http://www.w3.org/ns/dcat#accessURL",
                     "@type":"@id",
@@ -587,10 +611,11 @@
                     "title":"Name",
                     "description":"This property contains a name of the agent. This property can be repeated for different versions of the name (e.g. the name in different languages)",
                     "@id":"http://xmlns.com/foaf/0.1/name",
-                    "@type":"http://www.w3.org/2001/XMLSchema#string",
+                    "@type":"http://www.w3.org/1999/02/22-rdf-syntax-ns#langString",
                     "minItems":1,
                     "maxItems":1,
-                    "type":"string"
+                    "type":"object",
+                    "$ref":"#/definitions/langString"
                 },
                 "email":{
                     "title":"Email",
@@ -711,8 +736,7 @@
                 }
             },
             "required":[
-                "name",
-                "member_of"
+                "name"
             ]
         },
         "Project":{
@@ -843,45 +867,10 @@
 				"@type":{
             		"type":"string",
             		"enum":["Person","Organization"]
-            	},
-                "identifier":{
-                    "title":"Identifier",
-                    "description":"An unambiguous reference to the resource within a given context.",
-                    "@id":"http://purl.org/dc/terms/identifier",
-                    "@type":"@id",
-                    "maxItems":1
-                },
-                "name":{
-                    "title":"Name",
-                    "description":"This property contains a name of the agent. This property can be repeated for different versions of the name (e.g. the name in different languages)",
-                    "@id":"http://xmlns.com/foaf/0.1/name",
-                    "@type":"http://www.w3.org/2001/XMLSchema#string",
-                    "minItems":1,
-                    "maxItems":1,
-                    "type":"string"
-                },
-                "email":{
-                    "title":"Email",
-                    "description":"Email address.",
-                    "@id":"http://schema.org/email",
-                    "@type":"http://www.w3.org/2001/XMLSchema#string",
-                    "maxItems":1,
-                    "type":"string"
-                },
-                "telephone":{
-                    "title":"Phone",
-                    "description":"The telephone number.",
-                    "@id":"http://schema.org/telephone",
-                    "@type":"http://www.w3.org/2001/XMLSchema#string",
-                    "type":"array",
-                    "items":{
-                        "type":"string"
-                    }
-                }
+            	}
             },
             "required":[
-			    "@type",
-                "name"
+			    "@type"
             ]
         },
         "ResearchDataLicenseDocument":{

--- a/src/metax_api/api/base/schemas/syke_harvester_dataset_schema.json
+++ b/src/metax_api/api/base/schemas/syke_harvester_dataset_schema.json
@@ -1,6 +1,6 @@
 {
     "@id":"http://iow.csc.fi/ns/mrd#",
-    "title":"SYKE Research Datasets",
+    "title":"The Language Bank of Finland Research Datasets",
     "modified":"Mon, 09 Oct 2017 14:41:39 EEST",
     "$schema":"http://json-schema.org/draft-04/schema#",
     "type":"object",
@@ -600,6 +600,10 @@
             "@id":"http://xmlns.com/foaf/0.1/Organization",
             "description":"An organization.",
             "properties":{
+                "@type":{
+            		"type":"string",
+            		"enum":["Organization"]
+            	},
                 "identifier":{
                     "title":"Identifier",
                     "description":"An unambiguous reference to the resource within a given context.",
@@ -652,6 +656,7 @@
                 }
             },
             "required":[
+                "@type",
                 "name"
             ]
         },
@@ -685,6 +690,10 @@
             "@id":"http://xmlns.com/foaf/0.1/Person",
             "description":"A person.",
             "properties":{
+                "@type":{
+            		"type":"string",
+            		"enum":["Person"]
+            	},
                 "identifier":{
                     "title":"Identifier",
                     "description":"An unambiguous reference to the resource within a given context.",
@@ -736,6 +745,7 @@
                 }
             },
             "required":[
+                "@type",
                 "name"
             ]
         },
@@ -861,16 +871,61 @@
 			"type":"object",
             "title":"Agent",
             "@id":"http://xmlns.com/foaf/0.1/Agent",
-			"anyOf":[{"$ref": "#/definitions/Person"},{"$ref": "#/definitions/Organization"}],
-            "description":"An agent (eg. person, group, software or physical artifact).",
+			"anyOf":[
+                {"$ref": "#/definitions/Person"},
+                {"$ref": "#/definitions/Organization"},
+                {"$ref": "#/definitions/Agent"}
+            ],
+            "description":"An agent (eg. person, group, software or physical artifact)."
+        },
+        "Agent":{
+			"type":"object",
+            "title":"Generic Agent",
+            "@id":"http://xmlns.com/foaf/0.1/Agent",
+            "description":"Generic agent type",
             "properties":{
 				"@type":{
             		"type":"string",
-            		"enum":["Person","Organization"]
-            	}
+            		"enum":["Agent"]
+            	},
+                "identifier":{
+                    "title":"Identifier",
+                    "description":"An unambiguous reference to the resource within a given context.",
+                    "@id":"http://purl.org/dc/terms/identifier",
+                    "@type":"@id",
+                    "maxItems":1
+                },
+                "name":{
+                    "title":"Name",
+                    "description":"This property contains a name of the agent. This property can be repeated for different versions of the name (e.g. the name in different languages)",
+                    "@id":"http://xmlns.com/foaf/0.1/name",
+                    "@type":"http://www.w3.org/2001/XMLSchema#string",
+                    "minItems":1,
+                    "maxItems":1,
+                    "type":"string"
+                },
+                "email":{
+                    "title":"Email",
+                    "description":"Email address.",
+                    "@id":"http://schema.org/email",
+                    "@type":"http://www.w3.org/2001/XMLSchema#string",
+                    "maxItems":1,
+                    "type":"string"
+                },
+                "telephone":{
+                    "title":"Phone",
+                    "description":"The telephone number.",
+                    "@id":"http://schema.org/telephone",
+                    "@type":"http://www.w3.org/2001/XMLSchema#string",
+                    "type":"array",
+                    "items":{
+                        "type":"string"
+                    }
+                }
             },
             "required":[
-			    "@type"
+			    "@type",
+                "name"
             ]
         },
         "ResearchDataLicenseDocument":{

--- a/src/metax_api/api/base/schemas/syke_harvester_dataset_schema.json
+++ b/src/metax_api/api/base/schemas/syke_harvester_dataset_schema.json
@@ -195,6 +195,14 @@
                     "type":"string",
                     "format":"date-time"
                 },
+                "deprecated":{
+                    "title":"Deprecated",
+                    "description":"Catalog record is deprecated because files are removed",
+                    "@id":"http://iow.csc.fi/ns/mrd#readystatus",
+                    "@type":"http://www.w3.org/2001/XMLSchema#boolean",
+                    "maxItems":1,
+                    "type":"boolean"
+                },
                 "alternate_record":{
                     "title":"Alternate record",
                     "description":"Refers to alternate catalog record in different catalog. This reference is created if two datasets in different catalogs have the same preferred identifier",
@@ -328,8 +336,8 @@
             ]
         },
         "Directory":{
-			"type":"object",
-            "title":"Directory",
+            "type":"object",
+            "title":"Directory in IDA",
             "@id":"http://www.w3.org/ns/ldp#BasicContainer",
             "description":"Directory that links to its contained resources.",
             "properties":{
@@ -356,6 +364,22 @@
                     "@type":"http://www.w3.org/2001/XMLSchema#string",
                     "maxItems":1,
                     "type":"string"
+                },
+                "type":{
+                    "title":"Type",
+                    "description":"Recommended best practice is to use a controlled vocabulary such as the DCMI Type Vocabulary [DCMITYPE]. To describe the file format, physical medium, or dimensions of the resource, use the Format element.\n\nThe nature or genre of the resource.",
+                    "@id":"http://purl.org/dc/terms/type",
+                    "@type":"@id",
+                    "type":"object",
+                    "$ref":"#/definitions/Concept"
+                },
+                "access_url":{
+                    "title":"Access URL",
+                    "description":"Could be any kind of URL that gives access to a distribution of the dataset. E.g. landing page download, feed URL, SPARQL endpoint. Use when your catalog does not have information on which it is or when it is definitely not a download.",
+                    "@id":"http://www.w3.org/ns/dcat#accessURL",
+                    "@type":"@id",
+                    "type":"object",
+                    "$ref":"#/definitions/Document"
                 }
             },
             "required":[
@@ -474,7 +498,7 @@
                     "type":"string"
                 },
                 "access_url":{
-                    "title":"access URL",
+                    "title":"Access URL",
                     "description":"Could be any kind of URL that gives access to a distribution of the dataset. E.g. landing page download, feed URL, SPARQL endpoint. Use when your catalog does not have information on which it is or when it is definitely not a download.",
                     "@id":"http://www.w3.org/ns/dcat#accessURL",
                     "@type":"@id",
@@ -587,10 +611,11 @@
                     "title":"Name",
                     "description":"This property contains a name of the agent. This property can be repeated for different versions of the name (e.g. the name in different languages)",
                     "@id":"http://xmlns.com/foaf/0.1/name",
-                    "@type":"http://www.w3.org/2001/XMLSchema#string",
+                    "@type":"http://www.w3.org/1999/02/22-rdf-syntax-ns#langString",
                     "minItems":1,
                     "maxItems":1,
-                    "type":"string"
+                    "type":"object",
+                    "$ref":"#/definitions/langString"
                 },
                 "email":{
                     "title":"Email",
@@ -711,8 +736,7 @@
                 }
             },
             "required":[
-                "name",
-                "member_of"
+                "name"
             ]
         },
         "Project":{
@@ -843,45 +867,10 @@
 				"@type":{
             		"type":"string",
             		"enum":["Person","Organization"]
-            	},
-                "identifier":{
-                    "title":"Identifier",
-                    "description":"An unambiguous reference to the resource within a given context.",
-                    "@id":"http://purl.org/dc/terms/identifier",
-                    "@type":"@id",
-                    "maxItems":1
-                },
-                "name":{
-                    "title":"Name",
-                    "description":"This property contains a name of the agent. This property can be repeated for different versions of the name (e.g. the name in different languages)",
-                    "@id":"http://xmlns.com/foaf/0.1/name",
-                    "@type":"http://www.w3.org/2001/XMLSchema#string",
-                    "minItems":1,
-                    "maxItems":1,
-                    "type":"string"
-                },
-                "email":{
-                    "title":"Email",
-                    "description":"Email address.",
-                    "@id":"http://schema.org/email",
-                    "@type":"http://www.w3.org/2001/XMLSchema#string",
-                    "maxItems":1,
-                    "type":"string"
-                },
-                "telephone":{
-                    "title":"Phone",
-                    "description":"The telephone number.",
-                    "@id":"http://schema.org/telephone",
-                    "@type":"http://www.w3.org/2001/XMLSchema#string",
-                    "type":"array",
-                    "items":{
-                        "type":"string"
-                    }
-                }
+            	}
             },
             "required":[
-			    "@type",
-                "name"
+			    "@type"
             ]
         },
         "ResearchDataLicenseDocument":{

--- a/src/metax_api/api/base/views/dataset_view.py
+++ b/src/metax_api/api/base/views/dataset_view.py
@@ -102,8 +102,8 @@ class DatasetViewSet(CommonViewSet):
         res = super(DatasetViewSet, self).destroy(request, *args, **kwargs)
         if res.status_code == status.HTTP_204_NO_CONTENT:
             removed_object = self._get_removed_dataset()
-            self._publish_message({ 'urn_identifier': removed_object.research_dataset['urn_identifier'] },
-                routing_key='delete', exchange='datasets')
+            self._publish_message({'urn_identifier': removed_object.research_dataset['urn_identifier']},
+                                  routing_key='delete', exchange='datasets')
         return res
 
     def create(self, request, *args, **kwargs):

--- a/src/metax_api/services/data_catalog_service.py
+++ b/src/metax_api/services/data_catalog_service.py
@@ -54,10 +54,10 @@ class DataCatalogService(ReferenceDataMixin):
                 if ref_entry:
                     cls.populate_from_ref_data(ref_entry, rights_statement_license, label_field='title')
 
-            if 'has_right_related_agent' in access_rights:
-                for agent in access_rights.get('has_right_related_agent', []):
+            if 'has_rights_related_agent' in access_rights:
+                for agent in access_rights.get('has_rights_related_agent', []):
                     cls.process_org_obj_against_ref_data(orgdata['organization'], agent,
-                                                         'data_catalog_json.rights.has_right_related_agent')
+                                                         'data_catalog_json.rights.has_rights_related_agent')
 
         publisher = data_catalog.get('publisher', None)
         if publisher:

--- a/src/metax_api/services/reference_data_mixin.py
+++ b/src/metax_api/services/reference_data_mixin.py
@@ -109,7 +109,7 @@ class ReferenceDataMixin():
         First check if org object contains is_part_of relation, in which case recursively call this method
         until there is no is_part_of relation. After this, check whether org object has a value in identifier field.
         If there is, check whether it can be found from the organization reference data. If it is found, populate
-        the name field of org obj with the label.
+        the name field of org obj with the ref data label and identifier field with the ref data uri.
 
         If identifier value is not found from reference data, never mind
         """
@@ -125,11 +125,7 @@ class ReferenceDataMixin():
             ref_entry = cls.check_ref_data(org_ref_data, org_obj['identifier'],
                                            org_obj_relation_name + '.identifier', value_not_found_is_error=False)
             if ref_entry:
-                cls.populate_from_ref_data(ref_entry, org_obj)
-                if 'label' in ref_entry:
-                    # Organization field 'name' is not a langString, so must
-                    # select the default translation
-                    org_obj['name'] = ref_entry['label']['default']
+                cls.populate_from_ref_data(ref_entry, org_obj, 'identifier', 'name')
 
     @classmethod
     def process_research_agent_obj(cls, org_ref_data, agent_obj, agent_obj_relation_name):

--- a/src/metax_api/tests/api/base/apitests/catalog_records/write.py
+++ b/src/metax_api/tests/api/base/apitests/catalog_records/write.py
@@ -53,11 +53,19 @@ class CatalogRecordApiWriteCommon(APITestCase, TestClassUtils):
             "preferred_identifier": None,
             "creator": [{
                 "@type": "Person",
-                "name": "Teppo Testaaja"
+                "name": "Teppo Testaaja",
+                "member_of": {
+                    "@type": "Organization",
+                    "name": {"fi": "Mysterious Organization"}
+                }
             }],
             "curator": [{
                 "@type": "Person",
-                "name": "Default Owner"
+                "name": "Default Owner",
+                "member_of": {
+                    "@type": "Organization",
+                    "name": {"fi": "Mysterious Organization"}
+                }
             }],
             "total_byte_size": 1024,
             "files": catalog_record_from_test_data['research_dataset']['files']

--- a/src/metax_api/tests/api/base/apitests/catalog_records/write.py
+++ b/src/metax_api/tests/api/base/apitests/catalog_records/write.py
@@ -10,7 +10,6 @@ from metax_api.utils import RedisSentinelCache
 
 
 class CatalogRecordApiWriteCommon(APITestCase, TestClassUtils):
-
     """
     Common class for write tests, inherited by other write test classes
     """
@@ -87,7 +86,6 @@ class CatalogRecordApiWriteCommon(APITestCase, TestClassUtils):
 
 
 class CatalogRecordApiWriteCreateTests(CatalogRecordApiWriteCommon):
-
     #
     #
     #
@@ -101,20 +99,25 @@ class CatalogRecordApiWriteCreateTests(CatalogRecordApiWriteCommon):
         response = self.client.post('/rest/datasets', self.test_new_data, format="json")
         self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.data)
         self.assertEqual('research_dataset' in response.data.keys(), True)
-        self.assertEqual(response.data['research_dataset']['urn_identifier'] is not None, True, 'urn_identifier should have been generated')
-        self.assertEqual(response.data['research_dataset']['preferred_identifier'], self.test_new_data['research_dataset']['preferred_identifier'])
+        self.assertEqual(response.data['research_dataset']['urn_identifier'] is not None, True,
+                         'urn_identifier should have been generated')
+        self.assertEqual(response.data['research_dataset']['preferred_identifier'],
+                         self.test_new_data['research_dataset']['preferred_identifier'])
         cr = CatalogRecord.objects.get(pk=response.data['id'])
-        self.assertEqual(cr.created_by_api >= datetime.now() - timedelta(seconds=5), True, 'Timestamp should have been updated during object creation')
+        self.assertEqual(cr.created_by_api >= datetime.now() - timedelta(seconds=5), True,
+                         'Timestamp should have been updated during object creation')
 
     def test_create_catalog_record_without_preferred_identifier(self):
         self.test_new_data['research_dataset']['preferred_identifier'] = None
         response = self.client.post('/rest/datasets', self.test_new_data, format="json")
         self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.data)
         self.assertEqual('research_dataset' in response.data.keys(), True)
-        self.assertEqual(response.data['research_dataset']['preferred_identifier'], response.data['research_dataset']['urn_identifier'],
-            'urn_identifier and preferred_identifier should equal')
+        self.assertEqual(response.data['research_dataset']['preferred_identifier'],
+                         response.data['research_dataset']['urn_identifier'],
+                         'urn_identifier and preferred_identifier should equal')
         cr = CatalogRecord.objects.get(pk=response.data['id'])
-        self.assertEqual(cr.created_by_api >= datetime.now() - timedelta(seconds=5), True, 'Timestamp should have been updated during object creation')
+        self.assertEqual(cr.created_by_api >= datetime.now() - timedelta(seconds=5), True,
+                         'Timestamp should have been updated during object creation')
 
     def test_create_catalog_contract_string_identifier(self):
         self.test_new_data['contract'] = 'optional:contract:identifier1'
@@ -136,7 +139,8 @@ class CatalogRecordApiWriteCreateTests(CatalogRecordApiWriteCommon):
         response = self.client.post('/rest/datasets', self.test_new_data, format="json")
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(len(response.data), 1, 'there should be only one error')
-        self.assertEqual('research_dataset' in response.data.keys(), True, 'The error should concern the field research_dataset')
+        self.assertEqual('research_dataset' in response.data.keys(), True,
+                         'The error should concern the field research_dataset')
         self.assertEqual('1234456 is not of type' in response.data['research_dataset'][0], True, response.data)
         self.assertEqual('Json path: [\'title\']' in response.data['research_dataset'][0], True, response.data)
 
@@ -146,7 +150,7 @@ class CatalogRecordApiWriteCreateTests(CatalogRecordApiWriteCommon):
         objects that are deeply nested
         """
         self.test_new_data['research_dataset']['provenance'] = [{
-            'title': { 'en': 'provenance title' },
+            'title': {'en': 'provenance title'},
             'was_associated_with': [
                 {'@type': 'Person', 'xname': 'seppo'}
             ]
@@ -154,7 +158,8 @@ class CatalogRecordApiWriteCreateTests(CatalogRecordApiWriteCommon):
         response = self.client.post('/rest/datasets', self.test_new_data, format="json")
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(len(response.data), 1, 'there should be only one error')
-        self.assertEqual('research_dataset' in response.data.keys(), True, 'The error should concern the field research_dataset')
+        self.assertEqual('research_dataset' in response.data.keys(), True,
+                         'The error should concern the field research_dataset')
         self.assertEqual('is not valid' in response.data['research_dataset'][0], True, response.data)
         self.assertEqual('was_associated_with' in response.data['research_dataset'][0], True, response.data)
 
@@ -213,7 +218,8 @@ class CatalogRecordApiWriteCreateTests(CatalogRecordApiWriteCommon):
         self.assertEqual('success' in response.data.keys(), True)
         self.assertEqual('failed' in response.data.keys(), True)
         self.assertEqual('object' in response.data['failed'][0].keys(), True)
-        self.assertEqual('research_dataset' in response.data['failed'][0]['errors'], True, 'The error should have been about an already existing identifier')
+        self.assertEqual('research_dataset' in response.data['failed'][0]['errors'], True,
+                         'The error should have been about an already existing identifier')
 
     def test_create_catalog_record_list_error_all_fail(self):
         # data catalog is a required field, should fail
@@ -230,7 +236,6 @@ class CatalogRecordApiWriteCreateTests(CatalogRecordApiWriteCommon):
 
 
 class CatalogRecordApiWriteIdentifierUniqueness(CatalogRecordApiWriteCommon):
-
     """
     Tests related to checking preferred_identifier uniqueness.
     """
@@ -248,12 +253,15 @@ class CatalogRecordApiWriteIdentifierUniqueness(CatalogRecordApiWriteCommon):
 
         response = self.client.post('/rest/datasets', self.test_new_data, format="json")
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual('research_dataset' in response.data.keys(), True, 'The error should be about an error in research_dataset')
+        self.assertEqual('research_dataset' in response.data.keys(), True,
+                         'The error should be about an error in research_dataset')
 
         # the error message should clearly state that the value of preferred_identifier appears in the
         # field urn_identifier in another record, therefore two asserts
-        self.assertEqual('preferred_identifier' in response.data['research_dataset'][0], True, 'The error should be about urn_identifier existing with this identifier')
-        self.assertEqual('urn_identifier' in response.data['research_dataset'][0], True, 'The error should be about urn_identifier existing with this identifier')
+        self.assertEqual('preferred_identifier' in response.data['research_dataset'][0], True,
+                         'The error should be about urn_identifier existing with this identifier')
+        self.assertEqual('urn_identifier' in response.data['research_dataset'][0], True,
+                         'The error should be about urn_identifier existing with this identifier')
 
     def test_create_catalog_record_error_preferred_identifier_exists_in_same_catalog(self):
         """
@@ -264,8 +272,10 @@ class CatalogRecordApiWriteIdentifierUniqueness(CatalogRecordApiWriteCommon):
 
         response = self.client.post('/rest/datasets', self.test_new_data, format="json")
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual('research_dataset' in response.data.keys(), True, 'The error should be about an error in research_dataset')
-        self.assertEqual('preferred_identifier' in response.data['research_dataset'][0], True, 'The error should be about preferred_identifier already existing')
+        self.assertEqual('research_dataset' in response.data.keys(), True,
+                         'The error should be about an error in research_dataset')
+        self.assertEqual('preferred_identifier' in response.data['research_dataset'][0], True,
+                         'The error should be about preferred_identifier already existing')
 
     def test_create_catalog_record_preferred_identifier_exists_in_another_catalog(self):
         """
@@ -299,9 +309,12 @@ class CatalogRecordApiWriteIdentifierUniqueness(CatalogRecordApiWriteCommon):
         response = self.client.post('/rest/datasets', self.test_new_data, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual('research_dataset' in response.data.keys(), True, 'The error should be about an error in research_dataset')
-        self.assertEqual('preferred_identifier' in response.data['research_dataset'][0], True, 'The error should be about preferred_identifier already existing')
-        self.assertEqual('saving to ATT' in response.data['research_dataset'][0], True, 'The error should mention saving to ATT catalog as the reason')
+        self.assertEqual('research_dataset' in response.data.keys(), True,
+                         'The error should be about an error in research_dataset')
+        self.assertEqual('preferred_identifier' in response.data['research_dataset'][0], True,
+                         'The error should be about preferred_identifier already existing')
+        self.assertEqual('saving to ATT' in response.data['research_dataset'][0], True,
+                         'The error should mention saving to ATT catalog as the reason')
 
     #
     # update operations
@@ -320,7 +333,7 @@ class CatalogRecordApiWriteIdentifierUniqueness(CatalogRecordApiWriteCommon):
         cr.data_catalog_id = 2
         cr.save()
 
-        data = { 'research_dataset': self.test_new_data['research_dataset'] }
+        data = {'research_dataset': self.test_new_data['research_dataset']}
         data['research_dataset']['preferred_identifier'] = unique_identifier
 
         response = self.client.patch('/rest/datasets/2', data, format="json")
@@ -339,7 +352,7 @@ class CatalogRecordApiWriteIdentifierUniqueness(CatalogRecordApiWriteCommon):
         """
         unique_identifier = self._set_preferred_identifier_to_record(pk=1)
 
-        data = { 'research_dataset': self.test_new_data['research_dataset'] }
+        data = {'research_dataset': self.test_new_data['research_dataset']}
         data['research_dataset']['preferred_identifier'] = unique_identifier
         data['data_catalog'] = 2
 
@@ -359,13 +372,14 @@ class CatalogRecordApiWriteIdentifierUniqueness(CatalogRecordApiWriteCommon):
         """
         unique_identifier = self._set_preferred_identifier_to_record(pk=1)
 
-        data = { 'research_dataset': self.test_new_data['research_dataset'] }
+        data = {'research_dataset': self.test_new_data['research_dataset']}
         data['research_dataset']['preferred_identifier'] = unique_identifier
         data['data_catalog'] = 1
 
         response = self.client.patch('/rest/datasets/2', data, format="json")
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual('preferred_identifier' in response.data['research_dataset'][0], True, 'The error should be about preferred_identifier already existing')
+        self.assertEqual('preferred_identifier' in response.data['research_dataset'][0], True,
+                         'The error should be about preferred_identifier already existing')
 
     def test_update_catalog_record_in_att_preferred_identifier_exists_in_another_catalog(self):
         """
@@ -377,14 +391,17 @@ class CatalogRecordApiWriteIdentifierUniqueness(CatalogRecordApiWriteCommon):
         """
         unique_identifier = self._set_preferred_identifier_to_record(pk=2)
 
-        data = { 'research_dataset': self.test_new_data['research_dataset'] }
+        data = {'research_dataset': self.test_new_data['research_dataset']}
         data['research_dataset']['preferred_identifier'] = unique_identifier
 
         response = self.client.patch('/rest/datasets/1', data, format="json")
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual('research_dataset' in response.data.keys(), True, 'The error should be about an error in research_dataset')
-        self.assertEqual('preferred_identifier' in response.data['research_dataset'][0], True, 'The error should be about preferred_identifier already existing')
-        self.assertEqual('saving to ATT' in response.data['research_dataset'][0], True, 'The error should mention saving to ATT catalog as the reason')
+        self.assertEqual('research_dataset' in response.data.keys(), True,
+                         'The error should be about an error in research_dataset')
+        self.assertEqual('preferred_identifier' in response.data['research_dataset'][0], True,
+                         'The error should be about preferred_identifier already existing')
+        self.assertEqual('saving to ATT' in response.data['research_dataset'][0], True,
+                         'The error should mention saving to ATT catalog as the reason')
 
     #
     # helpers
@@ -404,7 +421,6 @@ class CatalogRecordApiWriteIdentifierUniqueness(CatalogRecordApiWriteCommon):
 
 
 class CatalogRecordApiWriteDatasetSchemaSelection(CatalogRecordApiWriteCommon):
-
     #
     #
     #
@@ -440,17 +456,17 @@ class CatalogRecordApiWriteDatasetSchemaSelection(CatalogRecordApiWriteCommon):
         json schemas than the default ATT
         """
         self.test_new_data['research_dataset']['remote_resources'] = [
-            { 'title': 'title' },
-            { 'title': 'title' }
+            {'title': 'title'},
+            {'title': 'title'}
         ]
 
         response = self.client.post('/rest/datasets', self.test_new_data, format="json")
         self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.data)
 
         self.test_new_data['research_dataset']['remote_resources'] = [
-            { 'title': 'title' },
-            { 'title': 'title' },
-            { 'woah': 'this should give a failure, since title is a required field, and it is missing' }
+            {'title': 'title'},
+            {'title': 'title'},
+            {'woah': 'this should give a failure, since title is a required field, and it is missing'}
         ]
 
         response = self.client.post('/rest/datasets', self.test_new_data, format="json")
@@ -461,23 +477,21 @@ class CatalogRecordApiWriteDatasetSchemaSelection(CatalogRecordApiWriteCommon):
         Ensure that dataset reference data validation and population works with other
         json schemas than the default ATT. Ref data validation should be schema agnostic
         """
-        self.test_new_data['research_dataset']['remote_resources'] = [
-            { 'title': 'title' },
+        self.test_new_data['research_dataset']['other_identifier'] = [
             {
-                'title': 'title',
-                'checksum': {
-                    'algorithm': 'SHA-512',
-                    'checksum_value': 'xxxyyyzz'
+                'notation': 'urn:1',
+                'type': {
+                    'identifier': 'doi',
                 }
-            },
+            }
         ]
 
         response = self.client.post('/rest/datasets', self.test_new_data, format="json")
         self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.data)
         self.assertEqual(
-            'purl' in response.data['research_dataset']['remote_resources'][1]['checksum']['algorithm'],
+            'purl' in response.data['research_dataset']['other_identifier'][0]['type']['identifier'],
             True,
-            'algorithm should have been populated with data from ref data'
+            'Identifier type should have been populated with data from ref data'
         )
 
     def _set_data_catalog_schema_to_harvester(self):
@@ -487,7 +501,6 @@ class CatalogRecordApiWriteDatasetSchemaSelection(CatalogRecordApiWriteCommon):
 
 
 class CatalogRecordApiWriteUpdateTests(CatalogRecordApiWriteCommon):
-
     #
     #
     # update apis PUT
@@ -500,12 +513,14 @@ class CatalogRecordApiWriteUpdateTests(CatalogRecordApiWriteCommon):
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT, response.data)
         self.assertEqual(len(response.data.keys()), 0, 'Returned dict should be empty')
         cr = CatalogRecord.objects.get(pk=self.pk)
-        self.assertEqual(cr.modified_by_api >= datetime.now() - timedelta(seconds=5), True, 'Timestamp should have been updated during object update')
+        self.assertEqual(cr.modified_by_api >= datetime.now() - timedelta(seconds=5), True,
+                         'Timestamp should have been updated during object update')
 
     def test_update_catalog_record_error_using_preferred_identifier(self):
         self.test_new_data['research_dataset']['preferred_identifier'] = self.preferred_identifier
         response = self.client.put('/rest/datasets/%s' % self.preferred_identifier, self.test_new_data, format="json")
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND, 'Update operation should return 404 when using preferred_identifier')
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND,
+                         'Update operation should return 404 when using preferred_identifier')
 
     def test_update_catalog_record_error_required_fields(self):
         """
@@ -516,7 +531,8 @@ class CatalogRecordApiWriteUpdateTests(CatalogRecordApiWriteCommon):
         response = self.client.put('/rest/datasets/%s' % self.urn_identifier, self.test_new_data, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual('research_dataset' in response.data.keys(), True, 'Error for field \'research_dataset\' is missing from response.data')
+        self.assertEqual('research_dataset' in response.data.keys(), True,
+                         'Error for field \'research_dataset\' is missing from response.data')
 
     def test_update_catalog_record_dont_allow_data_catalog_fields_update(self):
         original_title = self.test_new_data['data_catalog']['catalog_json']['title']['en']
@@ -555,15 +571,18 @@ class CatalogRecordApiWriteUpdateTests(CatalogRecordApiWriteCommon):
     def test_update_catalog_record_pas_state_unallowed_value(self):
         self.test_new_data['preservation_state'] = 111
         response = self.client.put('/rest/datasets/%s' % self.urn_identifier, self.test_new_data, format="json")
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, 'HTTP status should be 400 due to invalid value')
-        self.assertEqual('preservation_state' in response.data.keys(), True, 'The error should mention the field preservation_state')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST,
+                         'HTTP status should be 400 due to invalid value')
+        self.assertEqual('preservation_state' in response.data.keys(), True,
+                         'The error should mention the field preservation_state')
 
     def test_update_catalog_record_preservation_state_modified_is_updated(self):
         self.test_new_data['preservation_state'] = 4
         response = self.client.put('/rest/datasets/%s' % self.urn_identifier, self.test_new_data, format="json")
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT, response.data)
         cr = CatalogRecord.objects.get(pk=self.pk)
-        self.assertEqual(cr.preservation_state_modified >= datetime.now() - timedelta(seconds=5), True, 'Timestamp should have been updated during object update')
+        self.assertEqual(cr.preservation_state_modified >= datetime.now() - timedelta(seconds=5), True,
+                         'Timestamp should have been updated during object update')
 
     #
     # update list operations PUT
@@ -571,10 +590,10 @@ class CatalogRecordApiWriteUpdateTests(CatalogRecordApiWriteCommon):
 
     def test_catalog_record_update_list(self):
         self.test_new_data['id'] = 1
-        self.test_new_data['research_dataset']['description'] = [{ 'en': 'updated description' }]
+        self.test_new_data['research_dataset']['description'] = [{'en': 'updated description'}]
 
         self.second_test_new_data['id'] = 2
-        self.second_test_new_data['research_dataset']['description'] = [{ 'en': 'second updated description' }]
+        self.second_test_new_data['research_dataset']['description'] = [{'en': 'second updated description'}]
 
         response = self.client.put('/rest/datasets', [self.test_new_data, self.second_test_new_data], format="json")
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT, response.data)
@@ -586,7 +605,7 @@ class CatalogRecordApiWriteUpdateTests(CatalogRecordApiWriteCommon):
 
     def test_catalog_record_update_list_error_one_fails(self):
         self.test_new_data['id'] = 1
-        self.test_new_data['research_dataset']['description'] = [{ 'en': 'updated description' }]
+        self.test_new_data['research_dataset']['description'] = [{'en': 'updated description'}]
 
         # this value should already exist, therefore should fail
         self.second_test_new_data['research_dataset']['preferred_identifier'] = self.urn_identifier
@@ -596,7 +615,8 @@ class CatalogRecordApiWriteUpdateTests(CatalogRecordApiWriteCommon):
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
         self.assertEqual('success' in response.data.keys(), True)
         self.assertEqual('failed' in response.data.keys(), True)
-        self.assertEqual(isinstance(response.data['success'], list), True, 'return data should contain key success, which is a list')
+        self.assertEqual(isinstance(response.data['success'], list), True,
+                         'return data should contain key success, which is a list')
         self.assertEqual(len(response.data['success']), 0, 'success list should be empty')
         self.assertEqual(len(response.data['failed']), 1, 'there should have been one failed element')
 
@@ -607,10 +627,10 @@ class CatalogRecordApiWriteUpdateTests(CatalogRecordApiWriteCommon):
     def test_catalog_record_update_list_error_key_not_found(self):
         # does not have identifier key
         self.test_new_data['research_dataset'].pop('urn_identifier')
-        self.test_new_data['research_dataset']['description'] = [{ 'en': 'updated description' }]
+        self.test_new_data['research_dataset']['description'] = [{'en': 'updated description'}]
 
         self.second_test_new_data['id'] = 2
-        self.second_test_new_data['research_dataset']['description'] = [{ 'en': 'second updated description' }]
+        self.second_test_new_data['research_dataset']['description'] = [{'en': 'second updated description'}]
 
         response = self.client.put('/rest/datasets', [self.test_new_data, self.second_test_new_data], format="json")
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
@@ -621,7 +641,6 @@ class CatalogRecordApiWriteUpdateTests(CatalogRecordApiWriteCommon):
 
 
 class CatalogRecordApiWritePartialUpdateTests(CatalogRecordApiWriteCommon):
-
     #
     #
     # update apis PATCH
@@ -657,7 +676,8 @@ class CatalogRecordApiWritePartialUpdateTests(CatalogRecordApiWriteCommon):
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
         self.assertEqual('success' in response.data, True, 'response.data should contain list of changed objects')
         self.assertEqual(len(response.data), 2, 'response.data should contain 2 changed objects')
-        self.assertEqual('research_dataset' in response.data['success'][0]['object'], True, 'response.data should contain full objects')
+        self.assertEqual('research_dataset' in response.data['success'][0]['object'], True,
+                         'response.data should contain full objects')
 
         updated_cr = CatalogRecord.objects.get(pk=1)
         self.assertEqual(updated_cr.preservation_state, 1, 'preservation state should have changed to 1')
@@ -668,7 +688,7 @@ class CatalogRecordApiWritePartialUpdateTests(CatalogRecordApiWriteCommon):
         test_data['preservation_state'] = 1
 
         second_test_data = {}
-        second_test_data['preservation_state'] = 555 # value not allowed
+        second_test_data['preservation_state'] = 555  # value not allowed
         second_test_data['id'] = 2
 
         response = self.client.patch('/rest/datasets', [test_data, second_test_data], format="json")
@@ -677,7 +697,8 @@ class CatalogRecordApiWritePartialUpdateTests(CatalogRecordApiWriteCommon):
         self.assertEqual('failed' in response.data.keys(), True)
         self.assertEqual(len(response.data['success']), 1, 'success list should contain one item')
         self.assertEqual(len(response.data['failed']), 1, 'there should have been one failed element')
-        self.assertEqual('preservation_state' in response.data['failed'][0]['errors'], True, response.data['failed'][0]['errors'])
+        self.assertEqual('preservation_state' in response.data['failed'][0]['errors'], True,
+                         response.data['failed'][0]['errors'])
 
     def test_catalog_record_partial_update_list_error_key_not_found(self):
         # does not have identifier key
@@ -695,11 +716,11 @@ class CatalogRecordApiWritePartialUpdateTests(CatalogRecordApiWriteCommon):
         self.assertEqual(len(response.data['success']), 1, 'success list should contain one item')
         self.assertEqual(len(response.data['failed']), 1, 'there should have been one failed element')
         self.assertEqual('detail' in response.data['failed'][0]['errors'], True, response.data['failed'][0]['errors'])
-        self.assertEqual('identifying key' in response.data['failed'][0]['errors']['detail'][0], True, response.data['failed'][0]['errors'])
+        self.assertEqual('identifying key' in response.data['failed'][0]['errors']['detail'][0], True,
+                         response.data['failed'][0]['errors'])
 
 
 class CatalogRecordApiWriteHTTPHeaderTests(CatalogRecordApiWriteCommon):
-
     #
     # header if-modified-since tests, single
     #
@@ -707,14 +728,16 @@ class CatalogRecordApiWriteHTTPHeaderTests(CatalogRecordApiWriteCommon):
     def test_update_with_if_unmodified_since_header_ok(self):
         self.test_new_data['preservation_description'] = 'damn this is good coffee'
         cr = CatalogRecord.objects.get(pk=1)
-        headers = { 'If-Unmodified-Since': cr.modified_by_api.strftime('%a, %d %b %Y %H:%M:%S %Z') }
-        response = self.client.put('/rest/datasets/%s' % self.urn_identifier, self.test_new_data, headers=headers, format="json")
+        headers = {'If-Unmodified-Since': cr.modified_by_api.strftime('%a, %d %b %Y %H:%M:%S %Z')}
+        response = self.client.put('/rest/datasets/%s' % self.urn_identifier, self.test_new_data, headers=headers,
+                                   format="json")
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT, response.data)
 
     def test_update_with_if_unmodified_since_header_error(self):
         self.test_new_data['preservation_description'] = 'the owls are not what they seem'
-        headers = { 'If-Unmodified-Since': 'Wed, 23 Sep 2009 22:15:29 GMT' }
-        response = self.client.put('/rest/datasets/%s' % self.urn_identifier, self.test_new_data, headers=headers, format="json")
+        headers = {'If-Unmodified-Since': 'Wed, 23 Sep 2009 22:15:29 GMT'}
+        response = self.client.put('/rest/datasets/%s' % self.urn_identifier, self.test_new_data, headers=headers,
+                                   format="json")
         self.assertEqual(response.status_code, 412, 'http status should be 412 = precondition failed')
 
     #
@@ -730,8 +753,8 @@ class CatalogRecordApiWriteHTTPHeaderTests(CatalogRecordApiWriteCommon):
         data_1['preservation_description'] = 'damn this is good coffee'
         data_2['preservation_description'] = 'damn this is good coffee also'
 
-        headers = { 'If-Unmodified-Since': 'value is not checked' }
-        response = self.client.put('/rest/datasets', [ data_1, data_2 ], headers=headers, format="json")
+        headers = {'If-Unmodified-Since': 'value is not checked'}
+        response = self.client.put('/rest/datasets', [data_1, data_2], headers=headers, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT, response.data)
 
@@ -749,9 +772,10 @@ class CatalogRecordApiWriteHTTPHeaderTests(CatalogRecordApiWriteCommon):
         # should result in error for this record
         data_2['modified_by_api'] = '2002-01-01T10:10:10.000000'
 
-        headers = { 'If-Unmodified-Since': 'value is not checked' }
-        response = self.client.put('/rest/datasets', [ data_1, data_2 ], headers=headers, format="json")
-        self.assertEqual('modified' in response.data['failed'][0]['errors']['detail'][0], True, 'error should indicate resource has been modified')
+        headers = {'If-Unmodified-Since': 'value is not checked'}
+        response = self.client.put('/rest/datasets', [data_1, data_2], headers=headers, format="json")
+        self.assertEqual('modified' in response.data['failed'][0]['errors']['detail'][0], True,
+                         'error should indicate resource has been modified')
 
     def test_update_list_with_if_unmodified_since_header_error_2(self):
         """
@@ -767,9 +791,10 @@ class CatalogRecordApiWriteHTTPHeaderTests(CatalogRecordApiWriteCommon):
         # should result in error for this record
         data_2.pop('modified_by_api')
 
-        headers = { 'If-Unmodified-Since': 'value is not checked' }
-        response = self.client.patch('/rest/datasets', [ data_1, data_2 ], headers=headers, format="json")
-        self.assertEqual('required' in response.data['failed'][0]['errors']['detail'][0], True, 'error should be about field modified_by_api is required')
+        headers = {'If-Unmodified-Since': 'value is not checked'}
+        response = self.client.patch('/rest/datasets', [data_1, data_2], headers=headers, format="json")
+        self.assertEqual('required' in response.data['failed'][0]['errors']['detail'][0], True,
+                         'error should be about field modified_by_api is required')
 
     def test_update_list_with_if_unmodified_since_header_error_3(self):
         """
@@ -786,13 +811,13 @@ class CatalogRecordApiWriteHTTPHeaderTests(CatalogRecordApiWriteCommon):
         data_2['preservation_description'] = 'damn this is good coffee also'
         data_2['modified_by_api'] = None
 
-        headers = { 'If-Unmodified-Since': 'value is not checked' }
-        response = self.client.put('/rest/datasets', [ data_1, data_2 ], headers=headers, format="json")
-        self.assertEqual('modified' in response.data['failed'][0]['errors']['detail'][0], True, 'error should indicate resource has been modified')
+        headers = {'If-Unmodified-Since': 'value is not checked'}
+        response = self.client.put('/rest/datasets', [data_1, data_2], headers=headers, format="json")
+        self.assertEqual('modified' in response.data['failed'][0]['errors']['detail'][0], True,
+                         'error should indicate resource has been modified')
 
 
 class CatalogRecordApiWriteDeleteTests(CatalogRecordApiWriteCommon):
-
     #
     #
     #
@@ -811,7 +836,8 @@ class CatalogRecordApiWriteDeleteTests(CatalogRecordApiWriteCommon):
         deleted_catalog_record = None
 
         try:
-            deleted_catalog_record = CatalogRecord.objects.get(research_dataset__contains={ 'urn_identifier': self.urn_identifier })
+            deleted_catalog_record = CatalogRecord.objects.get(
+                research_dataset__contains={'urn_identifier': self.urn_identifier})
         except CatalogRecord.DoesNotExist:
             pass
 
@@ -819,7 +845,8 @@ class CatalogRecordApiWriteDeleteTests(CatalogRecordApiWriteCommon):
             raise Exception('Deleted CatalogRecord should not be retrievable from the default objects table')
 
         try:
-            deleted_catalog_record = CatalogRecord.objects_unfiltered.get(research_dataset__contains={ 'urn_identifier': self.urn_identifier })
+            deleted_catalog_record = CatalogRecord.objects_unfiltered.get(
+                research_dataset__contains={'urn_identifier': self.urn_identifier})
         except CatalogRecord.DoesNotExist:
             raise Exception('Deleted CatalogRecord should not be deleted from the db, but marked as removed')
 
@@ -836,7 +863,8 @@ class CatalogRecordApiWriteDeleteTests(CatalogRecordApiWriteCommon):
         url = '/rest/datasets/%s' % catalog_record_from_test_data['research_dataset']['urn_identifier']
         self.client.delete(url)
         response2 = self.client.get('/rest/contracts/%d' % catalog_record_from_test_data['contract'])
-        self.assertEqual(response2.status_code, status.HTTP_200_OK, 'The contract of the CatalogRecord should not be deleted when deleting a single CatalogRecord.')
+        self.assertEqual(response2.status_code, status.HTTP_200_OK,
+                         'The contract of the CatalogRecord should not be deleted when deleting a single CatalogRecord.')
 
     def test_delete_catalog_record_not_found_with_search_by_owner(self):
         # owner of pk=1 is Default Owner. Delete pk=2 == first dataset owner by Rahikainen.
@@ -849,7 +877,6 @@ class CatalogRecordApiWriteDeleteTests(CatalogRecordApiWriteCommon):
 
 
 class CatalogRecordApiWriteProposeToPasTests(CatalogRecordApiWriteCommon):
-
     #
     #
     #
@@ -863,12 +890,13 @@ class CatalogRecordApiWriteProposeToPasTests(CatalogRecordApiWriteCommon):
         catalog_record_before.save()
 
         response = self.client.post('/rest/datasets/%s/proposetopas?state=%d&contract=%s' %
-            (
-                self.urn_identifier,
-                CatalogRecord.PRESERVATION_STATE_PROPOSED_MIDTERM,
-                self._get_object_from_test_data('contract', requested_index=0)['contract_json']['identifier']
-            ),
-            format="json")
+                                    (
+                                        self.urn_identifier,
+                                        CatalogRecord.PRESERVATION_STATE_PROPOSED_MIDTERM,
+                                        self._get_object_from_test_data('contract', requested_index=0)['contract_json'][
+                                            'identifier']
+                                    ),
+                                    format="json")
 
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         catalog_record_after = CatalogRecord.objects.get(pk=self.pk)
@@ -876,34 +904,36 @@ class CatalogRecordApiWriteProposeToPasTests(CatalogRecordApiWriteCommon):
 
     def test_catalog_record_propose_to_pas_missing_parameter_state(self):
         response = self.client.post('/rest/datasets/%s/proposetopas?contract=%s' %
-            (
-                self.urn_identifier,
-                self._get_object_from_test_data('contract', requested_index=0)['contract_json']['identifier']
-            ),
-            format="json")
+                                    (
+                                        self.urn_identifier,
+                                        self._get_object_from_test_data('contract', requested_index=0)['contract_json'][
+                                            'identifier']
+                                    ),
+                                    format="json")
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual('state' in response.data, True, 'Response data should contain an error about the field')
 
     def test_catalog_record_propose_to_pas_wrong_parameter_state(self):
         response = self.client.post('/rest/datasets/%s/proposetopas?state=%d&contract=%s' %
-            (
-                self.urn_identifier,
-                15,
-                self._get_object_from_test_data('contract', requested_index=0)['contract_json']['identifier']
-            ),
-            format="json")
+                                    (
+                                        self.urn_identifier,
+                                        15,
+                                        self._get_object_from_test_data('contract', requested_index=0)['contract_json'][
+                                            'identifier']
+                                    ),
+                                    format="json")
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual('state' in response.data, True, 'Response data should contain an error about the field')
 
     def test_catalog_record_propose_to_pas_missing_parameter_contract(self):
         response = self.client.post('/rest/datasets/%s/proposetopas?state=%s' %
-            (
-                self.urn_identifier,
-                CatalogRecord.PRESERVATION_STATE_PROPOSED_MIDTERM,
-            ),
-            format="json")
+                                    (
+                                        self.urn_identifier,
+                                        CatalogRecord.PRESERVATION_STATE_PROPOSED_MIDTERM,
+                                    ),
+                                    format="json")
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual('contract' in response.data, True, 'Response data should contain an error about the field')
@@ -913,12 +943,12 @@ class CatalogRecordApiWriteProposeToPasTests(CatalogRecordApiWriteCommon):
         catalog_record_before.save()
 
         response = self.client.post('/rest/datasets/%s/proposetopas?state=%d&contract=%s' %
-            (
-                self.urn_identifier,
-                CatalogRecord.PRESERVATION_STATE_PROPOSED_MIDTERM,
-                'does-not-exist'
-            ),
-            format="json")
+                                    (
+                                        self.urn_identifier,
+                                        CatalogRecord.PRESERVATION_STATE_PROPOSED_MIDTERM,
+                                        'does-not-exist'
+                                    ),
+                                    format="json")
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual('contract' in response.data, True, 'Response data should contain an error about the field')
@@ -929,19 +959,16 @@ class CatalogRecordApiWriteProposeToPasTests(CatalogRecordApiWriteCommon):
         catalog_record_before.save()
 
         response = self.client.post('/rest/datasets/%s/proposetopas?state=%d&contract=%s' %
-            (
-                self.urn_identifier,
-                CatalogRecord.PRESERVATION_STATE_PROPOSED_MIDTERM,
-                self._get_object_from_test_data('contract', requested_index=0)['contract_json']['identifier']
-            ),
-            format="json")
+                                    (self.urn_identifier, CatalogRecord.PRESERVATION_STATE_PROPOSED_MIDTERM,
+                                     self._get_object_from_test_data('contract', requested_index=0)['contract_json'][
+                                         'identifier']), format="json")
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-        self.assertEqual('preservation_state' in response.data, True, 'Response data should contain an error about the field')
+        self.assertEqual('preservation_state' in response.data, True,
+                         'Response data should contain an error about the field')
 
 
 class CatalogRecordApiWriteReferenceDataTests(CatalogRecordApiWriteCommon):
-
     """
     Tests related to reference_data validation and dataset fields population
     from reference_data, according to given uri or code as the value.
@@ -954,7 +981,8 @@ class CatalogRecordApiWriteReferenceDataTests(CatalogRecordApiWriteCommon):
         """
         cache = RedisSentinelCache()
         cache.delete('reference_data')
-        self.assertEqual(cache.get('reference_data', master=True), None, 'cache ref data should be missing after cache.delete()')
+        self.assertEqual(cache.get('reference_data', master=True), None,
+                         'cache ref data should be missing after cache.delete()')
 
         response = self.client.post('/rest/datasets', self.test_new_data, format="json")
         self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.data)
@@ -1032,19 +1060,18 @@ class CatalogRecordApiWriteReferenceDataTests(CatalogRecordApiWriteCommon):
         # to easily check that label was populated (= that it appeared in the dataset after create)
         # without knowing its original value from the generated test data
         rd = self.third_test_new_data['research_dataset']
-        rd['theme'][0]                    = { 'identifier': refs['keyword']['code'] }
-        rd['field_of_science'][0]         = { 'identifier': refs['field_of_science']['code'] }
-        rd['language'][0]                 = { 'identifier': refs['language']['code'] }
-        rd['access_rights']['type'][0]    = { 'identifier': refs['access_type']['code'] }
-        rd['access_rights']['license'][0] = { 'identifier': refs['license']['code'] }
-        rd['other_identifier'][0]['type'] = { 'identifier': refs['identifier_type']['code'] }
-        rd['spatial'][0]['place_uri'][0]  = { 'identifier': refs['location']['code'] }
-        rd['files'][0]['type']            = { 'identifier': refs['resource_type']['code'] }
-        rd['remote_resources'][0]['type'] = { 'identifier': refs['resource_type']['code'] }
-        rd['remote_resources'][0]['license'][0] = { 'identifier': refs['license']['code'] }
+        rd['theme'][0] = {'identifier': refs['keyword']['code']}
+        rd['field_of_science'][0] = {'identifier': refs['field_of_science']['code']}
+        rd['language'][0] = {'identifier': refs['language']['code']}
+        rd['access_rights']['type'][0] = {'identifier': refs['access_type']['code']}
+        rd['access_rights']['license'][0] = {'identifier': refs['license']['code']}
+        rd['other_identifier'][0]['type'] = {'identifier': refs['identifier_type']['code']}
+        rd['spatial'][0]['place_uri'][0] = {'identifier': refs['location']['code']}
+        rd['files'][0]['type'] = {'identifier': refs['resource_type']['code']}
+        rd['remote_resources'][0]['type'] = {'identifier': refs['resource_type']['code']}
+        rd['remote_resources'][0]['license'][0] = {'identifier': refs['license']['code']}
 
         # these have other required fields, so only update the identifier with code
-        rd['remote_resources'][0]['checksum']['algorithm']            = refs['checksum_algorithm']['code']
         rd['is_output_of'][0]['source_organization'][0]['identifier'] = refs['organization']['code']
         rd['is_output_of'][0]['has_funding_agency'][0]['identifier'] = refs['organization']['code']
         rd['other_identifier'][0]['provider']['identifier'] = refs['organization']['code']
@@ -1055,6 +1082,11 @@ class CatalogRecordApiWriteReferenceDataTests(CatalogRecordApiWriteCommon):
         rd['rights_holder']['is_part_of']['identifier'] = refs['organization']['code']
         rd['access_rights']['has_rights_related_agent'][0]['identifier'] = refs['organization']['code']
 
+        # These are fields for which reference data values can be used, but their value should not be touched
+        # when they arrive to metax api. The existence of this section may not be justified since this concerns
+        # mostly e.g. qvain
+        rd['remote_resources'][0]['checksum']['algorithm'] = refs['checksum_algorithm']['code']
+
         response = self.client.post('/rest/datasets', self.third_test_new_data, format="json")
         self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.data)
         self.assertEqual('research_dataset' in response.data.keys(), True)
@@ -1063,60 +1095,65 @@ class CatalogRecordApiWriteReferenceDataTests(CatalogRecordApiWriteCommon):
         self._assert_uri_copied_to_identifier(refs, new_rd)
         self._assert_label_copied_to_pref_label(refs, new_rd)
         self._assert_label_copied_to_title(refs, new_rd)
-        self._assert_label_copied_to_others(refs, new_rd)
+        self._assert_label_copied_to_name(refs, new_rd)
+        self._assert_has_remained_the_same(refs, new_rd)
 
     def _assert_uri_copied_to_identifier(self, refs, new_rd):
-        self.assertEqual(refs['keyword']['uri'],          new_rd['theme'][0]['identifier'])
+        self.assertEqual(refs['keyword']['uri'], new_rd['theme'][0]['identifier'])
         self.assertEqual(refs['field_of_science']['uri'], new_rd['field_of_science'][0]['identifier'])
-        self.assertEqual(refs['language']['uri'],         new_rd['language'][0]['identifier'])
-        self.assertEqual(refs['access_type']['uri'],      new_rd['access_rights']['type'][0]['identifier'])
-        self.assertEqual(refs['license']['uri'],          new_rd['access_rights']['license'][0]['identifier'])
-        self.assertEqual(refs['identifier_type']['uri'],  new_rd['other_identifier'][0]['type']['identifier'])
-        self.assertEqual(refs['location']['uri'],         new_rd['spatial'][0]['place_uri'][0]['identifier'])
-        self.assertEqual(refs['resource_type']['uri'],    new_rd['files'][0]['type']['identifier'])
-        self.assertEqual(refs['resource_type']['uri'],    new_rd['remote_resources'][0]['type']['identifier'])
-        self.assertEqual(refs['license']['uri'],          new_rd['remote_resources'][0]['license'][0]['identifier'])
-        self.assertEqual(refs['organization']['uri'],     new_rd['is_output_of'][0]['source_organization'][0]['identifier'])
-        self.assertEqual(refs['checksum_algorithm']['uri'], new_rd['remote_resources'][0]['checksum']['algorithm'])
-        self.assertEqual(refs['organization']['uri'],     new_rd['is_output_of'][0]['has_funding_agency'][0]['identifier'])
-        self.assertEqual(refs['organization']['uri'],     new_rd['other_identifier'][0]['provider']['identifier'])
-        self.assertEqual(refs['organization']['uri'],     new_rd['contributor'][0]['member_of']['identifier'])
-        self.assertEqual(refs['organization']['uri'],     new_rd['creator'][0]['member_of']['identifier'])
-        self.assertEqual(refs['organization']['uri'],     new_rd['curator'][0]['is_part_of']['identifier'])
-        self.assertEqual(refs['organization']['uri'],     new_rd['publisher']['is_part_of']['identifier'])
-        self.assertEqual(refs['organization']['uri'],     new_rd['rights_holder']['is_part_of']['identifier'])
-        self.assertEqual(refs['organization']['uri'],     new_rd['access_rights']['has_rights_related_agent'][0]['identifier'])
+        self.assertEqual(refs['language']['uri'], new_rd['language'][0]['identifier'])
+        self.assertEqual(refs['access_type']['uri'], new_rd['access_rights']['type'][0]['identifier'])
+        self.assertEqual(refs['license']['uri'], new_rd['access_rights']['license'][0]['identifier'])
+        self.assertEqual(refs['identifier_type']['uri'], new_rd['other_identifier'][0]['type']['identifier'])
+        self.assertEqual(refs['location']['uri'], new_rd['spatial'][0]['place_uri'][0]['identifier'])
+        self.assertEqual(refs['resource_type']['uri'], new_rd['files'][0]['type']['identifier'])
+        self.assertEqual(refs['resource_type']['uri'], new_rd['remote_resources'][0]['type']['identifier'])
+        self.assertEqual(refs['license']['uri'], new_rd['remote_resources'][0]['license'][0]['identifier'])
+        self.assertEqual(refs['organization']['uri'], new_rd['is_output_of'][0]['source_organization'][0]['identifier'])
+        self.assertEqual(refs['organization']['uri'], new_rd['is_output_of'][0]['has_funding_agency'][0]['identifier'])
+        self.assertEqual(refs['organization']['uri'], new_rd['other_identifier'][0]['provider']['identifier'])
+        self.assertEqual(refs['organization']['uri'], new_rd['contributor'][0]['member_of']['identifier'])
+        self.assertEqual(refs['organization']['uri'], new_rd['creator'][0]['member_of']['identifier'])
+        self.assertEqual(refs['organization']['uri'], new_rd['curator'][0]['is_part_of']['identifier'])
+        self.assertEqual(refs['organization']['uri'], new_rd['publisher']['is_part_of']['identifier'])
+        self.assertEqual(refs['organization']['uri'], new_rd['rights_holder']['is_part_of']['identifier'])
+        self.assertEqual(refs['organization']['uri'],
+                         new_rd['access_rights']['has_rights_related_agent'][0]['identifier'])
 
     def _assert_label_copied_to_pref_label(self, refs, new_rd):
-        self.assertEqual(refs['keyword']['label'],          new_rd['theme'][0].get('pref_label', None))
+        self.assertEqual(refs['keyword']['label'], new_rd['theme'][0].get('pref_label', None))
         self.assertEqual(refs['field_of_science']['label'], new_rd['field_of_science'][0].get('pref_label', None))
-        self.assertEqual(refs['access_type']['label'],      new_rd['access_rights']['type'][0].get('pref_label', None))
-        self.assertEqual(refs['identifier_type']['label'],  new_rd['other_identifier'][0]['type'].get('pref_label', None))
-        self.assertEqual(refs['location']['label'],         new_rd['spatial'][0]['place_uri'][0].get('pref_label', None))
-        self.assertEqual(refs['resource_type']['label'],    new_rd['files'][0]['type'].get('pref_label', None))
-        self.assertEqual(refs['resource_type']['label'],    new_rd['remote_resources'][0]['type'].get('pref_label', None))
+        self.assertEqual(refs['access_type']['label'], new_rd['access_rights']['type'][0].get('pref_label', None))
+        self.assertEqual(refs['identifier_type']['label'],
+                         new_rd['other_identifier'][0]['type'].get('pref_label', None))
+        self.assertEqual(refs['location']['label'], new_rd['spatial'][0]['place_uri'][0].get('pref_label', None))
+        self.assertEqual(refs['resource_type']['label'], new_rd['files'][0]['type'].get('pref_label', None))
+        self.assertEqual(refs['resource_type']['label'], new_rd['remote_resources'][0]['type'].get('pref_label', None))
 
     def _assert_label_copied_to_title(self, refs, new_rd):
         self.assertEqual(refs['language']['label'], new_rd['language'][0].get('title', None))
-        self.assertEqual(refs['license']['label'],  new_rd['access_rights']['license'][0].get('title', None))
-        self.assertEqual(refs['license']['label'],  new_rd['remote_resources'][0]['license'][0].get('title', None))
+        self.assertEqual(refs['license']['label'], new_rd['access_rights']['license'][0].get('title', None))
+        self.assertEqual(refs['license']['label'], new_rd['remote_resources'][0]['license'][0].get('title', None))
 
-    def _assert_label_copied_to_others(self, refs, new_rd):
-        # the black sheep
-        self.assertEqual(refs['organization']['label']['default'],     new_rd['is_output_of'][0]['source_organization'][0].get('name', None))
-        self.assertEqual(refs['checksum_algorithm']['label'], new_rd['remote_resources'][0]['checksum'].get('checksum_algorithm', None))
-        self.assertEqual(refs['organization']['label']['default'], new_rd['is_output_of'][0]['has_funding_agency'][0].get('name', None))
-        self.assertEqual(refs['organization']['label']['default'], new_rd['other_identifier'][0]['provider'].get('name', None))
-        self.assertEqual(refs['organization']['label']['default'], new_rd['contributor'][0]['member_of'].get('name', None))
-        self.assertEqual(refs['organization']['label']['default'], new_rd['creator'][0]['member_of'].get('name', None))
-        self.assertEqual(refs['organization']['label']['default'], new_rd['curator'][0]['is_part_of'].get('name', None))
-        self.assertEqual(refs['organization']['label']['default'], new_rd['publisher']['is_part_of'].get('name', None))
-        self.assertEqual(refs['organization']['label']['default'], new_rd['rights_holder']['is_part_of'].get('name', None))
-        self.assertEqual(refs['organization']['label']['default'], new_rd['access_rights']['has_rights_related_agent'][0].get('name', None))
+    def _assert_label_copied_to_name(self, refs, new_rd):
+        self.assertEqual(refs['organization']['label'],
+                         new_rd['is_output_of'][0]['source_organization'][0].get('name', None))
+        self.assertEqual(refs['organization']['label'],
+                         new_rd['is_output_of'][0]['has_funding_agency'][0].get('name', None))
+        self.assertEqual(refs['organization']['label'], new_rd['other_identifier'][0]['provider'].get('name', None))
+        self.assertEqual(refs['organization']['label'], new_rd['contributor'][0]['member_of'].get('name', None))
+        self.assertEqual(refs['organization']['label'], new_rd['creator'][0]['member_of'].get('name', None))
+        self.assertEqual(refs['organization']['label'], new_rd['curator'][0]['is_part_of'].get('name', None))
+        self.assertEqual(refs['organization']['label'], new_rd['publisher']['is_part_of'].get('name', None))
+        self.assertEqual(refs['organization']['label'], new_rd['rights_holder']['is_part_of'].get('name', None))
+        self.assertEqual(refs['organization']['label'],
+                         new_rd['access_rights']['has_rights_related_agent'][0].get('name', None))
+
+    def _assert_has_remained_the_same(self, refs, new_rd):
+        self.assertEquals(refs['checksum_algorithm']['code'], new_rd['remote_resources'][0]['checksum']['algorithm'])
 
 
 class CatalogRecordApiWriteAlternateRecords(CatalogRecordApiWriteCommon):
-
     """
     Tests related to handling alternate records: Records which have the same
     preferred_identifier, but are in different data catalogs.
@@ -1133,14 +1170,18 @@ class CatalogRecordApiWriteAlternateRecords(CatalogRecordApiWriteCommon):
         Add a record, where a record already existed with the same pref_id, but did not have an
         alternate_record_set yet. Ensure a new set is created, and both records are added to it.
         """
-        existing_records_count = CatalogRecord.objects.filter(research_dataset__contains={ 'preferred_identifier': self.preferred_identifier }).count()
-        self.assertEqual(existing_records_count, 1, 'in the beginning, there should be only one record with pref id %s' % self.preferred_identifier)
+        existing_records_count = CatalogRecord.objects.filter(
+            research_dataset__contains={'preferred_identifier': self.preferred_identifier}).count()
+        self.assertEqual(existing_records_count, 1,
+                         'in the beginning, there should be only one record with pref id %s' % self.preferred_identifier)
 
         response = self.client.post('/rest/datasets', self.test_new_data, format="json")
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
-        records = CatalogRecord.objects.filter(research_dataset__contains={ 'preferred_identifier': self.preferred_identifier })
-        self.assertEqual(len(records), 2, 'after, there should be two records with pref id %s' % self.preferred_identifier)
+        records = CatalogRecord.objects.filter(
+            research_dataset__contains={'preferred_identifier': self.preferred_identifier})
+        self.assertEqual(len(records), 2,
+                         'after, there should be two records with pref id %s' % self.preferred_identifier)
 
         # both records are moved to same set
         ars_id = records[0].alternate_record_set.id
@@ -1158,14 +1199,18 @@ class CatalogRecordApiWriteAlternateRecords(CatalogRecordApiWriteCommon):
     def test_append_to_existing_alternate_record_set_if_it_exists(self):
         self._set_preferred_identifier_to_record(pk=2, data_catalog=3)
 
-        existing_records_count = CatalogRecord.objects.filter(research_dataset__contains={ 'preferred_identifier': self.preferred_identifier }).count()
-        self.assertEqual(existing_records_count, 2, 'in the beginning, there should be two records with pref id %s' % self.preferred_identifier)
+        existing_records_count = CatalogRecord.objects.filter(
+            research_dataset__contains={'preferred_identifier': self.preferred_identifier}).count()
+        self.assertEqual(existing_records_count, 2,
+                         'in the beginning, there should be two records with pref id %s' % self.preferred_identifier)
 
         response = self.client.post('/rest/datasets', self.test_new_data, format="json")
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
-        records = CatalogRecord.objects.filter(research_dataset__contains={ 'preferred_identifier': self.preferred_identifier })
-        self.assertEqual(len(records), 3, 'after, there should be three records with pref id %s' % self.preferred_identifier)
+        records = CatalogRecord.objects.filter(
+            research_dataset__contains={'preferred_identifier': self.preferred_identifier})
+        self.assertEqual(len(records), 3,
+                         'after, there should be three records with pref id %s' % self.preferred_identifier)
 
         # all records belong to same set
         ars_id = records[0].alternate_record_set.id
@@ -1189,21 +1234,25 @@ class CatalogRecordApiWriteAlternateRecords(CatalogRecordApiWriteCommon):
         response = self.client.delete('/rest/datasets/2', format="json")
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
-        records = CatalogRecord.objects.filter(research_dataset__contains={ 'preferred_identifier': self.preferred_identifier })
-        self.assertEqual(records[0].alternate_record_set.records.count(), 2, 'alternate_record_set should have two records after deleting one')
+        records = CatalogRecord.objects.filter(
+            research_dataset__contains={'preferred_identifier': self.preferred_identifier})
+        self.assertEqual(records[0].alternate_record_set.records.count(), 2,
+                         'alternate_record_set should have two records after deleting one')
 
     def test_record_is_removed_from_alternate_record_set_when_updated(self):
         self._set_and_ensure_initial_conditions()
 
         response = self.client.get('/rest/datasets/2', format="json")
-        data = { 'research_dataset': response.data['research_dataset'] }
+        data = {'research_dataset': response.data['research_dataset']}
         data['research_dataset']['preferred_identifier'] = 'a:new:identifier:here'
 
         response = self.client.patch('/rest/datasets/2', data=data, format="json")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        records = CatalogRecord.objects.filter(research_dataset__contains={ 'preferred_identifier': self.preferred_identifier })
-        self.assertEqual(records[0].alternate_record_set.records.count(), 2, 'alternate_record_set should have two records after updating one record')
+        records = CatalogRecord.objects.filter(
+            research_dataset__contains={'preferred_identifier': self.preferred_identifier})
+        self.assertEqual(records[0].alternate_record_set.records.count(), 2,
+                         'alternate_record_set should have two records after updating one record')
 
         # the patched record should not belong to any alt set any longer
         cr = CatalogRecord.objects.get(pk=2)
@@ -1214,13 +1263,14 @@ class CatalogRecordApiWriteAlternateRecords(CatalogRecordApiWriteCommon):
         old_ars_id = CatalogRecord.objects.get(pk=2).alternate_record_set.id
 
         response = self.client.get('/rest/datasets/2', format="json")
-        data = { 'research_dataset': response.data['research_dataset'] }
+        data = {'research_dataset': response.data['research_dataset']}
         data['research_dataset']['preferred_identifier'] = 'a:new:identifier:here'
 
         response = self.client.patch('/rest/datasets/2', data=data, format="json")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        records = CatalogRecord.objects.filter(research_dataset__contains={ 'preferred_identifier': self.preferred_identifier })
+        records = CatalogRecord.objects.filter(
+            research_dataset__contains={'preferred_identifier': self.preferred_identifier})
         self.assertEqual(records.count(), 1, 'should be only one record with this identifier left now')
 
         with self.assertRaises(AlternateRecordSet.DoesNotExist, msg='alternate record set should have been deleted'):
@@ -1238,7 +1288,8 @@ class CatalogRecordApiWriteAlternateRecords(CatalogRecordApiWriteCommon):
         response = self.client.delete('/rest/datasets/2', format="json")
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
-        records = CatalogRecord.objects.filter(research_dataset__contains={ 'preferred_identifier': self.preferred_identifier })
+        records = CatalogRecord.objects.filter(
+            research_dataset__contains={'preferred_identifier': self.preferred_identifier})
         self.assertEqual(records.count(), 1, 'should be only record with this identifier left now')
 
         with self.assertRaises(AlternateRecordSet.DoesNotExist, msg='alternate record set should have been deleted'):
@@ -1255,22 +1306,33 @@ class CatalogRecordApiWriteAlternateRecords(CatalogRecordApiWriteCommon):
         response_2 = self.client.get('/rest/datasets/1', format="json")
         self.assertEqual(response_1.status_code, status.HTTP_201_CREATED)
         self.assertEqual('alternate_record_set' in response_1.data, True)
-        self.assertEqual(response_1.data['research_dataset']['urn_identifier'] not in response_1.data['alternate_record_set'], True, msg_self_should_not_be_listed)
-        self.assertEqual(response_2.data['research_dataset']['urn_identifier'] in response_1.data['alternate_record_set'], True)
+        self.assertEqual(
+            response_1.data['research_dataset']['urn_identifier'] not in response_1.data['alternate_record_set'], True,
+            msg_self_should_not_be_listed)
+        self.assertEqual(
+            response_2.data['research_dataset']['urn_identifier'] in response_1.data['alternate_record_set'], True)
 
-        self.test_new_data.update({ 'data_catalog': 4 })
+        self.test_new_data.update({'data_catalog': 4})
         response_3 = self.client.post('/rest/datasets', self.test_new_data, format="json")
         self.assertEqual(response_3.status_code, status.HTTP_201_CREATED)
         self.assertEqual('alternate_record_set' in response_3.data, True)
-        self.assertEqual(response_1.data['research_dataset']['urn_identifier'] in response_3.data['alternate_record_set'], True)
-        self.assertEqual(response_2.data['research_dataset']['urn_identifier'] in response_3.data['alternate_record_set'], True)
-        self.assertEqual(response_3.data['research_dataset']['urn_identifier'] not in response_3.data['alternate_record_set'], True, msg_self_should_not_be_listed)
+        self.assertEqual(
+            response_1.data['research_dataset']['urn_identifier'] in response_3.data['alternate_record_set'], True)
+        self.assertEqual(
+            response_2.data['research_dataset']['urn_identifier'] in response_3.data['alternate_record_set'], True)
+        self.assertEqual(
+            response_3.data['research_dataset']['urn_identifier'] not in response_3.data['alternate_record_set'], True,
+            msg_self_should_not_be_listed)
 
         response_2 = self.client.get('/rest/datasets/1', format="json")
         self.assertEqual('alternate_record_set' in response_2.data, True)
-        self.assertEqual(response_1.data['research_dataset']['urn_identifier'] in response_2.data['alternate_record_set'], True)
-        self.assertEqual(response_3.data['research_dataset']['urn_identifier'] in response_2.data['alternate_record_set'], True)
-        self.assertEqual(response_2.data['research_dataset']['urn_identifier'] not in response_2.data['alternate_record_set'], True, msg_self_should_not_be_listed)
+        self.assertEqual(
+            response_1.data['research_dataset']['urn_identifier'] in response_2.data['alternate_record_set'], True)
+        self.assertEqual(
+            response_3.data['research_dataset']['urn_identifier'] in response_2.data['alternate_record_set'], True)
+        self.assertEqual(
+            response_2.data['research_dataset']['urn_identifier'] not in response_2.data['alternate_record_set'], True,
+            msg_self_should_not_be_listed)
 
     def _set_preferred_identifier_to_record(self, pk=1, data_catalog=1):
         """
@@ -1296,8 +1358,10 @@ class CatalogRecordApiWriteAlternateRecords(CatalogRecordApiWriteCommon):
         self._set_preferred_identifier_to_record(pk=3, data_catalog=4)
 
         # ensuring initial conditions...
-        records = CatalogRecord.objects.filter(research_dataset__contains={ 'preferred_identifier': self.preferred_identifier })
-        self.assertEqual(len(records), 3, 'in the beginning, there should be three records with pref id %s' % self.preferred_identifier)
+        records = CatalogRecord.objects.filter(
+            research_dataset__contains={'preferred_identifier': self.preferred_identifier})
+        self.assertEqual(len(records), 3,
+                         'in the beginning, there should be three records with pref id %s' % self.preferred_identifier)
         ars_id = records[0].alternate_record_set.id
         self.assertEqual(records[0].alternate_record_set.id, ars_id)
         self.assertEqual(records[1].alternate_record_set.id, ars_id)

--- a/src/metax_api/tests/api/base/apitests/contracts/contracts.py
+++ b/src/metax_api/tests/api/base/apitests/contracts/contracts.py
@@ -210,7 +210,11 @@ class ContractApiWriteTestV1(APITestCase, TestClassUtils):
                 }],
                 "creator": [{
                     "@type": "Person",
-                    "name": "Teppo Testaaja"
+                    "name": "Teppo Testaaja",
+                    "member_of": {
+                        "@type": "Organization",
+                        "name": {"fi": "Mysterious Organization"}
+                    }
                 }],
                 "curator": [{
                     "@type": "Organization",

--- a/src/metax_api/tests/api/base/apitests/contracts/contracts.py
+++ b/src/metax_api/tests/api/base/apitests/contracts/contracts.py
@@ -214,7 +214,7 @@ class ContractApiWriteTestV1(APITestCase, TestClassUtils):
                 }],
                 "curator": [{
                     "@type": "Organization",
-                    "name": "Curator"
+                    "name": {"en": "Curator org", "fi": "Organisaatio"}
                 }],
                 "language": [{
                     "title": "en",

--- a/src/metax_api/tests/api/base/apitests/data_catalogs/write.py
+++ b/src/metax_api/tests/api/base/apitests/data_catalogs/write.py
@@ -106,7 +106,7 @@ class DataCatalogApiWriteReferenceDataTests(DataCatalogApiWriteCommon):
 
         # these have other required fields, so only update the identifier with code
         dc['publisher']['identifier'] = refs['organization']['code']
-        dc['access_rights']['has_right_related_agent'][0]['identifier'] = refs['organization']['code']
+        dc['access_rights']['has_rights_related_agent'][0]['identifier'] = refs['organization']['code']
 
         response = self.client.post('/rest/datacatalogs', self.new_test_data, format="json")
         self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.data)
@@ -116,6 +116,7 @@ class DataCatalogApiWriteReferenceDataTests(DataCatalogApiWriteCommon):
         self._assert_uri_copied_to_identifier(refs, new_dc)
         self._assert_label_copied_to_pref_label(refs, new_dc)
         self._assert_label_copied_to_title(refs, new_dc)
+        self._assert_label_copied_to_name(refs, new_dc)
 
     def _assert_uri_copied_to_identifier(self, refs, new_dc):
         self.assertEqual(refs['field_of_science']['uri'], new_dc['field_of_science'][0]['identifier'])
@@ -123,7 +124,7 @@ class DataCatalogApiWriteReferenceDataTests(DataCatalogApiWriteCommon):
         self.assertEqual(refs['access_type']['uri'],      new_dc['access_rights']['type'][0]['identifier'])
         self.assertEqual(refs['license']['uri'],          new_dc['access_rights']['license'][0]['identifier'])
         self.assertEqual(refs['organization']['uri'],     new_dc['publisher']['identifier'])
-        self.assertEqual(refs['organization']['uri'], new_dc['access_rights']['has_right_related_agent'][0]['identifier'])
+        self.assertEqual(refs['organization']['uri'], new_dc['access_rights']['has_rights_related_agent'][0]['identifier'])
 
     def _assert_label_copied_to_pref_label(self, refs, new_dc):
         self.assertEqual(refs['field_of_science']['label'], new_dc['field_of_science'][0].get('pref_label', None))
@@ -131,3 +132,6 @@ class DataCatalogApiWriteReferenceDataTests(DataCatalogApiWriteCommon):
 
     def _assert_label_copied_to_title(self, refs, new_dc):
         self.assertEqual(refs['license']['label'], new_dc['access_rights']['license'][0].get('title', None))
+
+    def _assert_label_copied_to_name(self, refs, new_dc):
+        self.assertEqual(refs['organization']['label'], new_dc['publisher']['name'])

--- a/src/metax_api/tests/testdata/catalog_record_test_data_template.json
+++ b/src/metax_api/tests/testdata/catalog_record_test_data_template.json
@@ -24,7 +24,7 @@
         "curator":[{
             "@type": "Organization",
             "identifier": "10076-E700",
-            "name": "Owner org in ref data"
+            "name": {"en": "Org in ref data", "fi": "Organisaatio"}
         }],
         "language":[{
             "title": "English",

--- a/src/metax_api/tests/testdata/catalog_record_test_data_template.json
+++ b/src/metax_api/tests/testdata/catalog_record_test_data_template.json
@@ -19,7 +19,13 @@
         }],
         "creator":[{
             "@type": "Person",
-            "name": "Teppo Testaaja"
+            "name": "Teppo Testaaja",
+            "member_of": {
+                "@type": "Organization",
+                "name": {
+                    "fi": "Mysteeriorganisaatio"
+                }
+            }
         }],
         "curator":[{
             "@type": "Organization",

--- a/src/metax_api/tests/testdata/catalog_record_test_data_template_full.json
+++ b/src/metax_api/tests/testdata/catalog_record_test_data_template_full.json
@@ -89,7 +89,7 @@
             "has_rights_related_agent": [{
                 "@type": "Organization",
                 "identifier": "http://purl.org/att/es/organization_data/organization/organization_1901",
-                "name": "Mysterious Organization",
+                "name": {"en": "Org in ref data", "fi": "Organisaatio"},
                 "email": "info@csc.fi",
                 "telephone": [
                     "+358501231235"
@@ -122,7 +122,7 @@
                 "provider": {
                         "@type": "Organization",
                         "identifier": "http://purl.org/att/es/organization_data/organization/organization_1901",
-                        "name": "Mysterious Organization",
+                        "name": {"en": "Org in ref data", "fi": "Organisaatio"},
                         "email": "info@csc.fi",
                         "telephone": [
                             "+358501231235"
@@ -150,7 +150,7 @@
                 "provider": {
                         "@type": "Organization",
                         "identifier": ["http://purl.org/att/es/organization_data/organization/organization_1901"],
-                        "name": "Mysterious Organization",
+                        "name": {"en": "Mysterious Organization", "fi": "Organisaatio"},
                         "email": "info@csc.fi",
                         "telephone": [
                             "+358501231235"
@@ -262,7 +262,7 @@
             "was_associated_with": [{
                 "@type": "Organization",
                 "identifier": "http://purl.org/att/es/organization_data/organization/organization_1901",
-                "name": "Mysterious Organization",
+                "name": {"en": "Mysterious Organization", "fi": "Organisaatio"},
                 "email": "info@csc.fi",
                 "telephone": [
                     "+358501231235"
@@ -316,7 +316,7 @@
         "rights_holder": {
             "@type": "Organization",
             "identifier": "http://purl.org/att/es/organization_data/organization/organization_1901",
-            "name": "Mysterious Organization",
+            "name": {"en": "Mysterious Organization", "fi": "Organisaatio"},
             "email": "info@csc.fi",
             "telephone": [
                 "+358501231235"
@@ -324,7 +324,7 @@
             "is_part_of": {
                 "@type": "Organization",
                 "identifier": "10076",
-                "name": "Mysterious Organization"
+                "name": {"en": "Parent Mysterious Organization", "fi": "Organisaatio"}
             }
         },
         "creator":[{
@@ -333,23 +333,23 @@
             "member_of": {
                 "@type": "Organization",
                 "identifier": "10076",
-                "name": "Mysterious Organization"
+                "name": {"en": "Mysterious Organization", "fi": "Organisaatio"}
             }
         }],
         "curator":[{
             "@type": "Organization",
             "identifier": "id:of:curator:default",
-            "name": "Default Owner",
+            "name": {"en": "Mysterious Organization", "fi": "Organisaatio"},
             "is_part_of": {
                 "@type": "Organization",
                 "identifier": "10076",
-                "name": "Mysterious Organization"
+                "name": {"en": "Parent Mysterious Organization", "fi": "Organisaatio"}
             }
         }],
         "publisher": {
             "@type": "Organization",
             "identifier": "http://purl.org/att/es/organization_data/organization/organization_10076-A800",
-            "name": "Mysterious Organization",
+            "name": {"en": "Mysterious Organization", "fi": "Organisaatio"},
             "email": "info@csc.fi",
             "telephone": [
                 "+358501231235"
@@ -364,7 +364,7 @@
             "is_part_of": {
                 "@type": "Organization",
                 "identifier": "http://purl.org/att/es/organization_data/organization/organization_10076",
-                "name": "Parent of Mysterious Organization",
+                "name": {"en": "Parent of Mysterious Organization", "fi": "Organisaatio"},
                 "email": "info@csc.fi",
                 "telephone": [
                     "+234234"
@@ -390,7 +390,7 @@
                 "member_of": {
                     "@type": "Organization",
                     "identifier": "http://purl.org/att/es/organization_data/organization/organization_1901",
-                    "name": "Mysterious Organization",
+                    "name": {"en": "Mysterious Organization 1", "fi": "Organisaatio"},
                     "email": "info@csc.fi",
                     "telephone": [
                         "+358501231235"
@@ -408,7 +408,7 @@
                 "member_of": {
                     "@type": "Organization",
                     "identifier": "org_identifier",
-                    "name": "Mysterious Organization 2",
+                    "name": {"en": "Mysterious Organization 2", "fi": "Organisaatio"},
                     "email": "joo@csc.fi",
                     "telephone": [
                         "+23423423"
@@ -425,7 +425,7 @@
             "has_funding_agency": [{
                 "@type": "Organization",
                 "identifier": "fundingagencyidentifier",
-                "name": "Rahoittava Organisaatio",
+                "name": {"en": "Funding Organization", "fi": "Organisaatio"},
                 "email": "rahoitus@rahaorg.fi",
                 "telephone": [
                     "+358501232233"
@@ -434,7 +434,7 @@
             "source_organization" : [{
                 "@type": "Organization",
                 "identifier": "http://purl.org/att/es/organization_data/organization/organization_1901",
-                "name": "Mysterious Organization",
+                "name": {"en": "Mysterious Organization", "fi": "Organisaatio"},
                 "email": "info@csc.fi",
                 "telephone": [
                     "+358501231235"

--- a/src/metax_api/tests/testdata/data_catalog_test_data_template.json
+++ b/src/metax_api/tests/testdata/data_catalog_test_data_template.json
@@ -53,7 +53,7 @@
           "description": [
             {"fi": "Käyttöehtojen kuvaus"}
           ],
-          "has_right_related_agent": [
+          "has_rights_related_agent": [
             {
               "identifier": "whatever_id",
               "name": {

--- a/src/metax_api/tests/testdata/data_catalog_test_data_template.json
+++ b/src/metax_api/tests/testdata/data_catalog_test_data_template.json
@@ -38,14 +38,14 @@
         "publisher": {
           "identifier": "http://isni.org/isni/0000000405129137",
           "name": {
-            "fi": "Julkaisija",
-            "en": "Publisher"
+            "fi": "Datakatalogin julkaisijaorganisaatio",
+            "en": "Data catalog publisher organization"
           },
           "homepage": [{
             "identifier": "http://www.publisher.fi/",
             "title": {
-              "fi": "Julkaisijan kotisivu",
-              "en": "Publisher website"
+              "fi": "Julkaisijaorganisaation kotisivu",
+              "en": "Publisher organization website"
             }
           }]
         },
@@ -55,10 +55,10 @@
           ],
           "has_rights_related_agent": [
             {
-              "identifier": "whatever_id",
+              "identifier": "org_id",
               "name": {
-                "fi": "Oikeuksiin liittyvä agentti",
-                "en": "A rights related agent"
+                "fi": "Oikeuksiin liittyvä organisaatio",
+                "en": "A rights related organization"
               }
             },
             {

--- a/src/metax_api/tests/testdata/generate_test_data.py
+++ b/src/metax_api/tests/testdata/generate_test_data.py
@@ -79,7 +79,6 @@ schema_path = os.path.dirname(__file__) + '../api/base/schemas'
 
 
 def generate_file_storages(mode, file_storage_max_rows):
-
     test_file_storage_list = []
 
     if mode == 'json':
@@ -110,7 +109,6 @@ def generate_file_storages(mode, file_storage_max_rows):
 
 
 def generate_files(mode, file_max_rows, test_file_storage_list, validate_json, url):
-
     print('generating files%s...' % ('' if mode in ('json', 'request_list') else ' and uploading'))
 
     with open('file_test_data_template.json') as json_file:
@@ -179,7 +177,8 @@ def generate_files(mode, file_max_rows, test_file_storage_list, validate_json, u
 
             if mode == 'request':
                 start = time.time()
-                res = requests.post(url, data=json_dumps(new), headers={ 'Content-Type': 'application/json' }, verify=False)
+                res = requests.post(url, data=json_dumps(new), headers={'Content-Type': 'application/json'},
+                                    verify=False)
                 end = time.time()
                 total_time_elapsed += (end - start)
 
@@ -214,13 +213,14 @@ def generate_files(mode, file_max_rows, test_file_storage_list, validate_json, u
     return test_data_list
 
 
-def save_test_data(mode, file_storage_list, file_list, data_catalogs_list, contract_list, catalog_record_list, batch_size):
+def save_test_data(mode, file_storage_list, file_list, data_catalogs_list, contract_list, catalog_record_list,
+                   batch_size):
     if mode == 'json':
 
         with open('test_data.json', 'w') as f:
             print('dumping test data as json to metax_api/tests/test_data.json...')
             json_dump(file_storage_list + file_list + data_catalogs_list + contract_list + catalog_record_list,
-                f, indent=4, sort_keys=True)
+                      f, indent=4, sort_keys=True)
 
     elif mode == 'request_list':
 
@@ -236,11 +236,12 @@ def save_test_data(mode, file_storage_list, file_list, data_catalogs_list, contr
 
             batch_start = time.time()
             res = requests.post(url, data=json_dumps(file_list[start:end]),
-                                headers={ 'Content-Type': 'application/json' }, verify=False)
+                                headers={'Content-Type': 'application/json'}, verify=False)
             batch_end = time.time()
             batch_time_elapsed = batch_end - batch_start
             total_time_elapsed += batch_time_elapsed
-            print('completed batch #%d: %d rows in %.3f seconds' % (i, batch_size or total_rows_count, batch_time_elapsed))
+            print('completed batch #%d: %d rows in %.3f seconds'
+                  % (i, batch_size or total_rows_count, batch_time_elapsed))
 
             start += batch_size
             end += batch_size or total_rows_count
@@ -265,7 +266,6 @@ def save_test_data(mode, file_storage_list, file_list, data_catalogs_list, contr
 
 
 def generate_data_catalogs(mode, data_catalog_max_rows, validate_json):
-
     test_data_catalog_list = []
     json_schema = get_json_schema('datacatalog')
 
@@ -293,7 +293,6 @@ def generate_data_catalogs(mode, data_catalog_max_rows, validate_json):
 
 
 def generate_contracts(mode, contract_max_rows, validate_json):
-
     test_contract_list = []
     json_schema = get_json_schema('contract')
 
@@ -323,8 +322,8 @@ def generate_contracts(mode, contract_max_rows, validate_json):
     return test_contract_list
 
 
-def generate_catalog_records(mode, catalog_record_max_rows, data_catalogs_list, contract_list, file_list, validate_json, url):
-
+def generate_catalog_records(mode, catalog_record_max_rows, data_catalogs_list, contract_list, file_list, validate_json,
+                             url):
     print('generating catalog records%s...' % ('' if mode in ('json', 'request_list') else ' and uploading'))
 
     with open('catalog_record_test_data_template.json') as json_file:
@@ -373,20 +372,20 @@ def generate_catalog_records(mode, catalog_record_max_rows, data_catalogs_list, 
                     # first third of files has this as type
                     files[-1]['type'] = {
                         "identifier": "http://purl.org/att/es/reference_data/resource_type/resource_type_event",
-                        "label": {
+                        "pref_label": {
                             "fi": "Tapahtuma",
                             "en": "Event",
-                            "default": "Tapahtuma"
+                            "und": "Tapahtuma"
                         }
                     }
                 elif third_of_files <= j < (third_of_files * 2):
                     # second third of files has this as type
                     files[-1]['type'] = {
                         "identifier": "http://purl.org/att/es/reference_data/resource_type/resource_type_model",
-                        "label": {
+                        "pref_label": {
                             "fi": "Mallinnus",
                             "en": "Model",
-                            "default": "Mallinnus"
+                            "und": "Mallinnus"
                         }
                     }
                 else:
@@ -459,11 +458,13 @@ def generate_catalog_records(mode, catalog_record_max_rows, data_catalogs_list, 
         if 3 <= i <= 4:
             test_data_list[i]['fields']['mets_object_identifier'] = ["a", "b", "c"]
 
-        test_data_list[i]['fields']['research_dataset']['curator'] = [{ "@type": "Person", "name": "Rahikainen", "identifier": "id:of:curator:rahikainen" }]
+        test_data_list[i]['fields']['research_dataset']['curator'] = [
+            {"@type": "Person", "name": "Rahikainen", "identifier": "id:of:curator:rahikainen"}]
 
     # set different owner
     for i in range(6, len(test_data_list)):
-        test_data_list[i]['fields']['research_dataset']['curator'] = [{ "@type": "Person", "name": "Jarski", "identifier": "id:of:curator:jarski" }]
+        test_data_list[i]['fields']['research_dataset']['curator'] = [
+            {"@type": "Person", "name": "Jarski", "identifier": "id:of:curator:jarski"}]
 
     # if preservation_state is other than 0, means it has been modified at some point,
     # so set timestamp
@@ -482,7 +483,7 @@ def generate_catalog_records(mode, catalog_record_max_rows, data_catalogs_list, 
             'model': 'metax_api.catalogrecord',
             'pk': len(test_data_list) + 1,
         }
-        new['fields']['files'] = [1, 2] # for the relation in the db
+        new['fields']['files'] = [1, 2]  # for the relation in the db
         new['fields']['modified_by_api'] = '2017-05-23T10:07:22.559656Z'
         new['fields']['created_by_api'] = '2017-05-23T10:07:22.559656Z'
         new['fields']['research_dataset']['urn_identifier'] = 'very:unique:urn-%d' % j
@@ -520,7 +521,8 @@ def generate_catalog_records(mode, catalog_record_max_rows, data_catalogs_list, 
     # create one other record
     alt_rec = deepcopy(test_data_list[9])
     alt_rec['pk'] = test_data_list[-1]['pk'] + 1
-    alt_rec['fields']['research_dataset']['preferred_identifier'] = test_data_list[9]['fields']['research_dataset']['preferred_identifier']
+    alt_rec['fields']['research_dataset']['preferred_identifier'] = test_data_list[9]['fields']['research_dataset'][
+        'preferred_identifier']
     alt_rec['fields']['research_dataset']['urn_identifier'] += '-alt-1'
     alt_rec['fields']['data_catalog'] = 2
     alt_rec['fields']['alternate_record_set'] = 1
@@ -529,7 +531,8 @@ def generate_catalog_records(mode, catalog_record_max_rows, data_catalogs_list, 
     # create second other record
     alt_rec = deepcopy(test_data_list[9])
     alt_rec['pk'] = test_data_list[-1]['pk'] + 1
-    alt_rec['fields']['research_dataset']['preferred_identifier'] = test_data_list[9]['fields']['research_dataset']['preferred_identifier']
+    alt_rec['fields']['research_dataset']['preferred_identifier'] = test_data_list[9]['fields']['research_dataset'][
+        'preferred_identifier']
     alt_rec['fields']['research_dataset']['urn_identifier'] += '-alt-2'
     alt_rec['fields']['data_catalog'] = 3
     alt_rec['fields']['alternate_record_set'] = 1
@@ -552,7 +555,8 @@ file_storage_list = generate_file_storages(mode, file_storage_max_rows)
 file_list = generate_files(mode, file_max_rows, file_storage_list, validate_json, url)
 data_catalogs_list = generate_data_catalogs(mode, data_catalog_max_rows, validate_json)
 contract_list = generate_contracts(mode, contract_max_rows, validate_json)
-catalog_record_list = generate_catalog_records(mode, catalog_record_max_rows, data_catalogs_list, contract_list, file_list, validate_json, url)
+catalog_record_list = generate_catalog_records(mode, catalog_record_max_rows, data_catalogs_list, contract_list,
+                                               file_list, validate_json, url)
 
 save_test_data(mode, file_storage_list, file_list, data_catalogs_list, contract_list, catalog_record_list, batch_size)
 

--- a/src/metax_api/tests/testdata/generate_test_data.py
+++ b/src/metax_api/tests/testdata/generate_test_data.py
@@ -398,7 +398,6 @@ def generate_catalog_records(mode, catalog_record_max_rows, data_catalogs_list, 
             new['fields']['research_dataset']['files'] = files
             new['fields']['research_dataset']['total_byte_size'] = total_byte_size
             files_start_idx += files_per_dataset
-
             if validate_json or i == 1:
                 json_validate(new['fields']['research_dataset'], json_schema)
 
@@ -458,13 +457,31 @@ def generate_catalog_records(mode, catalog_record_max_rows, data_catalogs_list, 
         if 3 <= i <= 4:
             test_data_list[i]['fields']['mets_object_identifier'] = ["a", "b", "c"]
 
-        test_data_list[i]['fields']['research_dataset']['curator'] = [
-            {"@type": "Person", "name": "Rahikainen", "identifier": "id:of:curator:rahikainen"}]
+        test_data_list[i]['fields']['research_dataset']['curator'] = [{
+            "@type": "Person",
+            "name": "Rahikainen",
+            "identifier": "id:of:curator:rahikainen",
+            "member_of": {
+                "@type": "Organization",
+                "name": {
+                    "fi": "MysteeriOrganisaatio"
+                }
+            }
+        }]
 
     # set different owner
     for i in range(6, len(test_data_list)):
-        test_data_list[i]['fields']['research_dataset']['curator'] = [
-            {"@type": "Person", "name": "Jarski", "identifier": "id:of:curator:jarski"}]
+        test_data_list[i]['fields']['research_dataset']['curator'] = [{
+            "@type": "Person",
+            "name": "Jarski",
+            "identifier": "id:of:curator:jarski",
+            "member_of": {
+                "@type": "Organization",
+                "name": {
+                    "fi": "MysteeriOrganisaatio"
+                }
+            }
+        }]
 
     # if preservation_state is other than 0, means it has been modified at some point,
     # so set timestamp

--- a/src/metax_api/tests/testdata/test_data.json
+++ b/src/metax_api/tests/testdata/test_data.json
@@ -694,7 +694,7 @@
                             "fi": "K\u00e4ytt\u00f6ehtojen kuvaus"
                         }
                     ],
-                    "has_right_related_agent": [
+                    "has_rights_related_agent": [
                         {
                             "identifier": "whatever_id",
                             "name": {
@@ -813,7 +813,7 @@
                             "fi": "K\u00e4ytt\u00f6ehtojen kuvaus"
                         }
                     ],
-                    "has_right_related_agent": [
+                    "has_rights_related_agent": [
                         {
                             "identifier": "whatever_id",
                             "name": {
@@ -932,7 +932,7 @@
                             "fi": "K\u00e4ytt\u00f6ehtojen kuvaus"
                         }
                     ],
-                    "has_right_related_agent": [
+                    "has_rights_related_agent": [
                         {
                             "identifier": "whatever_id",
                             "name": {
@@ -1051,7 +1051,7 @@
                             "fi": "K\u00e4ytt\u00f6ehtojen kuvaus"
                         }
                     ],
-                    "has_right_related_agent": [
+                    "has_rights_related_agent": [
                         {
                             "identifier": "whatever_id",
                             "name": {
@@ -1370,7 +1370,10 @@
                     {
                         "@type": "Organization",
                         "identifier": "10076-E700",
-                        "name": "Owner org in ref data"
+                        "name": {
+                            "en": "Org in ref data",
+                            "fi": "Organisaatio"
+                        }
                     }
                 ],
                 "description": [
@@ -1384,10 +1387,10 @@
                         "title": "File metadata title 0",
                         "type": {
                             "identifier": "http://purl.org/att/es/reference_data/resource_type/resource_type_event",
-                            "label": {
-                                "default": "Tapahtuma",
+                            "pref_label": {
                                 "en": "Event",
-                                "fi": "Tapahtuma"
+                                "fi": "Tapahtuma",
+                                "und": "Tapahtuma"
                             }
                         }
                     },
@@ -1396,10 +1399,10 @@
                         "title": "File metadata title 1",
                         "type": {
                             "identifier": "http://purl.org/att/es/reference_data/resource_type/resource_type_event",
-                            "label": {
-                                "default": "Tapahtuma",
+                            "pref_label": {
                                 "en": "Event",
-                                "fi": "Tapahtuma"
+                                "fi": "Tapahtuma",
+                                "und": "Tapahtuma"
                             }
                         }
                     }
@@ -1464,10 +1467,10 @@
                         "title": "File metadata title 2",
                         "type": {
                             "identifier": "http://purl.org/att/es/reference_data/resource_type/resource_type_event",
-                            "label": {
-                                "default": "Tapahtuma",
+                            "pref_label": {
                                 "en": "Event",
-                                "fi": "Tapahtuma"
+                                "fi": "Tapahtuma",
+                                "und": "Tapahtuma"
                             }
                         }
                     },
@@ -1476,10 +1479,10 @@
                         "title": "File metadata title 3",
                         "type": {
                             "identifier": "http://purl.org/att/es/reference_data/resource_type/resource_type_event",
-                            "label": {
-                                "default": "Tapahtuma",
+                            "pref_label": {
                                 "en": "Event",
-                                "fi": "Tapahtuma"
+                                "fi": "Tapahtuma",
+                                "und": "Tapahtuma"
                             }
                         }
                     }
@@ -1544,10 +1547,10 @@
                         "title": "File metadata title 4",
                         "type": {
                             "identifier": "http://purl.org/att/es/reference_data/resource_type/resource_type_event",
-                            "label": {
-                                "default": "Tapahtuma",
+                            "pref_label": {
                                 "en": "Event",
-                                "fi": "Tapahtuma"
+                                "fi": "Tapahtuma",
+                                "und": "Tapahtuma"
                             }
                         }
                     },
@@ -1556,10 +1559,10 @@
                         "title": "File metadata title 5",
                         "type": {
                             "identifier": "http://purl.org/att/es/reference_data/resource_type/resource_type_event",
-                            "label": {
-                                "default": "Tapahtuma",
+                            "pref_label": {
                                 "en": "Event",
-                                "fi": "Tapahtuma"
+                                "fi": "Tapahtuma",
+                                "und": "Tapahtuma"
                             }
                         }
                     }
@@ -1628,10 +1631,10 @@
                         "title": "File metadata title 6",
                         "type": {
                             "identifier": "http://purl.org/att/es/reference_data/resource_type/resource_type_event",
-                            "label": {
-                                "default": "Tapahtuma",
+                            "pref_label": {
                                 "en": "Event",
-                                "fi": "Tapahtuma"
+                                "fi": "Tapahtuma",
+                                "und": "Tapahtuma"
                             }
                         }
                     },
@@ -1640,10 +1643,10 @@
                         "title": "File metadata title 7",
                         "type": {
                             "identifier": "http://purl.org/att/es/reference_data/resource_type/resource_type_model",
-                            "label": {
-                                "default": "Mallinnus",
+                            "pref_label": {
                                 "en": "Model",
-                                "fi": "Mallinnus"
+                                "fi": "Mallinnus",
+                                "und": "Mallinnus"
                             }
                         }
                     }
@@ -1712,10 +1715,10 @@
                         "title": "File metadata title 8",
                         "type": {
                             "identifier": "http://purl.org/att/es/reference_data/resource_type/resource_type_model",
-                            "label": {
-                                "default": "Mallinnus",
+                            "pref_label": {
                                 "en": "Model",
-                                "fi": "Mallinnus"
+                                "fi": "Mallinnus",
+                                "und": "Mallinnus"
                             }
                         }
                     },
@@ -1724,10 +1727,10 @@
                         "title": "File metadata title 9",
                         "type": {
                             "identifier": "http://purl.org/att/es/reference_data/resource_type/resource_type_model",
-                            "label": {
-                                "default": "Mallinnus",
+                            "pref_label": {
                                 "en": "Model",
-                                "fi": "Mallinnus"
+                                "fi": "Mallinnus",
+                                "und": "Mallinnus"
                             }
                         }
                     }
@@ -1792,10 +1795,10 @@
                         "title": "File metadata title 10",
                         "type": {
                             "identifier": "http://purl.org/att/es/reference_data/resource_type/resource_type_model",
-                            "label": {
-                                "default": "Mallinnus",
+                            "pref_label": {
                                 "en": "Model",
-                                "fi": "Mallinnus"
+                                "fi": "Mallinnus",
+                                "und": "Mallinnus"
                             }
                         }
                     },
@@ -1804,10 +1807,10 @@
                         "title": "File metadata title 11",
                         "type": {
                             "identifier": "http://purl.org/att/es/reference_data/resource_type/resource_type_model",
-                            "label": {
-                                "default": "Mallinnus",
+                            "pref_label": {
                                 "en": "Model",
-                                "fi": "Mallinnus"
+                                "fi": "Mallinnus",
+                                "und": "Mallinnus"
                             }
                         }
                     }
@@ -1871,10 +1874,10 @@
                         "title": "File metadata title 12",
                         "type": {
                             "identifier": "http://purl.org/att/es/reference_data/resource_type/resource_type_model",
-                            "label": {
-                                "default": "Mallinnus",
+                            "pref_label": {
                                 "en": "Model",
-                                "fi": "Mallinnus"
+                                "fi": "Mallinnus",
+                                "und": "Mallinnus"
                             }
                         }
                     },
@@ -1883,10 +1886,10 @@
                         "title": "File metadata title 13",
                         "type": {
                             "identifier": "http://purl.org/att/es/reference_data/resource_type/resource_type_model",
-                            "label": {
-                                "default": "Mallinnus",
+                            "pref_label": {
                                 "en": "Model",
-                                "fi": "Mallinnus"
+                                "fi": "Mallinnus",
+                                "und": "Mallinnus"
                             }
                         }
                     }
@@ -2133,7 +2136,10 @@
                                 }
                             },
                             "identifier": "http://purl.org/att/es/organization_data/organization/organization_1901",
-                            "name": "Mysterious Organization",
+                            "name": {
+                                "en": "Org in ref data",
+                                "fi": "Organisaatio"
+                            },
                             "telephone": [
                                 "+358501231235"
                             ]
@@ -2187,7 +2193,10 @@
                             "@type": "Organization",
                             "email": "info@csc.fi",
                             "identifier": "http://purl.org/att/es/organization_data/organization/organization_1901",
-                            "name": "Mysterious Organization",
+                            "name": {
+                                "en": "Mysterious Organization 1",
+                                "fi": "Organisaatio"
+                            },
                             "telephone": [
                                 "+358501231235"
                             ]
@@ -2205,7 +2214,10 @@
                             "@type": "Organization",
                             "email": "joo@csc.fi",
                             "identifier": "org_identifier",
-                            "name": "Mysterious Organization 2",
+                            "name": {
+                                "en": "Mysterious Organization 2",
+                                "fi": "Organisaatio"
+                            },
                             "telephone": [
                                 "+23423423"
                             ]
@@ -2222,7 +2234,10 @@
                         "member_of": {
                             "@type": "Organization",
                             "identifier": "10076",
-                            "name": "Mysterious Organization"
+                            "name": {
+                                "en": "Mysterious Organization",
+                                "fi": "Organisaatio"
+                            }
                         },
                         "name": "Teppo Testaaja"
                     }
@@ -2234,9 +2249,15 @@
                         "is_part_of": {
                             "@type": "Organization",
                             "identifier": "10076",
-                            "name": "Mysterious Organization"
+                            "name": {
+                                "en": "Parent Mysterious Organization",
+                                "fi": "Organisaatio"
+                            }
                         },
-                        "name": "Default Owner"
+                        "name": {
+                            "en": "Mysterious Organization",
+                            "fi": "Organisaatio"
+                        }
                     }
                 ],
                 "description": [
@@ -2341,7 +2362,10 @@
                                 "@type": "Organization",
                                 "email": "rahoitus@rahaorg.fi",
                                 "identifier": "fundingagencyidentifier",
-                                "name": "Rahoittava Organisaatio",
+                                "name": {
+                                    "en": "Funding Organization",
+                                    "fi": "Organisaatio"
+                                },
                                 "telephone": [
                                     "+358501232233"
                                 ]
@@ -2356,7 +2380,10 @@
                                 "@type": "Organization",
                                 "email": "info@csc.fi",
                                 "identifier": "http://purl.org/att/es/organization_data/organization/organization_1901",
-                                "name": "Mysterious Organization",
+                                "name": {
+                                    "en": "Mysterious Organization",
+                                    "fi": "Organisaatio"
+                                },
                                 "telephone": [
                                     "+358501231235"
                                 ]
@@ -2384,7 +2411,10 @@
                             "@type": "Organization",
                             "email": "info@csc.fi",
                             "identifier": "http://purl.org/att/es/organization_data/organization/organization_1901",
-                            "name": "Mysterious Organization",
+                            "name": {
+                                "en": "Org in ref data",
+                                "fi": "Organisaatio"
+                            },
                             "telephone": [
                                 "+358501231235"
                             ]
@@ -2418,7 +2448,10 @@
                             "identifier": [
                                 "http://purl.org/att/es/organization_data/organization/organization_1901"
                             ],
-                            "name": "Mysterious Organization",
+                            "name": {
+                                "en": "Mysterious Organization",
+                                "fi": "Organisaatio"
+                            },
                             "telephone": [
                                 "+358501231235"
                             ]
@@ -2579,7 +2612,10 @@
                                 "@type": "Organization",
                                 "email": "info@csc.fi",
                                 "identifier": "http://purl.org/att/es/organization_data/organization/organization_1901",
-                                "name": "Mysterious Organization",
+                                "name": {
+                                    "en": "Mysterious Organization",
+                                    "fi": "Organisaatio"
+                                },
                                 "telephone": [
                                     "+358501231235"
                                 ]
@@ -2609,12 +2645,18 @@
                             }
                         },
                         "identifier": "http://purl.org/att/es/organization_data/organization/organization_10076",
-                        "name": "Parent of Mysterious Organization",
+                        "name": {
+                            "en": "Parent of Mysterious Organization",
+                            "fi": "Organisaatio"
+                        },
                         "telephone": [
                             "+234234"
                         ]
                     },
-                    "name": "Mysterious Organization",
+                    "name": {
+                        "en": "Mysterious Organization",
+                        "fi": "Organisaatio"
+                    },
                     "telephone": [
                         "+358501231235"
                     ]
@@ -2731,9 +2773,15 @@
                     "is_part_of": {
                         "@type": "Organization",
                         "identifier": "10076",
-                        "name": "Mysterious Organization"
+                        "name": {
+                            "en": "Parent Mysterious Organization",
+                            "fi": "Organisaatio"
+                        }
                     },
-                    "name": "Mysterious Organization",
+                    "name": {
+                        "en": "Mysterious Organization",
+                        "fi": "Organisaatio"
+                    },
                     "telephone": [
                         "+358501231235"
                     ]
@@ -2828,7 +2876,10 @@
                                 }
                             },
                             "identifier": "http://purl.org/att/es/organization_data/organization/organization_1901",
-                            "name": "Mysterious Organization",
+                            "name": {
+                                "en": "Org in ref data",
+                                "fi": "Organisaatio"
+                            },
                             "telephone": [
                                 "+358501231235"
                             ]
@@ -2882,7 +2933,10 @@
                             "@type": "Organization",
                             "email": "info@csc.fi",
                             "identifier": "http://purl.org/att/es/organization_data/organization/organization_1901",
-                            "name": "Mysterious Organization",
+                            "name": {
+                                "en": "Mysterious Organization 1",
+                                "fi": "Organisaatio"
+                            },
                             "telephone": [
                                 "+358501231235"
                             ]
@@ -2900,7 +2954,10 @@
                             "@type": "Organization",
                             "email": "joo@csc.fi",
                             "identifier": "org_identifier",
-                            "name": "Mysterious Organization 2",
+                            "name": {
+                                "en": "Mysterious Organization 2",
+                                "fi": "Organisaatio"
+                            },
                             "telephone": [
                                 "+23423423"
                             ]
@@ -2917,7 +2974,10 @@
                         "member_of": {
                             "@type": "Organization",
                             "identifier": "10076",
-                            "name": "Mysterious Organization"
+                            "name": {
+                                "en": "Mysterious Organization",
+                                "fi": "Organisaatio"
+                            }
                         },
                         "name": "Teppo Testaaja"
                     }
@@ -2929,9 +2989,15 @@
                         "is_part_of": {
                             "@type": "Organization",
                             "identifier": "10076",
-                            "name": "Mysterious Organization"
+                            "name": {
+                                "en": "Parent Mysterious Organization",
+                                "fi": "Organisaatio"
+                            }
                         },
-                        "name": "Default Owner"
+                        "name": {
+                            "en": "Mysterious Organization",
+                            "fi": "Organisaatio"
+                        }
                     }
                 ],
                 "description": [
@@ -3036,7 +3102,10 @@
                                 "@type": "Organization",
                                 "email": "rahoitus@rahaorg.fi",
                                 "identifier": "fundingagencyidentifier",
-                                "name": "Rahoittava Organisaatio",
+                                "name": {
+                                    "en": "Funding Organization",
+                                    "fi": "Organisaatio"
+                                },
                                 "telephone": [
                                     "+358501232233"
                                 ]
@@ -3051,7 +3120,10 @@
                                 "@type": "Organization",
                                 "email": "info@csc.fi",
                                 "identifier": "http://purl.org/att/es/organization_data/organization/organization_1901",
-                                "name": "Mysterious Organization",
+                                "name": {
+                                    "en": "Mysterious Organization",
+                                    "fi": "Organisaatio"
+                                },
                                 "telephone": [
                                     "+358501231235"
                                 ]
@@ -3079,7 +3151,10 @@
                             "@type": "Organization",
                             "email": "info@csc.fi",
                             "identifier": "http://purl.org/att/es/organization_data/organization/organization_1901",
-                            "name": "Mysterious Organization",
+                            "name": {
+                                "en": "Org in ref data",
+                                "fi": "Organisaatio"
+                            },
                             "telephone": [
                                 "+358501231235"
                             ]
@@ -3113,7 +3188,10 @@
                             "identifier": [
                                 "http://purl.org/att/es/organization_data/organization/organization_1901"
                             ],
-                            "name": "Mysterious Organization",
+                            "name": {
+                                "en": "Mysterious Organization",
+                                "fi": "Organisaatio"
+                            },
                             "telephone": [
                                 "+358501231235"
                             ]
@@ -3274,7 +3352,10 @@
                                 "@type": "Organization",
                                 "email": "info@csc.fi",
                                 "identifier": "http://purl.org/att/es/organization_data/organization/organization_1901",
-                                "name": "Mysterious Organization",
+                                "name": {
+                                    "en": "Mysterious Organization",
+                                    "fi": "Organisaatio"
+                                },
                                 "telephone": [
                                     "+358501231235"
                                 ]
@@ -3304,12 +3385,18 @@
                             }
                         },
                         "identifier": "http://purl.org/att/es/organization_data/organization/organization_10076",
-                        "name": "Parent of Mysterious Organization",
+                        "name": {
+                            "en": "Parent of Mysterious Organization",
+                            "fi": "Organisaatio"
+                        },
                         "telephone": [
                             "+234234"
                         ]
                     },
-                    "name": "Mysterious Organization",
+                    "name": {
+                        "en": "Mysterious Organization",
+                        "fi": "Organisaatio"
+                    },
                     "telephone": [
                         "+358501231235"
                     ]
@@ -3426,9 +3513,15 @@
                     "is_part_of": {
                         "@type": "Organization",
                         "identifier": "10076",
-                        "name": "Mysterious Organization"
+                        "name": {
+                            "en": "Parent Mysterious Organization",
+                            "fi": "Organisaatio"
+                        }
                     },
-                    "name": "Mysterious Organization",
+                    "name": {
+                        "en": "Mysterious Organization",
+                        "fi": "Organisaatio"
+                    },
                     "telephone": [
                         "+358501231235"
                     ]

--- a/src/metax_api/tests/testdata/test_data.json
+++ b/src/metax_api/tests/testdata/test_data.json
@@ -696,10 +696,10 @@
                     ],
                     "has_rights_related_agent": [
                         {
-                            "identifier": "whatever_id",
+                            "identifier": "org_id",
                             "name": {
-                                "en": "A rights related agent",
-                                "fi": "Oikeuksiin liittyv\u00e4 agentti"
+                                "en": "A rights related organization",
+                                "fi": "Oikeuksiin liittyv\u00e4 organisaatio"
                             }
                         },
                         {
@@ -779,15 +779,15 @@
                         {
                             "identifier": "http://www.publisher.fi/",
                             "title": {
-                                "en": "Publisher website",
-                                "fi": "Julkaisijan kotisivu"
+                                "en": "Publisher organization website",
+                                "fi": "Julkaisijaorganisaation kotisivu"
                             }
                         }
                     ],
                     "identifier": "http://isni.org/isni/0000000405129137",
                     "name": {
-                        "en": "Publisher",
-                        "fi": "Julkaisija"
+                        "en": "Data catalog publisher organization",
+                        "fi": "Datakatalogin julkaisijaorganisaatio"
                     }
                 },
                 "research_dataset_schema": "att",
@@ -815,10 +815,10 @@
                     ],
                     "has_rights_related_agent": [
                         {
-                            "identifier": "whatever_id",
+                            "identifier": "org_id",
                             "name": {
-                                "en": "A rights related agent",
-                                "fi": "Oikeuksiin liittyv\u00e4 agentti"
+                                "en": "A rights related organization",
+                                "fi": "Oikeuksiin liittyv\u00e4 organisaatio"
                             }
                         },
                         {
@@ -898,15 +898,15 @@
                         {
                             "identifier": "http://www.publisher.fi/",
                             "title": {
-                                "en": "Publisher website",
-                                "fi": "Julkaisijan kotisivu"
+                                "en": "Publisher organization website",
+                                "fi": "Julkaisijaorganisaation kotisivu"
                             }
                         }
                     ],
                     "identifier": "http://isni.org/isni/0000000405129137",
                     "name": {
-                        "en": "Publisher",
-                        "fi": "Julkaisija"
+                        "en": "Data catalog publisher organization",
+                        "fi": "Datakatalogin julkaisijaorganisaatio"
                     }
                 },
                 "research_dataset_schema": "att",
@@ -934,10 +934,10 @@
                     ],
                     "has_rights_related_agent": [
                         {
-                            "identifier": "whatever_id",
+                            "identifier": "org_id",
                             "name": {
-                                "en": "A rights related agent",
-                                "fi": "Oikeuksiin liittyv\u00e4 agentti"
+                                "en": "A rights related organization",
+                                "fi": "Oikeuksiin liittyv\u00e4 organisaatio"
                             }
                         },
                         {
@@ -1017,15 +1017,15 @@
                         {
                             "identifier": "http://www.publisher.fi/",
                             "title": {
-                                "en": "Publisher website",
-                                "fi": "Julkaisijan kotisivu"
+                                "en": "Publisher organization website",
+                                "fi": "Julkaisijaorganisaation kotisivu"
                             }
                         }
                     ],
                     "identifier": "http://isni.org/isni/0000000405129137",
                     "name": {
-                        "en": "Publisher",
-                        "fi": "Julkaisija"
+                        "en": "Data catalog publisher organization",
+                        "fi": "Datakatalogin julkaisijaorganisaatio"
                     }
                 },
                 "research_dataset_schema": "att",
@@ -1053,10 +1053,10 @@
                     ],
                     "has_rights_related_agent": [
                         {
-                            "identifier": "whatever_id",
+                            "identifier": "org_id",
                             "name": {
-                                "en": "A rights related agent",
-                                "fi": "Oikeuksiin liittyv\u00e4 agentti"
+                                "en": "A rights related organization",
+                                "fi": "Oikeuksiin liittyv\u00e4 organisaatio"
                             }
                         },
                         {
@@ -1136,15 +1136,15 @@
                         {
                             "identifier": "http://www.publisher.fi/",
                             "title": {
-                                "en": "Publisher website",
-                                "fi": "Julkaisijan kotisivu"
+                                "en": "Publisher organization website",
+                                "fi": "Julkaisijaorganisaation kotisivu"
                             }
                         }
                     ],
                     "identifier": "http://isni.org/isni/0000000405129137",
                     "name": {
-                        "en": "Publisher",
-                        "fi": "Julkaisija"
+                        "en": "Data catalog publisher organization",
+                        "fi": "Datakatalogin julkaisijaorganisaatio"
                     }
                 },
                 "research_dataset_schema": "att",

--- a/src/metax_api/tests/testdata/test_data.json
+++ b/src/metax_api/tests/testdata/test_data.json
@@ -1363,6 +1363,12 @@
                 "creator": [
                     {
                         "@type": "Person",
+                        "member_of": {
+                            "@type": "Organization",
+                            "name": {
+                                "fi": "Mysteeriorganisaatio"
+                            }
+                        },
                         "name": "Teppo Testaaja"
                     }
                 ],
@@ -1446,6 +1452,12 @@
                 "creator": [
                     {
                         "@type": "Person",
+                        "member_of": {
+                            "@type": "Organization",
+                            "name": {
+                                "fi": "Mysteeriorganisaatio"
+                            }
+                        },
                         "name": "Teppo Testaaja"
                     }
                 ],
@@ -1453,6 +1465,12 @@
                     {
                         "@type": "Person",
                         "identifier": "id:of:curator:rahikainen",
+                        "member_of": {
+                            "@type": "Organization",
+                            "name": {
+                                "fi": "MysteeriOrganisaatio"
+                            }
+                        },
                         "name": "Rahikainen"
                     }
                 ],
@@ -1526,6 +1544,12 @@
                 "creator": [
                     {
                         "@type": "Person",
+                        "member_of": {
+                            "@type": "Organization",
+                            "name": {
+                                "fi": "Mysteeriorganisaatio"
+                            }
+                        },
                         "name": "Teppo Testaaja"
                     }
                 ],
@@ -1533,6 +1557,12 @@
                     {
                         "@type": "Person",
                         "identifier": "id:of:curator:rahikainen",
+                        "member_of": {
+                            "@type": "Organization",
+                            "name": {
+                                "fi": "MysteeriOrganisaatio"
+                            }
+                        },
                         "name": "Rahikainen"
                     }
                 ],
@@ -1610,6 +1640,12 @@
                 "creator": [
                     {
                         "@type": "Person",
+                        "member_of": {
+                            "@type": "Organization",
+                            "name": {
+                                "fi": "Mysteeriorganisaatio"
+                            }
+                        },
                         "name": "Teppo Testaaja"
                     }
                 ],
@@ -1617,6 +1653,12 @@
                     {
                         "@type": "Person",
                         "identifier": "id:of:curator:rahikainen",
+                        "member_of": {
+                            "@type": "Organization",
+                            "name": {
+                                "fi": "MysteeriOrganisaatio"
+                            }
+                        },
                         "name": "Rahikainen"
                     }
                 ],
@@ -1694,6 +1736,12 @@
                 "creator": [
                     {
                         "@type": "Person",
+                        "member_of": {
+                            "@type": "Organization",
+                            "name": {
+                                "fi": "Mysteeriorganisaatio"
+                            }
+                        },
                         "name": "Teppo Testaaja"
                     }
                 ],
@@ -1701,6 +1749,12 @@
                     {
                         "@type": "Person",
                         "identifier": "id:of:curator:rahikainen",
+                        "member_of": {
+                            "@type": "Organization",
+                            "name": {
+                                "fi": "MysteeriOrganisaatio"
+                            }
+                        },
                         "name": "Rahikainen"
                     }
                 ],
@@ -1774,6 +1828,12 @@
                 "creator": [
                     {
                         "@type": "Person",
+                        "member_of": {
+                            "@type": "Organization",
+                            "name": {
+                                "fi": "Mysteeriorganisaatio"
+                            }
+                        },
                         "name": "Teppo Testaaja"
                     }
                 ],
@@ -1781,6 +1841,12 @@
                     {
                         "@type": "Person",
                         "identifier": "id:of:curator:rahikainen",
+                        "member_of": {
+                            "@type": "Organization",
+                            "name": {
+                                "fi": "MysteeriOrganisaatio"
+                            }
+                        },
                         "name": "Rahikainen"
                     }
                 ],
@@ -1853,6 +1919,12 @@
                 "creator": [
                     {
                         "@type": "Person",
+                        "member_of": {
+                            "@type": "Organization",
+                            "name": {
+                                "fi": "Mysteeriorganisaatio"
+                            }
+                        },
                         "name": "Teppo Testaaja"
                     }
                 ],
@@ -1860,6 +1932,12 @@
                     {
                         "@type": "Person",
                         "identifier": "id:of:curator:jarski",
+                        "member_of": {
+                            "@type": "Organization",
+                            "name": {
+                                "fi": "MysteeriOrganisaatio"
+                            }
+                        },
                         "name": "Jarski"
                     }
                 ],
@@ -1932,6 +2010,12 @@
                 "creator": [
                     {
                         "@type": "Person",
+                        "member_of": {
+                            "@type": "Organization",
+                            "name": {
+                                "fi": "Mysteeriorganisaatio"
+                            }
+                        },
                         "name": "Teppo Testaaja"
                     }
                 ],
@@ -1939,6 +2023,12 @@
                     {
                         "@type": "Person",
                         "identifier": "id:of:curator:jarski",
+                        "member_of": {
+                            "@type": "Organization",
+                            "name": {
+                                "fi": "MysteeriOrganisaatio"
+                            }
+                        },
                         "name": "Jarski"
                     }
                 ],
@@ -1995,6 +2085,12 @@
                 "creator": [
                     {
                         "@type": "Person",
+                        "member_of": {
+                            "@type": "Organization",
+                            "name": {
+                                "fi": "Mysteeriorganisaatio"
+                            }
+                        },
                         "name": "Teppo Testaaja"
                     }
                 ],
@@ -2002,6 +2098,12 @@
                     {
                         "@type": "Person",
                         "identifier": "id:of:curator:jarski",
+                        "member_of": {
+                            "@type": "Organization",
+                            "name": {
+                                "fi": "MysteeriOrganisaatio"
+                            }
+                        },
                         "name": "Jarski"
                     }
                 ],
@@ -2059,6 +2161,12 @@
                 "creator": [
                     {
                         "@type": "Person",
+                        "member_of": {
+                            "@type": "Organization",
+                            "name": {
+                                "fi": "Mysteeriorganisaatio"
+                            }
+                        },
                         "name": "Teppo Testaaja"
                     }
                 ],
@@ -2066,6 +2174,12 @@
                     {
                         "@type": "Person",
                         "identifier": "id:of:curator:jarski",
+                        "member_of": {
+                            "@type": "Organization",
+                            "name": {
+                                "fi": "MysteeriOrganisaatio"
+                            }
+                        },
                         "name": "Jarski"
                     }
                 ],
@@ -3603,6 +3717,12 @@
                 "creator": [
                     {
                         "@type": "Person",
+                        "member_of": {
+                            "@type": "Organization",
+                            "name": {
+                                "fi": "Mysteeriorganisaatio"
+                            }
+                        },
                         "name": "Teppo Testaaja"
                     }
                 ],
@@ -3610,6 +3730,12 @@
                     {
                         "@type": "Person",
                         "identifier": "id:of:curator:jarski",
+                        "member_of": {
+                            "@type": "Organization",
+                            "name": {
+                                "fi": "MysteeriOrganisaatio"
+                            }
+                        },
                         "name": "Jarski"
                     }
                 ],
@@ -3667,6 +3793,12 @@
                 "creator": [
                     {
                         "@type": "Person",
+                        "member_of": {
+                            "@type": "Organization",
+                            "name": {
+                                "fi": "Mysteeriorganisaatio"
+                            }
+                        },
                         "name": "Teppo Testaaja"
                     }
                 ],
@@ -3674,6 +3806,12 @@
                     {
                         "@type": "Person",
                         "identifier": "id:of:curator:jarski",
+                        "member_of": {
+                            "@type": "Organization",
+                            "name": {
+                                "fi": "MysteeriOrganisaatio"
+                            }
+                        },
                         "name": "Jarski"
                     }
                 ],

--- a/src/metax_api/tests/utils.py
+++ b/src/metax_api/tests/utils.py
@@ -60,6 +60,6 @@ class TestClassUtils():
                 else:
                     i += 1
 
-        raise Exception('Could not find model %s from test data with index == %d.'
-            ' Are you certain you generated rows for model %s in generate_test_data.py?'
-            % (model_name, requested_index))
+        raise Exception('Could not find model %s from test data with index == %d. '
+                        'Are you certain you generated rows for model %s in generate_test_data.py?'
+                        % (model_name, requested_index))


### PR DESCRIPTION
…, fix some semantic errors, update dataset and data catalog schemas and fix tests accordingly. From dataset schema, remove ResearchAgent duplicate properties since persons did not pass schema validation when change was introduced for Organization name field (string -> langString). For Person in the dataset schema, remove member_of from being required field.