### PR TITLE
CSCMETAX-242: [FIX] Replace directory original byte_size and file_cou…

### DIFF
--- a/src/metax_api/services/file_service.py
+++ b/src/metax_api/services/file_service.py
@@ -521,7 +521,8 @@ class FileService(CommonService):
                 directory['file_count'] = file_count
 
         elif 'id' in directory:
-            # bottom dir - retrieve total byte_size and file_count from db
+            # bottom dir - retrieve total byte_size and file_count from db for this cr,
+            # and replace the original byte_size and file_count of the directory
 
             sql_calculate_byte_size_and_file_count = """
                 select sum(f.byte_size) as byte_size, count(f.id) as file_count
@@ -545,8 +546,8 @@ class FileService(CommonService):
                 )
 
                 bs, fc = cr.fetchall()[0]
-                directory['byte_size'] += bs or 0
-                directory['file_count'] += fc or 0
+                directory['byte_size'] = bs or 0
+                directory['file_count'] = fc or 0
         else:
             # called without include_parent on a directory which has files, but no directories - do nothing
             return

--- a/src/metax_api/tests/api/rest/base/views/directories/read.py
+++ b/src/metax_api/tests/api/rest/base/views/directories/read.py
@@ -4,6 +4,7 @@ from rest_framework import status
 from rest_framework.test import APITestCase
 
 from metax_api.models import CatalogRecord, Directory
+from metax_api.services import FileService
 from metax_api.tests.utils import test_data_file_path, TestClassUtils
 
 
@@ -277,6 +278,9 @@ class DirectoryApiReadCatalogRecordFileBrowsingTests(DirectoryApiReadCommon):
         """
         dr = Directory.objects.get(pk=2)
         cr = CatalogRecord.objects.get(pk=1)
+
+        # calculate all directory byte sizes and file counts to real values, from their default 0 values
+        FileService.calculate_project_directory_byte_sizes_and_file_counts(dr.project_identifier)
 
         byte_size = cr.files.filter(file_path__startswith='%s/' % dr.directory_path) \
             .aggregate(Sum('byte_size'))['byte_size__sum']


### PR DESCRIPTION
…nt when browsing files for a CR, instead of adding to them. Fix test case.

The bug did not manifest in the testcase previously due to not executing FileService.calculate_project_directory_byte_sizes_and_file_counts() in the testcase first to replace default 0 values with real values