### PR TITLE
CSCMETAX-339: [ADD] Get license URL automatically from reference data…

### DIFF
--- a/src/metax_api/services/data_catalog_service.py
+++ b/src/metax_api/services/data_catalog_service.py
@@ -48,11 +48,21 @@ class DataCatalogService(ReferenceDataMixin):
                 if ref_entry:
                     cls.populate_from_ref_data(ref_entry, rights_statement_type, label_field='pref_label')
 
-            for rights_statement_license in access_rights.get('license', []):
-                ref_entry = cls.check_ref_data(refdata['license'], rights_statement_license['identifier'],
+            for license in access_rights.get('license', []):
+                license_url = license.get('license', None)
+
+                ref_entry = cls.check_ref_data(refdata['license'], license['identifier'],
                                                'data_catalog_json.rights.license.identifier', errors)
                 if ref_entry:
-                    cls.populate_from_ref_data(ref_entry, rights_statement_license, label_field='title')
+                    cls.populate_from_ref_data(ref_entry, license, label_field='title')
+
+                    # Populate license field from reference data only if it is empty, i.e. not provided by the user
+                    # and when the reference data uri does not contain purl.org/att
+                    if not license_url and ref_entry.get('uri', False):
+                        license_url = ref_entry['uri'] if 'purl.org/att' not in ref_entry['uri'] else None
+
+                if license_url:
+                    license['license'] = license_url
 
             if 'has_rights_related_agent' in access_rights:
                 for agent in access_rights.get('has_rights_related_agent', []):


### PR DESCRIPTION
… if it is not provided by user and if the actual URL is something else than referring to purl.org/att type address. Additionally, spatial as_wkt does not get set to spatial object as key, if it is empty.