### PR TITLE
CSCMETAX-199: [ADD] Add wkt field to cache for location reference dat…

### DIFF
--- a/src/metax_api/services/catalog_record_service.py
+++ b/src/metax_api/services/catalog_record_service.py
@@ -303,7 +303,7 @@ class CatalogRecordService(CommonService, ReferenceDataMixin):
                     if ref_entry.get('wkt', False) and populate_as_wkt_with_ref_data:
                         as_wkt.append(ref_entry.get('wkt'))
                     else:
-                        as_wkt.append("unknown")
+                        as_wkt.append(None)
 
             spatial['as_wkt'] = as_wkt
 

--- a/src/metax_api/services/catalog_record_service.py
+++ b/src/metax_api/services/catalog_record_service.py
@@ -300,10 +300,11 @@ class CatalogRecordService(CommonService, ReferenceDataMixin):
                 if ref_entry:
                     cls.populate_from_ref_data(ref_entry, place_uri, label_field='pref_label')
 
-                    if ref_entry.get('wkt', False) and populate_as_wkt_with_ref_data:
-                        as_wkt.append(ref_entry.get('wkt'))
-                    else:
-                        as_wkt.append(None)
+                    if populate_as_wkt_with_ref_data:
+                        if ref_entry.get('wkt', False):
+                            as_wkt.append(ref_entry.get('wkt'))
+                        else:
+                            as_wkt.append('')
 
             spatial['as_wkt'] = as_wkt
 

--- a/src/metax_api/tests/api/base/apitests/catalog_records/write.py
+++ b/src/metax_api/tests/api/base/apitests/catalog_records/write.py
@@ -1095,7 +1095,8 @@ class CatalogRecordApiWriteReferenceDataTests(CatalogRecordApiWriteCommon):
         # the values in these selected entries will be used throghout the rest of the test case
         for dtype in data_types:
             if dtype == 'location':
-                entry = next(obj for obj in refdata[dtype] if obj.get('wkt', False))
+                entry = next((obj for obj in refdata[dtype] if obj.get('wkt', False)), None)
+                self.assertTrue(entry is not None)
             else:
                 entry = refdata[dtype][0]
             refs[dtype] = {

--- a/src/metax_api/tests/testdata/catalog_record_test_data_template_full.json
+++ b/src/metax_api/tests/testdata/catalog_record_test_data_template_full.json
@@ -32,15 +32,25 @@
             "start_date": "2014-01-01T08:19:58Z",
             "end_date": "2014-12-31T08:19:58Z"
         }],
-        "spatial": [{
-            "geographic_name": "Geographic name",
-            "alt": "11.111",
-            "full_address": "The complete address written as a string, with or without formatting",
-            "as_wkt": ["POLYGON((0 0, 0 20, 40 20, 40 0, 0 0))"],
-            "place_uri": [
-                {"identifier": "http://www.yso.fi/onto/yso/p107966"}
-            ]
-        }],
+        "spatial": [
+            {
+                "geographic_name": "Geographic name",
+                "alt": "11.111",
+                "full_address": "The complete address written as a string, with or without formatting",
+                "as_wkt": ["POLYGON((0 0, 0 20, 40 20, 40 0, 0 0))"],
+                "place_uri": [
+                    {"identifier": "http://www.yso.fi/onto/yso/p107966"}
+                ]
+            },
+            {
+                "geographic_name": "Geographic name 2",
+                "alt": "60",
+                "full_address": "The complete address written as a string, with or without formatting",
+                "place_uri": [
+                    {"identifier": "http://www.yso.fi/onto/yso/p107966"}
+                ]
+            }
+        ],
         "related_entity": [{
             "title": {
                 "en": "A name given to the resource"

--- a/src/metax_api/tests/testdata/test_data.json
+++ b/src/metax_api/tests/testdata/test_data.json
@@ -2926,6 +2926,16 @@
                                 "identifier": "http://www.yso.fi/onto/yso/p107966"
                             }
                         ]
+                    },
+                    {
+                        "alt": "60",
+                        "full_address": "The complete address written as a string, with or without formatting",
+                        "geographic_name": "Geographic name 2",
+                        "place_uri": [
+                            {
+                                "identifier": "http://www.yso.fi/onto/yso/p107966"
+                            }
+                        ]
                     }
                 ],
                 "temporal": [
@@ -3700,6 +3710,16 @@
                         ],
                         "full_address": "The complete address written as a string, with or without formatting",
                         "geographic_name": "Geographic name",
+                        "place_uri": [
+                            {
+                                "identifier": "http://www.yso.fi/onto/yso/p107966"
+                            }
+                        ]
+                    },
+                    {
+                        "alt": "60",
+                        "full_address": "The complete address written as a string, with or without formatting",
+                        "geographic_name": "Geographic name 2",
                         "place_uri": [
                             {
                                 "identifier": "http://www.yso.fi/onto/yso/p107966"

--- a/src/metax_api/utils/reference_data_loader.py
+++ b/src/metax_api/utils/reference_data_loader.py
@@ -99,6 +99,9 @@ class ReferenceDataLoader():
                     if label:
                         entry['label'] = label
 
+                    if type_name == 'location':
+                        entry['wkt'] = row['_source'].get('wkt', None)
+
                     reference_data[index_name][type_name].append(entry)
 
         return reference_data


### PR DESCRIPTION
…a. Populate spatial object's as_wkt field with the location reference data wkt field(s), which are referred to in the spatial object's place_uri objects. NOTE: Do this only if the as_wkt array of the spatial object is empty on request, since otherwise we would not be able to distinguish between the location coordinates corresponding to the place_uri objects and the coordinates given by the user. Also, if some place_uri object in the spatial object's place_uri array does not have a coordinate, populate that as_wkt item with 'unknown' not to mess up with the array indices (place_uri array indices vs. as_wkt array indices).