### PR TITLE
CSCMETAX-61: [REF] When starting to work on this, initial thought was…

### DIFF
--- a/src/metax_api/services/catalog_record_service.py
+++ b/src/metax_api/services/catalog_record_service.py
@@ -245,7 +245,7 @@ class CatalogRecordService(CommonService, ReferenceDataMixin):
                     cls.populate_from_ref_data(ref_entry, rights_statement_license, label_field='title')
 
             for rra in access_rights.get('has_rights_related_agent', []):
-                cls.process_research_agent_obj(orgdata, rra, 'research_dataset.access_rights.has_rights_related_agent')
+                cls.process_research_agent_obj_with_type(orgdata, rra, 'research_dataset.access_rights.has_rights_related_agent')
 
         for project in research_dataset.get('is_output_of', []):
             for org_obj in project.get('source_organization', []):
@@ -282,23 +282,23 @@ class CatalogRecordService(CommonService, ReferenceDataMixin):
                     cls.populate_from_ref_data(ref_entry, file['type'], label_field='pref_label')
 
         for contributor in research_dataset.get('contributor', []):
-            cls.process_research_agent_obj(orgdata, contributor, 'research_dataset.contributor')
+            cls.process_research_agent_obj_with_type(orgdata, contributor, 'research_dataset.contributor')
 
         if 'publisher' in research_dataset:
-            cls.process_research_agent_obj(orgdata, research_dataset['publisher'], 'research_dataset.publisher')
+            cls.process_research_agent_obj_with_type(orgdata, research_dataset['publisher'], 'research_dataset.publisher')
 
         for curator in research_dataset.get('curator', []):
-            cls.process_research_agent_obj(orgdata, curator, 'research_dataset.curator')
+            cls.process_research_agent_obj_with_type(orgdata, curator, 'research_dataset.curator')
 
         for creator in research_dataset.get('creator', []):
-            cls.process_research_agent_obj(orgdata, creator, 'research_dataset.creator')
+            cls.process_research_agent_obj_with_type(orgdata, creator, 'research_dataset.creator')
 
         if 'rights_holder' in research_dataset:
-            cls.process_research_agent_obj(orgdata, research_dataset['rights_holder'], 'research_dataset.rights_holder')
+            cls.process_research_agent_obj_with_type(orgdata, research_dataset['rights_holder'], 'research_dataset.rights_holder')
 
         for activity in research_dataset.get('provenance', []):
             for was_associated_with in activity.get('was_associated_with', []):
-                cls.process_research_agent_obj(orgdata, was_associated_with,
+                cls.process_research_agent_obj_with_type(orgdata, was_associated_with,
                                                'research_dataset.provenance.was_associated_with')
 
         if errors:

--- a/src/metax_api/services/reference_data_mixin.py
+++ b/src/metax_api/services/reference_data_mixin.py
@@ -128,7 +128,7 @@ class ReferenceDataMixin():
                 cls.populate_from_ref_data(ref_entry, org_obj, 'identifier', 'name')
 
     @classmethod
-    def process_research_agent_obj(cls, org_ref_data, agent_obj, agent_obj_relation_name):
+    def process_research_agent_obj_with_type(cls, org_ref_data, agent_obj, agent_obj_relation_name):
         if agent_obj.get('@type') == 'Person':
             member_of = agent_obj.get('member_of', None)
             if member_of:

--- a/src/metax_api/settings.py
+++ b/src/metax_api/settings.py
@@ -291,7 +291,7 @@ else:
         'HOSTS': app_config_dict['ELASTICSEARCH']['HOSTS'],
         # normally cache is reloaded from elasticsearch only if reference data is missing.
         # for one-off reload / debugging / development, use below flag
-        'ALWAYS_RELOAD_REFERENCE_DATA_ON_RESTART': False,
+        'ALWAYS_RELOAD_REFERENCE_DATA_ON_RESTART': app_config_dict['ALWAYS_RELOAD_REFERENCE_DATA_ON_RESTART'],
     }
 
 if not executing_in_travis:


### PR DESCRIPTION
… data catalog Organization was not getting populated from ref data. This was false, but instead improved function name and cache reloading on app restart is now read from a parameter, since in test there were old stuff in cache even though there had been restart of VM in between.