### PR TITLE
CSCMETAX-256: Single file post and delete

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 coveralls==1.2.0 # code coverage reportin in travis
 dicttoxml==1.7.4
 python-dateutil==2.6.1
-Django==1.11.7  # BSD-license
+Django==2.0  # BSD-license
 elasticsearch<6.0.0
 hiredis==0.2.0 # Used by redis (redis-py) for parser
 djangorestframework==3.7.3  # BSD-license
@@ -11,7 +11,7 @@ gevent==1.2.2 # gunicorn dep
 gunicorn==19.7.1 # MIT-license
 ipdb==0.10.3 # dev tool
 jsonschema==2.6.0
-pika==0.11.1
+pika==0.11.2
 psycopg2==2.7.3.2  # LGPL with exceptions or ZPL
 python-simplexquery==1.0.5.3
 pytz==2017.3

--- a/src/metax_api/api/base/views/file_view.py
+++ b/src/metax_api/api/base/views/file_view.py
@@ -41,17 +41,6 @@ class FileViewSet(CommonViewSet):
         self.set_json_schema(__file__)
         super(FileViewSet, self).__init__(*args, **kwargs)
 
-    def get_object(self):
-        """
-        future todo:
-        - query params:
-            - owner_email (string)
-            - fields (list of strings)
-            - offset (integer) (paging)
-            - limit (integer) (limit for paging)
-        """
-        return super(FileViewSet, self).get_object()
-
     @list_route(methods=['post'], url_path="datasets")
     def datasets(self, request):
         """
@@ -64,19 +53,8 @@ class FileViewSet(CommonViewSet):
         """
         return FileService.get_datasets_where_file_belongs_to(request.data)
 
-    def destroy(self, request, *args, **kwargs):
-        """
-        since IDA only deletes entire directories, supporting single file delete is useless.
-        if this ever becomes relevant:
-        file.delete()
-        if not file.parent_directory.files.all().count()
-            and not file.parent_directory.child_directories.all().count():
-            file.parent_directory.delete()
-            file.parent_directory = None
-            file.save()
-        and delete a possible long tree of empty directories... or something like that
-        """
-        return Response({}, status=status.HTTP_405_METHOD_NOT_ALLOWED)
+    def destroy(self, request, pk, **kwargs):
+        return FileService.destroy_single(self.get_object())
 
     def destroy_bulk(self, request, *args, **kwargs):
         return FileService.destroy_bulk(request.data)

--- a/src/metax_api/models/catalog_record.py
+++ b/src/metax_api/models/catalog_record.py
@@ -76,7 +76,7 @@ class CatalogRecord(Common):
 
     contract = models.ForeignKey(Contract, null=True, on_delete=models.DO_NOTHING)
 
-    data_catalog = models.ForeignKey(DataCatalog)
+    data_catalog = models.ForeignKey(DataCatalog, on_delete=models.DO_NOTHING)
 
     dataset_group_edit = models.CharField(
         max_length=200, blank=True, null=True,

--- a/src/metax_api/models/directory.py
+++ b/src/metax_api/models/directory.py
@@ -1,32 +1,6 @@
-from django.db import connection, models
+from django.db import models
 
-from .common import Common, CommonManager
-
-
-class DirectoryManager(CommonManager):
-
-    def delete_directory(self, directory_path):
-        """
-        For every File whose file_path.startswith(directory_path),
-            set removed=True,
-            and for every dataset this file belongs to,
-                set flag removed_in_ida=True in file in dataset list
-        """
-
-        # copy-paste leftover from old FileManager, to be revisited...
-
-        affected_files = 0
-
-        sql = 'update metax_api_file set removed = true ' \
-              'where removed = false ' \
-              'and active = true ' \
-              'and (file_path = %s or file_path like %s)'
-
-        with connection.cursor() as cr:
-            cr.execute(sql, [directory_path, '%s/%%' % directory_path])
-            affected_files = cr.rowcount
-
-        return affected_files
+from .common import Common
 
 
 class Directory(Common):
@@ -48,8 +22,6 @@ class Directory(Common):
     indexes = [
         models.Index(fields=['identifier']),
     ]
-
-    objects = DirectoryManager()
 
     def delete(self):
         # actual delete

--- a/src/metax_api/models/file.py
+++ b/src/metax_api/models/file.py
@@ -44,7 +44,7 @@ class File(Common):
     file_modified = models.DateTimeField(auto_now=True)
     file_name = models.CharField(max_length=200)
     file_path = models.TextField()
-    file_storage = models.ForeignKey(FileStorage)
+    file_storage = models.ForeignKey(FileStorage, on_delete=models.DO_NOTHING)
     file_uploaded = models.DateTimeField()
     identifier = models.CharField(max_length=200, unique=True)
     open_access = models.BooleanField(default=False)

--- a/src/metax_api/models/xml_metadata.py
+++ b/src/metax_api/models/xml_metadata.py
@@ -10,7 +10,7 @@ class XmlMetadata(Common):
 
     namespace = models.CharField(max_length=200)
     xml = models.TextField()
-    file = models.ForeignKey(File)
+    file = models.ForeignKey(File, on_delete=models.DO_NOTHING)
 
     # END OF MODEL FIELD DEFINITIONS #
 

--- a/src/metax_api/services/common_service.py
+++ b/src/metax_api/services/common_service.py
@@ -61,13 +61,19 @@ class CommonService():
                 http_status = status.HTTP_400_BAD_REQUEST
 
         else:
-            serializer = serializer_class(data=request.data, **kwargs)
-            serializer.is_valid(raise_exception=True)
-            serializer.save(**common_info)
-            http_status = status.HTTP_201_CREATED
-            results = serializer.data
+            results, http_status = cls._create_single(common_info, request.data, serializer_class, **kwargs)
 
         return results, http_status
+
+    @classmethod
+    def _create_single(cls, common_info, initial_data, serializer_class, **kwargs):
+        """
+        Extracted into its own method so it may be inherited.
+        """
+        serializer = serializer_class(data=initial_data, **kwargs)
+        serializer.is_valid(raise_exception=True)
+        serializer.save(**common_info)
+        return serializer.data, status.HTTP_201_CREATED
 
     @classmethod
     def _create_bulk(cls, common_info, initial_data_list, results, serializer_class, **kwargs):


### PR DESCRIPTION
Includes a rather big overhaul of previous bulk create of files (file hierarchy creation). But now single create may use the same methods (they dont assume the request always concerns an entire directory only)