### PR TITLE
CSCMETAX-321: [ADD] new query parameter for dataset single API: prefe…

### DIFF
--- a/src/metax_api/api/rest/base/views/dataset_view.py
+++ b/src/metax_api/api/rest/base/views/dataset_view.py
@@ -174,16 +174,18 @@ class DatasetViewSet(CommonViewSet):
     def _search_using_dataset_identifiers(self):
         """
         Search by lookup value from urn_identifier and preferred_identifier fields. preferred_identifier
-        searched only with GET requests.
+        searched only with GET requests. If query contains parameter 'preferred_identifier', do not lookup
+        using urn_identifier
         """
         lookup_value = self.kwargs.get(self.lookup_field, False)
 
-        try:
-            return super(DatasetViewSet, self).get_object(
-                search_params={ 'research_dataset__contains': {'urn_identifier': lookup_value} })
-        except Http404:
-            if self.request.method != 'GET':
-                raise
+        if not CS.get_boolean_query_param(self.request, 'preferred_identifier'):
+            try:
+                return super(DatasetViewSet, self).get_object(
+                    search_params={ 'research_dataset__contains': {'urn_identifier': lookup_value} })
+            except Http404:
+                if self.request.method != 'GET':
+                    raise
 
         # search by preferred_identifier only for GET requests, while preferring:
         # - hits from att catalogs (assumed to be first created. improve logic if situation changes)
@@ -192,10 +194,11 @@ class DatasetViewSet(CommonViewSet):
 
         # note: cant use get_object() like above, because get_object() will throw an error if there are
         # multiple results
-        obj = self.get_queryset().filter(research_dataset__contains={'preferred_identifier': lookup_value}) \
-            .order_by('data_catalog_id', '-next_version_id', 'date_created').first()
-        if obj:
-            return obj
+        if self.request.method == 'GET':
+            obj = self.get_queryset().filter(research_dataset__contains={'preferred_identifier': lookup_value}) \
+                .order_by('data_catalog_id', '-next_version_id', 'date_created').first()
+            if obj:
+                return obj
 
         raise Http404
 

--- a/src/metax_api/tests/api/rest/base/views/datasets/read.py
+++ b/src/metax_api/tests/api/rest/base/views/datasets/read.py
@@ -116,6 +116,14 @@ class CatalogRecordApiReadBasicTests(CatalogRecordApiReadCommon):
         self.assertTrue(len(response.data) > 0)
         self.assertTrue(response.data[0].startswith('urn:'))
 
+    def test_get_only_by_preferred_identifier(self):
+        response = self.client.get('/rest/datasets/%s?preferred_identifier' % self.preferred_identifier)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['research_dataset']['preferred_identifier'], self.preferred_identifier)
+
+        response = self.client.get('/rest/datasets/%s?preferred_identifier' % self.urn_identifier)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
 
 class CatalogRecordApiReadPreservationStateTests(CatalogRecordApiReadCommon):
     """

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -830,6 +830,12 @@ paths:
             byte_size and file_count in each directory's details as extra information.
           required: false
           type: boolean
+        - name: preferred_identifier
+          in: query
+          description: |
+            Return a hit only if the given PID is a preferred identifier.
+          required: false
+          type: boolean
       responses:
         '200':
           description: return dataset metadata


### PR DESCRIPTION
…rred_identifier. Using this does not lookup value from urn_identifier field. NOTE: Using pk still works, but it should be disallowed anyway for general audience.