### PR TITLE
CSCMETAX-253: [ADD] Remove all language related titles that are not '…

### DIFF
--- a/src/metax_api/services/catalog_record_service.py
+++ b/src/metax_api/services/catalog_record_service.py
@@ -244,7 +244,9 @@ class CatalogRecordService(CommonService, ReferenceDataMixin):
             ref_entry = cls.check_ref_data(refdata['language'], language['identifier'],
                                            'research_dataset.language.identifier', errors)
             if ref_entry:
-                cls.populate_from_ref_data(ref_entry, language, label_field='title')
+                label_field = 'title'
+                cls.populate_from_ref_data(ref_entry, language, label_field=label_field)
+                cls.remove_language_obj_irrelevant_titles(language, label_field)
 
         access_rights = research_dataset.get('access_rights', None)
         if access_rights:

--- a/src/metax_api/services/data_catalog_service.py
+++ b/src/metax_api/services/data_catalog_service.py
@@ -30,7 +30,9 @@ class DataCatalogService(ReferenceDataMixin):
             ref_entry = cls.check_ref_data(refdata['language'], language['identifier'],
                                            'data_catalog_json.language.identifier', errors)
             if ref_entry:
-                cls.populate_from_ref_data(ref_entry, language, label_field='title')
+                label_field = 'title'
+                cls.populate_from_ref_data(ref_entry, language, label_field=label_field)
+                cls.remove_language_obj_irrelevant_titles(language, label_field)
 
         for fos in data_catalog.get('field_of_science', []):
             ref_entry = cls.check_ref_data(refdata['field_of_science'], fos['identifier'],

--- a/src/metax_api/services/reference_data_mixin.py
+++ b/src/metax_api/services/reference_data_mixin.py
@@ -143,3 +143,11 @@ class ReferenceDataMixin():
 
         elif agent_obj.get('@type') == 'Organization':
             cls.process_org_obj_against_ref_data(orgdata, agent_obj, agent_obj_relation_name)
+
+    @classmethod
+    def remove_language_obj_irrelevant_titles(cls, lang_obj, title_label_field):
+        title_obj = lang_obj.get(title_label_field, None)
+        if title_obj:
+            to_delete = set(title_obj.keys()).difference(['fi', 'sv', 'en', 'und'])
+            for d in to_delete:
+                del title_obj[d]


### PR DESCRIPTION
…fi', 'sv', 'en' or 'und' in reference data population for catalog records and data catalogs.