### PR TITLE
CSCMETAX-223: [ADD] Add validation of lifecycle and preservation even…

### DIFF
--- a/src/metax_api/services/catalog_record_service.py
+++ b/src/metax_api/services/catalog_record_service.py
@@ -370,6 +370,20 @@ class CatalogRecordService(CommonService, ReferenceDataMixin):
 
                 spatial['as_wkt'] = as_wkt
 
+            if activity.get('type', False):
+                ref_entry = cls.check_ref_data(refdata['lifecycle_event'],
+                                               activity['type']['identifier'],
+                                               'research_dataset.activity.type.identifier',
+                                               value_not_found_is_error=False)
+
+                if not ref_entry:
+                    ref_entry = cls.check_ref_data(refdata['preservation_event'],
+                                                   activity['type']['identifier'],
+                                                   'research_dataset.activity.type.identifier', errors)
+
+                if ref_entry:
+                    cls.populate_from_ref_data(ref_entry, activity['type'], label_field='pref_label')
+
         for infra in research_dataset.get('infrastructure', []):
             ref_entry = cls.check_ref_data(refdata['research_infra'], infra['identifier'],
                                            'research_dataset.infrastructure.identifier', errors)

--- a/src/metax_api/tests/api/base/apitests/catalog_records/write.py
+++ b/src/metax_api/tests/api/base/apitests/catalog_records/write.py
@@ -950,10 +950,13 @@ class CatalogRecordApiWriteReferenceDataTests(CatalogRecordApiWriteCommon):
         rd['is_output_of'][0]['funder_type']['identifier'] = 'nonexisting'
         rd['directories'][0]['use_category']['identifier'] = 'nonexisting'
         rd['relation'][0]['relation_type']['identifier'] = 'nonexisting'
