### PR TITLE
CSCMETAX-332: [ADD] File browsing API takes parameter preferred_ident…

### DIFF
--- a/src/metax_api/api/rest/base/views/directory_view.py
+++ b/src/metax_api/api/rest/base/views/directory_view.py
@@ -67,7 +67,7 @@ class DirectoryViewSet(CommonViewSet):
             if max_depth <= 0:
                 raise Http400({ 'detail': ['value of depth must be higher than 0'] })
 
-        metadata_version_identifier = request.query_params.get('metadata_version_identifier', None)
+        preferred_identifier = request.query_params.get('preferred_identifier', None)
 
         files_and_dirs = FileService.get_directory_contents(
             identifier=identifier,
@@ -77,7 +77,7 @@ class DirectoryViewSet(CommonViewSet):
             max_depth=max_depth,
             dirs_only=dirs_only,
             include_parent=include_parent,
-            metadata_version_identifier=metadata_version_identifier
+            preferred_identifier=preferred_identifier
         )
 
         return Response(files_and_dirs)

--- a/src/metax_api/models/catalog_record.py
+++ b/src/metax_api/models/catalog_record.py
@@ -125,10 +125,9 @@ class CatalogRecordManager(CommonManager):
                     'id, or research_dataset ->> metadata_version_identifier')
         return super(CatalogRecordManager, self).get(*args, **kwargs)
 
-    def get_id(self, metadata_version_identifier=None):
+    def get_id(self, metadata_version_identifier=None): # pragma: no cover
         """
-        Takes metadata_version_identifier, and returns the plain pk of the record. Useful for debugging,
-        and some other situations.
+        Takes metadata_version_identifier, and returns the plain pk of the record. Useful for debugging
         """
         if not metadata_version_identifier:
             raise ValidationError('metadata_version_identifier is a required keyword argument')

--- a/src/metax_api/tests/api/rest/base/views/directories/read.py
+++ b/src/metax_api/tests/api/rest/base/views/directories/read.py
@@ -223,10 +223,10 @@ class DirectoryApiReadCatalogRecordFileBrowsingTests(DirectoryApiReadCommon):
 
     def test_read_directory_for_catalog_record(self):
         """
-        Test query parameter 'metadata_version_identifier'.
+        Test query parameter 'preferred_identifier'.
         """
-        response = self.client.get('/rest/directories/3/files?metadata_version_identifier=%s'
-            % CatalogRecord.objects.get(pk=1).metadata_version_identifier)
+        response = self.client.get('/rest/directories/3/files?preferred_identifier=%s'
+            % CatalogRecord.objects.get(pk=1).preferred_identifier)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual('directories' in response.data, True)
         self.assertEqual('files' in response.data, True)
@@ -235,10 +235,10 @@ class DirectoryApiReadCatalogRecordFileBrowsingTests(DirectoryApiReadCommon):
 
     def test_read_directory_for_catalog_record_not_found(self):
         """
-        Not found metadata_version_identifier should raise 400 instead of 404, which is raised when the
+        Not found preferred_identifier should raise 400 instead of 404, which is raised when the
         directory itself is not found. the error contains details about the 400.
         """
-        response = self.client.get('/rest/directories/3/files?metadata_version_identifier=notexisting')
+        response = self.client.get('/rest/directories/3/files?preferred_identifier=notexisting')
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_read_directory_for_catalog_record_directory_does_not_exist(self):
@@ -252,22 +252,22 @@ class DirectoryApiReadCatalogRecordFileBrowsingTests(DirectoryApiReadCommon):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         # ... but should not contain any files FOR THIS CR
-        response = self.client.get('/rest/directories/4/files?metadata_version_identifier=%s'
-            % CatalogRecord.objects.get(pk=1).metadata_version_identifier)
+        response = self.client.get('/rest/directories/4/files?preferred_identifier=%s'
+            % CatalogRecord.objects.get(pk=1).preferred_identifier)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_read_directory_for_catalog_record_recursively(self):
         """
-        Test query parameter 'metadata_version_identifier' with 'recursive'.
+        Test query parameter 'preferred_identifier' with 'recursive'.
         """
-        response = self.client.get('/rest/directories/1/files?recursive&metadata_version_identifier=%s&depth=*'
-            % CatalogRecord.objects.get(pk=1).metadata_version_identifier)
+        response = self.client.get('/rest/directories/1/files?recursive&preferred_identifier=%s&depth=*'
+            % CatalogRecord.objects.get(pk=1).preferred_identifier)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data), 2)
 
-        # not found metadata_version_identifier should raise 400 instead of 404, which is raised when the
+        # not found preferred_identifier should raise 400 instead of 404, which is raised when the
         # directory itself is not found. the error contains details about the 400
-        response = self.client.get('/rest/directories/1/files?recursive&metadata_version_identifier=notexisting')
+        response = self.client.get('/rest/directories/1/files?recursive&preferred_identifier=notexisting')
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_directory_byte_size_and_file_count(self):
@@ -286,7 +286,7 @@ class DirectoryApiReadCatalogRecordFileBrowsingTests(DirectoryApiReadCommon):
         file_count = cr.files.filter(file_path__startswith='%s/' % dr.directory_path).count()
 
         response = self.client.get(
-            '/rest/directories/%d/files?metadata_version_identifier=%s' % (dr.id, cr.metadata_version_identifier))
+            '/rest/directories/%d/files?preferred_identifier=%s' % (dr.id, cr.preferred_identifier))
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
         self.assertEqual('directories' in response.data, True)
         self.assertEqual('byte_size' in response.data['directories'][0], True)
@@ -302,8 +302,8 @@ class DirectoryApiReadCatalogRecordFileBrowsingTests(DirectoryApiReadCommon):
         file_count = cr.files.filter(file_path__startswith='%s/' % dr.directory_path).count()
 
         response = self.client.get(
-            '/rest/directories/%d/files?metadata_version_identifier=%s&include_parent'
-            % (dr.id, cr.metadata_version_identifier))
+            '/rest/directories/%d/files?preferred_identifier=%s&include_parent'
+            % (dr.id, cr.preferred_identifier))
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
         self.assertEqual('byte_size' in response.data, True)
         self.assertEqual('file_count' in response.data, True)

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -439,9 +439,9 @@ paths:
             otherwise, one would query for its data separately by GET /directories/3.
           required: false
           type: boolean
-        - name: metadata_version_identifier
+        - name: preferred_identifier
           in: query
-          description: metadata_version_identifier of a dataset. browse only files that have been selected for that record.
+          description: preferred_identifier of a dataset. browse only files that have been selected for that record.
           required: false
           type: string
       responses:
@@ -501,9 +501,9 @@ paths:
             otherwise, one would query for its data separately by GET /directories/3.
           required: false
           type: boolean
-        - name: metadata_version_identifier
+        - name: preferred_identifier
           in: query
-          description: metadata_version_identifier of a dataset. browse only files that have been selected for that record.
+          description: preferred_identifier of a dataset. browse only files that have been selected for that record.
           required: false
           type: string
       responses:


### PR DESCRIPTION
…ifier instead of metadata_version_identifier, since preferred_identifier is really what files are linked to