+        rd['provenance'][0]['type']['identifier'] = 'nonexisting'
+        rd['provenance'][1]['type']['identifier'] = 'nonexisting'
         response = self.client.post('/rest/datasets', self.third_test_new_data, format="json")
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual('research_dataset' in response.data.keys(), True)
-        self.assertEqual(len(response.data['research_dataset']), 18)
+        self.assertEqual(len(response.data['research_dataset']), 19)
+        self.assertEqual(len(response.data['research_dataset']['research_dataset.activity.type.identifier']), 2)
 
     def test_create_catalog_record_populate_fields_from_reference_data(self):
         """
@@ -994,7 +997,9 @@ class CatalogRecordApiWriteReferenceDataTests(CatalogRecordApiWriteCommon):
             'research_infra',
             'contributor_role',
             'funder_type',
-            'relation_type'
+            'relation_type',
+            'lifecycle_event',
+            'preservation_event'
         ]
 
         # the values in these selected entries will be used throghout the rest of the test case
@@ -1038,6 +1043,8 @@ class CatalogRecordApiWriteReferenceDataTests(CatalogRecordApiWriteCommon):
         rd['creator'][0]['contributor_role'] = {'identifier': refs['contributor_role']['code']}
         rd['is_output_of'][0]['funder_type'] = {'identifier': refs['funder_type']['code']}
         rd['relation'][0]['relation_type'] = {'identifier': refs['relation_type']['code']}
+        rd['provenance'][0]['type'] = {'identifier': refs['lifecycle_event']['code']}
+        rd['provenance'][1]['type'] = {'identifier': refs['preservation_event']['code']}
 
         # these have other required fields, so only update the identifier with code
         rd['is_output_of'][0]['source_organization'][0]['identifier'] = refs['organization']['code']
@@ -1105,6 +1112,8 @@ class CatalogRecordApiWriteReferenceDataTests(CatalogRecordApiWriteCommon):
         self.assertEqual(refs['contributor_role']['uri'], new_rd['creator'][0]['contributor_role']['identifier'])
         self.assertEqual(refs['funder_type']['uri'], new_rd['is_output_of'][0]['funder_type']['identifier'])
         self.assertEqual(refs['relation_type']['uri'], new_rd['relation'][0]['relation_type']['identifier'])
+        self.assertEqual(refs['lifecycle_event']['uri'], new_rd['provenance'][0]['type']['identifier'])
+        self.assertEqual(refs['preservation_event']['uri'], new_rd['provenance'][1]['type']['identifier'])
 
     def _assert_label_copied_to_pref_label(self, refs, new_rd):
         self.assertEqual(refs['keyword']['label'], new_rd['theme'][0].get('pref_label', None))
@@ -1126,6 +1135,8 @@ class CatalogRecordApiWriteReferenceDataTests(CatalogRecordApiWriteCommon):
                          new_rd['creator'][0]['contributor_role'].get('pref_label', None))
         self.assertEqual(refs['funder_type']['label'], new_rd['is_output_of'][0]['funder_type'].get('pref_label', None))
         self.assertEqual(refs['relation_type']['label'], new_rd['relation'][0]['relation_type'].get('pref_label', None))
+        self.assertEqual(refs['lifecycle_event']['label'], new_rd['provenance'][0]['type'].get('pref_label', None))
+        self.assertEqual(refs['preservation_event']['label'], new_rd['provenance'][1]['type'].get('pref_label', None))
 
     def _assert_label_copied_to_title(self, refs, new_rd):
         required_langs = dict((lang, val) for lang, val in refs['language']['label'].items()

--- a/src/metax_api/tests/testdata/catalog_record_test_data_template_full.json
+++ b/src/metax_api/tests/testdata/catalog_record_test_data_template_full.json
@@ -299,10 +299,7 @@
           }
         },
         "type": {
-          "identifier": "provenancetypeidentifier",
-          "pref_label": {
-            "en": "pref label for this type"
-          },
+          "identifier": "http://purl.org/att/es/reference_data/lifecycle_event/lifecycle_event_collected",
           "definition": [
             {
               "en": "A statement or formal explanation of the meaning of a concept."
@@ -419,6 +416,29 @@
             }
           }
         ]
+      },
+      {
+        "title": {
+          "en": "Some other activity"
+        },
+        "description": {
+          "en": "Description of other provenance activity"
+        },
+        "temporal": {
+          "start_date": "2014-01-01T08:19:58Z",
+          "end_date": "2014-12-31T08:19:58Z"
+        },
+        "spatial": {
+          "geographic_name": "Geographic name",
+          "alt": "11.111",
+          "fullAddress": "The complete address written as a string, with or without formatting",
+          "place_uri": {
+            "identifier": "http://www.yso.fi/onto/yso/p105917"
+          }
+        },
+        "type": {
+          "identifier": "http://purl.org/att/reference_data/preservation_event/preservation_event_upd"
+        }
       }
     ],
     "rights_holder": {

--- a/src/metax_api/tests/testdata/test_data.json
+++ b/src/metax_api/tests/testdata/test_data.json
@@ -2902,7 +2902,7 @@
                                     "en": "A statement or formal explanation of the meaning of a concept."
                                 }
                             ],
-                            "identifier": "provenancetypeidentifier",
+                            "identifier": "http://purl.org/att/es/reference_data/lifecycle_event/lifecycle_event_collected",
                             "in_scheme": [
                                 {
                                     "identifier": "http://uri.of.provenance.concept/scheme",
@@ -2910,10 +2910,7 @@
                                         "en": "The preferred lexical label for a resource"
                                     }
                                 }
-                            ],
-                            "pref_label": {
-                                "en": "pref label for this type"
-                            }
+                            ]
                         },
                         "used_entity": [
                             {
@@ -3017,6 +3014,29 @@
                                 ]
                             }
                         ]
+                    },
+                    {
+                        "description": {
+                            "en": "Description of other provenance activity"
+                        },
+                        "spatial": {
+                            "alt": "11.111",
+                            "fullAddress": "The complete address written as a string, with or without formatting",
+                            "geographic_name": "Geographic name",
+                            "place_uri": {
+                                "identifier": "http://www.yso.fi/onto/yso/p105917"
+                            }
+                        },
+                        "temporal": {
+                            "end_date": "2014-12-31T08:19:58Z",
+                            "start_date": "2014-01-01T08:19:58Z"
+                        },
+                        "title": {
+                            "en": "Some other activity"
+                        },
+                        "type": {
+                            "identifier": "http://purl.org/att/reference_data/preservation_event/preservation_event_upd"
+                        }
                     }
                 ],
                 "publisher": {
@@ -3752,7 +3772,7 @@
                                     "en": "A statement or formal explanation of the meaning of a concept."
                                 }
                             ],
-                            "identifier": "provenancetypeidentifier",
+                            "identifier": "http://purl.org/att/es/reference_data/lifecycle_event/lifecycle_event_collected",
                             "in_scheme": [
                                 {
                                     "identifier": "http://uri.of.provenance.concept/scheme",
@@ -3760,10 +3780,7 @@
                                         "en": "The preferred lexical label for a resource"
                                     }
                                 }
-                            ],
-                            "pref_label": {
-                                "en": "pref label for this type"
-                            }
+                            ]
                         },
                         "used_entity": [
                             {
@@ -3867,6 +3884,29 @@
                                 ]
                             }
                         ]
+                    },
+                    {
+                        "description": {
+                            "en": "Description of other provenance activity"
+                        },
+                        "spatial": {
+                            "alt": "11.111",
+                            "fullAddress": "The complete address written as a string, with or without formatting",
+                            "geographic_name": "Geographic name",
+                            "place_uri": {
+                                "identifier": "http://www.yso.fi/onto/yso/p105917"
+                            }
+                        },
+                        "temporal": {
+                            "end_date": "2014-12-31T08:19:58Z",
+                            "start_date": "2014-01-01T08:19:58Z"
+                        },
+                        "title": {
+                            "en": "Some other activity"
+                        },
+                        "type": {
+                            "identifier": "http://purl.org/att/reference_data/preservation_event/preservation_event_upd"
+                        }
                     }
                 ],
                 "publisher": {


### PR DESCRIPTION
…ts for activity type field of provenance object. Since they are separate types, both reference data types need to be checked before failing. Update test data and tests.