### PR TITLE
CSCMETAX-350: [ADD|REF] Dataset versioning simplification

### DIFF
--- a/src/metax_api/api/oaipmh/base/metax_oai_server.py
+++ b/src/metax_api/api/oaipmh/base/metax_oai_server.py
@@ -30,8 +30,6 @@ class MetaxOAIServer(ResumptionOAIPMH):
         if not self._is_valid_set(set):
             raise BadArgumentError('invalid set value')
 
-        # only get the latest metadata versions
-        query_set = CatalogRecord.objects.filter(next_metadata_version__isnull=True)
         if from_ and until:
             query_set = CatalogRecord.objects.filter(date_modified__gte=from_, date_modified__lte=until)
         elif from_:

--- a/src/metax_api/api/rest/base/api_schemas/catalogrecord.json
+++ b/src/metax_api/api/rest/base/api_schemas/catalogrecord.json
@@ -12,6 +12,12 @@
             "title":"Catalog Record",
             "description":"A record in a data catalog, describing a single dataset.",
             "properties":{
+                "identifier":{
+                    "title":"Identifier",
+                    "description":"Internal identifier of the record. Required by API write operations.",
+                    "type":"string",
+                    "readonly": true
+                },
                 "data_catalog":{
                     "title":"Data catalog",
                     "description":"Data Catalog",
@@ -32,7 +38,7 @@
                 },
                 "alternate_record_set":{
                     "title":"Alternate Records",
-                    "description":"List of records who share the same preferred_identifier value, but are saved in different data catalogs. The list of contains the metadata_version_identifier values of those records.",
+                    "description":"List of records who share the same preferred_identifier value, but are saved in different data catalogs. The list of contains the identifier values of those records.",
                     "type":"array",
                     "items":{
                         "type":"string"
@@ -74,7 +80,8 @@
                     "description":"Date when preservation state was last changed",
                     "maxItems":1,
                     "type":"string",
-                    "format":"date-time"
+                    "format":"date-time",
+                    "readonly": true
                 },
                 "mets_object_identifier":{
                     "title":"Mets object identifier",
@@ -96,27 +103,6 @@
                     "type":"object",
                     "$ref":"#/definitions/Editor"
                 },
-                "metadata_version_set":{
-                    "title":"Metadata version set",
-                    "description":"List of records (metadata_version_identifiers) which are different metadata versions of the same record.",
-                    "type":"array",
-                    "items":{
-                        "type":"string"
-                    },
-                    "readonly": true
-                },
-                "next_metadata_version":{
-                    "title":"Next metadata version record",
-                    "description":"Link to the next metadata version record",
-                    "type":"object",
-                    "$ref":"#/definitions/CatalogRecordVersion"
-                },
-                "previous_metadata_version":{
-                    "title":"Previous metadata version record",
-                    "description":"Link to the previous metadata version record",
-                    "type":"object",
-                    "$ref":"#/definitions/CatalogRecordVersion"
-                },
                 "dataset_version_set":{
                     "title":"Dataset version set",
                     "description":"List of preferred_identifiers of the different related dataset versions.",
@@ -128,21 +114,24 @@
                 },
                 "next_dataset_version":{
                     "title":"Next dataset version",
-                    "description":"Next dataset version preferred_identifier",
+                    "description":"Next dataset version info.",
                     "type":"object",
-                    "$ref":"#/definitions/CatalogRecordVersion"
+                    "$ref":"#/definitions/CatalogRecordVersion",
+                    "readonly": true
                 },
                 "previous_dataset_version":{
                     "title":"Previous dataset version",
-                    "description":"previous dataset version preferred_identifier",
+                    "description":"Previous dataset version info.",
                     "type":"object",
-                    "$ref":"#/definitions/CatalogRecordVersion"
+                    "$ref":"#/definitions/CatalogRecordVersion",
+                    "readonly": true
                 },
                 "new_version_created":{
                     "title":"New version created",
                     "description":"Included in the API response when an update results in a new version being created.",
                     "type":"object",
-                    "$ref":"#/definitions/CatalogRecordVersionCreatedInfo"
+                    "$ref":"#/definitions/CatalogRecordVersionCreatedInfo",
+                    "readonly": true
                 },
                 "date_modified":{
                     "title":"Date Modified",
@@ -228,9 +217,9 @@
                     "type":"integer",
                     "readonly": true
                 },
-                "metadata_version_identifier":{
-                    "title":"Metadata version identifier",
-                    "description":"metadata_version_identifier of the record. Only present in links to different metadata version records.",
+                "identifier":{
+                    "title":"Identifier",
+                    "description":"Identifier of the record. Only present in links to different metadata version records.",
                     "type":"string",
                     "readonly": true
                 },
@@ -252,9 +241,9 @@
                     "type":"integer",
                     "readonly": true
                 },
-                "metadata_version_identifier":{
-                    "title":"Metadata version identifier",
-                    "description":"metadata_version_identifier of the new version record",
+                "identifier":{
+                    "title":"Identifier",
+                    "description":"Identifier of the new version record",
                     "type":"string",
                     "readonly": true
                 },
@@ -270,13 +259,13 @@
                     "type":"string",
                     "readonly": true,
                     "enum":[
-                        "metadata",
                         "dataset",
                     ],
                 },
             },
             "required":[
-                "metadata_version_identifier",
+                "identifier",
+                "preferred_identifier",
                 "version_type"
             ]
         }

--- a/src/metax_api/api/rest/base/router.py
+++ b/src/metax_api/api/rest/base/router.py
@@ -56,4 +56,8 @@ router.register(r'directories/?', DirectoryViewSet)
 router.register(r'files/?', FileViewSet)
 router.register(r'schemas/?', SchemaViewSet, 'schema')
 
+# note: this somehow maps to list-api... but the end result works when
+# the presence of the parameters is inspected in the list-api method.
+router.register(r'datasets/(?P<identifier>.+)/metadata_versions/(?P<metadata_version_identifier>.+)/?', DatasetViewSet)
+
 api_urlpatterns = router.urls

--- a/src/metax_api/api/rest/base/serializers/catalog_record_serializer.py
+++ b/src/metax_api/api/rest/base/serializers/catalog_record_serializer.py
@@ -13,12 +13,14 @@ from .serializer_utils import validate_json
 _logger = logging.getLogger(__name__)
 d = logging.getLogger(__name__).debug
 
+
 class CatalogRecordSerializer(CommonSerializer):
 
     class Meta:
         model = CatalogRecord
         fields = (
             'id',
+            'identifier',
             'alternate_record_set',
             'contract',
             'data_catalog',
@@ -30,10 +32,6 @@ class CatalogRecordSerializer(CommonSerializer):
             'preservation_description',
             'preservation_reason_description',
             'mets_object_identifier',
-            'dataset_group_edit',
-            'next_metadata_version',
-            'previous_metadata_version',
-            'metadata_version_set',
             'editor',
             'removed',
         ) + CommonSerializer.Meta.fields
@@ -41,12 +39,13 @@ class CatalogRecordSerializer(CommonSerializer):
         extra_kwargs = {
             # these values are generated automatically or provide default values on creation.
             # some fields can be later updated by the user, some are generated
+            'identifier':       { 'required': False },
             'preservation_state':       { 'required': False },
             'preservation_description': { 'required': False },
             'preservation_state_modified':    { 'required': False },
             'mets_object_identifier':   { 'required': False },
-            'next_metadata_version':             { 'required': False },
-            'previous_metadata_version':         { 'required': False },
+            'next_dataset_version':             { 'required': False },
+            'previous_dataset_version':         { 'required': False },
         }
 
         extra_kwargs.update(CommonSerializer.Meta.extra_kwargs)
@@ -60,9 +59,8 @@ class CatalogRecordSerializer(CommonSerializer):
 
         self.initial_data.pop('alternate_record_set', None)
         self.initial_data.pop('dataset_version_set', None)
-        self.initial_data.pop('metadata_version_set', None)
-        self.initial_data.pop('next_metadata_version', None)
-        self.initial_data.pop('previous_metadata_version', None)
+        self.initial_data.pop('next_dataset_version', None)
+        self.initial_data.pop('previous_dataset_version', None)
         self.initial_data.pop('removed', None)
 
         if self._data_catalog_is_changed():
@@ -98,40 +96,26 @@ class CatalogRecordSerializer(CommonSerializer):
         if 'alternate_record_set' in res:
             alternate_records = instance.alternate_record_set.records.exclude(pk=instance.id)
             if len(alternate_records):
-                res['alternate_record_set'] = [ ar.metadata_version_identifier for ar in alternate_records ]
-
-        if 'metadata_version_set' in res:
-            res['metadata_version_set'] = instance.metadata_version_set.get_listing()
-
-        if 'next_metadata_version' in res:
-            res['next_metadata_version'] = {
-                'id': instance.next_metadata_version.id,
-                'metadata_version_identifier': instance.next_metadata_version.metadata_version_identifier,
-            }
-
-        if 'previous_metadata_version' in res:
-            res['previous_metadata_version'] = {
-                'id': instance.previous_metadata_version.id,
-                'metadata_version_identifier': instance.previous_metadata_version.metadata_version_identifier,
-            }
+                res['alternate_record_set'] = [ ar.identifier for ar in alternate_records ]
 
         if 'dataset_version_set' in res:
             res['dataset_version_set'] = instance.dataset_version_set.get_listing()
 
-        if instance.next_dataset_version:
+        if instance.next_dataset_version_id:
             res['next_dataset_version'] = {
                 'id': instance.next_dataset_version.id,
+                'identifier': instance.next_dataset_version.identifier,
                 'preferred_identifier': instance.next_dataset_version.preferred_identifier,
             }
 
-        if instance.previous_dataset_version:
+        if instance.previous_dataset_version_id:
             res['previous_dataset_version'] = {
                 'id': instance.previous_dataset_version.id,
+                'identifier': instance.previous_dataset_version.identifier,
                 'preferred_identifier': instance.previous_dataset_version.preferred_identifier,
             }
 
-        if instance.new_metadata_version_created_in_current_request \
-                or instance.new_dataset_version_created_in_current_request:
+        if instance.new_dataset_version_created_in_current_request:
             # when a new version is created:
             # 1) inform the view that new versions should be published as a new record.
             #    the view should also remove the key __actions once it is done.
@@ -139,28 +123,17 @@ class CatalogRecordSerializer(CommonSerializer):
             #    created.
             res['__actions'] = {}
 
-            if instance.new_metadata_version_created_in_current_request:
-                res['__actions']['publish_new_version'] = {
-                    'dataset': self.to_representation(instance.next_metadata_version)
-                }
-                res['new_version_created'] = {
-                    'id': instance.next_metadata_version.id,
-                    'metadata_version_identifier': instance.next_metadata_version.metadata_version_identifier,
-                    'version_type': 'metadata'
-                }
-
-            elif instance.new_dataset_version_created_in_current_request:
-                res['__actions']['publish_new_version'] = {
-                    'dataset': self.to_representation(instance.next_dataset_version)
-                }
-                # note: returning metadata_version_identifier even if the new version creatd
-                # is of type 'dataset', to be explicit about the specific record that was created.
-                res['new_version_created'] = {
-                    'id': instance.next_dataset_version.id,
-                    'metadata_version_identifier': instance.next_dataset_version.metadata_version_identifier,
-                    'preferred_identifier': instance.next_dataset_version.preferred_identifier,
-                    'version_type': 'dataset'
-                }
+            res['__actions']['publish_new_version'] = {
+                'dataset': self.to_representation(instance.next_dataset_version)
+            }
+            # note: returning metadata_version_identifier even if the new version creatd
+            # is of type 'dataset', to be explicit about the specific record that was created.
+            res['new_version_created'] = {
+                'id': instance.next_dataset_version.id,
+                'identifier': instance.next_dataset_version.identifier,
+                'preferred_identifier': instance.next_dataset_version.preferred_identifier,
+                'version_type': 'dataset'
+            }
 
         return res
 

--- a/src/metax_api/models/catalog_record.py
+++ b/src/metax_api/models/catalog_record.py
@@ -4,7 +4,7 @@ import logging
 
 from django.conf import settings
 from django.contrib.postgres.fields import JSONField, ArrayField
-from django.db import connection, models
+from django.db import connection, models, transaction
 from django.db.models import Q, Sum
 from django.http import Http404
 from rest_framework.serializers import ValidationError
@@ -20,6 +20,10 @@ from .file import File
 
 DEBUG = settings.DEBUG
 _logger = logging.getLogger(__name__)
+
+
+class DiscardRecord(Exception):
+    pass
 
 
 class AlternateRecordSet(models.Model):
@@ -54,14 +58,9 @@ class DatasetVersionSet(models.Model):
         Return a list of record preferred_identifiers that belong in the same dataset version chain.
         Latest first.
         """
-        records = CatalogRecord.objects \
-            .filter(dataset_version_set_id=self.id, previous_metadata_version_id=None) \
-            .distinct('metadata_version_set_id') \
-            .order_by('metadata_version_set_id', 'date_created')
-
         return [
             { 'preferred_identifier': r.preferred_identifier, 'date_created': r.date_created.astimezone().isoformat() }
-            for r in reversed(records) # unable to order_by -date_created when using distinct()...
+            for r in self.records.all().order_by('-date_created')
         ]
 
     def print_records(self): # pragma: no cover
@@ -69,37 +68,28 @@ class DatasetVersionSet(models.Model):
             print(r.__repr__())
 
 
-class MetadataVersionSet(models.Model):
+class ResearchDatasetVersion(models.Model):
 
-    """
-    A table which contains records that are different metadata versions of each other.
+    date_created = models.DateTimeField()
+    stored_to_pas = models.DateTimeField(null=True)
+    metadata_version_identifier = models.CharField(max_length=200, unique=True)
+    preferred_identifier = models.CharField(max_length=200)
+    research_dataset = JSONField()
+    catalog_record = models.ForeignKey('CatalogRecord', on_delete=models.DO_NOTHING,
+        related_name='research_dataset_versions')
 
-    Note! Does not inherit from model Common, so does not have timestmap fields,
-    and a delete is an actual delete.
-    """
-    id = models.BigAutoField(primary_key=True, editable=False)
+    def __str__(self):
+        return self.__repr__()
 
-    next_dataset_version = models.ForeignKey('self', null=True, on_delete=models.DO_NOTHING,
-        related_name='+', help_text='Link to next dataset version')
-
-    previous_dataset_version = models.ForeignKey('self', null=True, on_delete=models.DO_NOTHING,
-        related_name='+', help_text='Link to previous dataset version')
-
-    def get_listing(self):
-        """
-        Return a list of record metadata_version_identifiers that belong in the same metadata version chain.
-        Latest first.
-        """
-        return [
-            {
-                'metadata_version_identifier': r.metadata_version_identifier,
-                'date_created': r.date_created.astimezone().isoformat()
-            } for r in self.records.order_by('-date_created')
-        ]
-
-    def print_records(self): # pragma: no cover
-        for r in self.records.all():
-            print(r.__repr__())
+    def __repr__(self):
+        return '<%s: %d, cr: %d, metadata_version_identifier: %s, stored_to_pas: %s>' \
+            % (
+                'ResearchDatasetVersion',
+                self.id,
+                self.catalog_record_id,
+                self.metadata_version_identifier,
+                str(self.stored_to_pas),
+            )
 
 
 class CatalogRecordManager(CommonManager):
@@ -115,14 +105,16 @@ class CatalogRecordManager(CommonManager):
             row = kwargs.pop('using_dict')
             if row.get('id', None):
                 kwargs['id'] = row['id']
+            elif row.get('identifier', None):
+                kwargs['identifier'] = row['identifier']
             elif row.get('research_dataset', None) and row['research_dataset'].get('metadata_version_identifier', None):
+                # todo probably remove at some point
                 kwargs['research_dataset__contains'] = {
                     'metadata_version_identifier': row['research_dataset']['metadata_version_identifier']
                 }
             else:
                 raise ValidationError(
-                    'this operation requires an identifying key to be present: '
-                    'id, or research_dataset ->> metadata_version_identifier')
+                    'this operation requires an identifying key to be present: id, or identifier')
         return super(CatalogRecordManager, self).get(*args, **kwargs)
 
     def get_id(self, metadata_version_identifier=None): # pragma: no cover
@@ -182,6 +174,8 @@ class CatalogRecord(Common):
 
     files = models.ManyToManyField(File)
 
+    identifier = models.CharField(max_length=200, unique=True, null=False)
+
     mets_object_identifier = ArrayField(models.CharField(max_length=200), null=True)
 
     editor = JSONField(null=True, help_text='Editor specific fields, such as owner_id, modified, record_identifier')
@@ -199,15 +193,11 @@ class CatalogRecord(Common):
 
     research_dataset = JSONField()
 
-    next_metadata_version = models.OneToOneField('self', on_delete=models.DO_NOTHING, null=True,
+    next_dataset_version = models.OneToOneField('self', on_delete=models.DO_NOTHING, null=True,
         related_name='+')
 
-    previous_metadata_version = models.OneToOneField('self', on_delete=models.DO_NOTHING, null=True,
+    previous_dataset_version = models.OneToOneField('self', on_delete=models.DO_NOTHING, null=True,
         related_name='+')
-
-    metadata_version_set = models.ForeignKey(
-        MetadataVersionSet, on_delete=models.SET_NULL, null=True, related_name='records',
-        help_text='Records which are different metadata versions of each other.')
 
     dataset_version_set = models.ForeignKey(
         DatasetVersionSet, on_delete=models.SET_NULL, null=True, related_name='records',
@@ -233,7 +223,7 @@ class CatalogRecord(Common):
     was created), because if the request is interrupted for whatever reason after publishing,
     the new version will not get created after all, but the publish message already left.
     """
-    new_metadata_version_created_in_current_request = False
+    # new_metadata_version_created_in_current_request = False
     new_dataset_version_created_in_current_request = False
 
     objects = CatalogRecordManager()
@@ -245,6 +235,7 @@ class CatalogRecord(Common):
         super(CatalogRecord, self).__init__(*args, **kwargs)
         self.track_fields(
             'deprecated',
+            'identifier',
             'preservation_state',
             'research_dataset',
             'research_dataset.files',
@@ -274,7 +265,7 @@ class CatalogRecord(Common):
             self._pre_update_operations()
             super(CatalogRecord, self).save(*args, **kwargs)
 
-    def _process_file_changes(self, file_changes):
+    def _process_file_changes(self, file_changes, new_record_id, old_record_id):
         """
         Process any changes in files between versions.
 
@@ -312,7 +303,7 @@ class CatalogRecord(Common):
                     where catalogrecord_id = %s
                     and file_id in %s
                 '''
-                sql_params_copy_files = [self.id, self.previous_metadata_version.id, tuple(files_to_keep)]
+                sql_params_copy_files = [new_record_id, old_record_id, tuple(files_to_keep)]
 
                 if DEBUG:
                     _logger.debug('File ids to keep: %s' % files_to_keep)
@@ -335,7 +326,7 @@ class CatalogRecord(Common):
                         where catalogrecord_id = %s
                     )
                 '''
-                sql_params_copy_dirs = [self.id, self.previous_metadata_version.id]
+                sql_params_copy_dirs = [new_record_id, old_record_id]
 
                 copy_dirs_sql = []
 
@@ -344,7 +335,7 @@ class CatalogRecord(Common):
                         copy_dirs_sql.append("(f.project_identifier = %s and f.file_path like (%s || '/%%'))")
                         sql_params_copy_dirs.extend([project, dir_path])
 
-                sql_params_copy_dirs.extend([self.id])
+                sql_params_copy_dirs.extend([new_record_id])
 
                 sql_copy_dirs_from_prev_version = sql_copy_dirs_from_prev_version.replace(
                     'COMPARE_PROJECT_AND_FILE_PATHS',
@@ -384,7 +375,7 @@ class CatalogRecord(Common):
                         where catalogrecord_id = %s
                     )
                 '''
-                sql_params_insert_dirs = [self.id]
+                sql_params_insert_dirs = [new_record_id]
 
                 add_dirs_sql = []
 
@@ -398,7 +389,7 @@ class CatalogRecord(Common):
                     ' or '.join(add_dirs_sql)
                 )
 
-                sql_params_insert_dirs.extend([self.id])
+                sql_params_insert_dirs.extend([new_record_id])
 
                 if DEBUG:
                     _logger.debug('Directory paths to add, by project:')
@@ -424,7 +415,7 @@ class CatalogRecord(Common):
                         where catalogrecord_id = %s
                     )
                 '''
-                sql_params_insert_single = [self.id, tuple(files_to_add), self.id]
+                sql_params_insert_single = [new_record_id, tuple(files_to_add), new_record_id]
 
                 if DEBUG:
                     _logger.debug('File ids to add: %s' % files_to_add)
@@ -443,10 +434,10 @@ class CatalogRecord(Common):
                 ) as compare_old_to_new
             '''
             sql_params_files_changed = [
-                self.id,
-                self.previous_metadata_version_id,
-                self.previous_metadata_version_id,
-                self.id
+                new_record_id,
+                old_record_id,
+                old_record_id,
+                new_record_id
             ]
 
             with connection.cursor() as cr:
@@ -467,27 +458,12 @@ class CatalogRecord(Common):
                 # fetchall() returns i.e. [(False, ), (True, )] or just [(False, )]
                 actual_files_changed = any(v[0] for v in cr.fetchall())
 
-            self._calculate_total_ida_byte_size()
-
             if DEBUG:
                 _logger.debug('Actual files changed during version change: %s' % str(actual_files_changed))
         else:
-            # no files to specifically add or remove - just copy all from previous version
-
-            _logger.debug('No files changes detected between versions - copying files from previous version')
-
-            sql_copy_files_from_prev_version = '''
-                insert into metax_api_catalogrecord_files (catalogrecord_id, file_id)
-                select %s as catalogrecord_id, file_id
-                from metax_api_catalogrecord_files
-                where catalogrecord_id = %s
-            '''
-            with connection.cursor() as cr:
-                cr.execute(sql_copy_files_from_prev_version, [self.id, self.previous_metadata_version.id])
-
-            if 'total_ida_byte_size' in self.previous_metadata_version.research_dataset:
-                self.research_dataset['total_ida_byte_size'] = \
-                    self.previous_metadata_version.research_dataset['total_ida_byte_size']
+            # no files to specifically add or remove - do nothing. shouldnt even be here. the new record
+            # created will be discarded
+            return False
 
         return actual_files_changed
 
@@ -624,10 +600,10 @@ class CatalogRecord(Common):
         another directory included in the PREVIOUS VERSION dataset selected directories.
         """
         if not hasattr(self, '_previous_highest_level_dirs_by_project'):
-            if 'directories' not in self.previous_metadata_version.research_dataset:
+            if 'directories' not in self._initial_data['research_dataset']:
                 return False
             dir_identifiers = [
-                d['identifier'] for d in self.previous_metadata_version.research_dataset['directories']
+                d['identifier'] for d in self._initial_data['research_dataset']['directories']
             ]
             self._previous_highest_level_dirs_by_project = self._get_top_level_parent_dirs_by_project(dir_identifiers)
         return any(
@@ -669,33 +645,18 @@ class CatalogRecord(Common):
     def has_alternate_records(self):
         return bool(self.alternate_record_set)
 
-    def has_versions(self):
-        return bool(self.metadata_version_set)
-
-    def has_newer_dataset_versions(self):
-        return self.metadata_version_set_id and self.metadata_version_set.next_dataset_version_id
-
-    @property
-    def next_dataset_version(self):
-        """
-        Find the next known dataset version, if any, and return its latest valid metadata version record.
-        """
-        try:
-            cr = self.metadata_version_set.next_dataset_version.records.order_by('-date_created').first()
-        except:
-            return None
-        return cr or None
-
-    @property
-    def previous_dataset_version(self):
-        """
-        Find the previous known dataset version, if any, and return its latest valid metadata version record.
-        """
-        try:
-            cr = self.metadata_version_set.previous_dataset_version.records.order_by('-date_created').first()
-        except:
-            return None
-        return cr or None
+    def get_metadata_version_listing(self):
+        entries = []
+        for entry in self.research_dataset_versions.all():
+            entries.append({
+                'id': entry.id,
+                'date_created': entry.date_created,
+                'metadata_version_identifier': entry.metadata_version_identifier,
+            })
+            if entry.stored_to_pas:
+                # dont include null values
+                entries[-1]['stored_to_pas'] = entry.stored_to_pas
+        return entries
 
     def _pre_create_operations(self):
         if self.catalog_is_harvested():
@@ -708,15 +669,13 @@ class CatalogRecord(Common):
 
         self.research_dataset['metadata_version_identifier'] = generate_identifier()
 
+        self.identifier = generate_identifier()
+
         if 'remote_resources' in self.research_dataset:
             self._calculate_total_remote_resources_byte_size()
 
     def _post_create_operations(self):
         if self.catalog_versions_datasets():
-            mvs = MetadataVersionSet()
-            mvs.save()
-            mvs.records.add(self)
-
             dvs = DatasetVersionSet()
             dvs.save()
             dvs.records.add(self)
@@ -733,6 +692,10 @@ class CatalogRecord(Common):
             self._create_or_update_alternate_record_set(other_record)
 
     def _pre_update_operations(self):
+        if self.field_changed('identifier'):
+            # read-only
+            self.identifier = self._initial_data['identifier']
+
         if self.field_changed('research_dataset.metadata_version_identifier'):
             # read-only
             self.research_dataset['metadata_version_identifier'] = \
@@ -766,16 +729,10 @@ class CatalogRecord(Common):
 
         if self.catalog_versions_datasets() and not self.preserve_version:
             if self.field_changed('research_dataset'):
-                if self.next_metadata_version_id:
-                    raise ValidationError({ 'detail': [
-                        'modifying metadata of old metadata versions not permitted'
-                    ]})
+                if self._files_changed():
+                    self._create_new_dataset_version()
                 else:
-                    self._create_new_version()
-            else:
-                # edits to any other field than research_dataset are OK even in
-                # old metadata versions of a dataset.
-                pass
+                    self._handle_metadata_versioning()
         else:
             # non-versioning catalogs, such as harvesters, or if an update
             # was forced to occur without version update.
@@ -925,45 +882,107 @@ class CatalogRecord(Common):
 
         return top_level_dirs_by_project
 
-    def _create_new_version(self):
-        """
-        Create a new version of the record who calls this method.
+    def _files_changed(self):
+        file_changes = self._find_file_changes()
+        if False:
+            # can also check presence of added, removed etc and return false immediately
+            pass
 
-        - Creates a new metadata_version_set if required
-        - Sets links next_metadata_version and previous_metadata_version to related objects
-        - Creates a new dataset version if required
+        try:
+            with transaction.atomic():
+                # create temporary record to perform the file changes on, to see if there were real file changes.
+                # if no, discard it. if yes, the temp_record will be transformed into the new dataset version record.
+                temp_record = CatalogRecord.objects.get(pk=self.id)
+                temp_record.id = None
+                temp_record.next_dataset_version = None
+                temp_record.previous_dataset_version = None
+                temp_record.identifier = generate_identifier()
+                temp_record.research_dataset['metadata_version_identifier'] = generate_identifier()
+                super(Common, temp_record).save()
+                actual_files_changed = self._process_file_changes(file_changes, temp_record.id, self.id)
+
+                if actual_files_changed:
+                    self._new_version = temp_record
+                    return True
+                else:
+                    _logger.debug('no real file changes detected, discarding the temporary record...')
+                    raise DiscardRecord()
+        except DiscardRecord:
+            # rolled back
+            pass
+        return False
+
+    def _handle_metadata_versioning(self):
+        if not self.research_dataset_versions.exists():
+            # when a record is initially created, there are no versions.
+            # when the first new version is created, first add the initial version.
+            first_rdv = ResearchDatasetVersion(
+                date_created=self.date_created,
+                metadata_version_identifier=self._initial_data['research_dataset']['metadata_version_identifier'],
+                preferred_identifier=self.preferred_identifier,
+                research_dataset=self._initial_data['research_dataset'],
+                catalog_record=self,
+            )
+            first_rdv.save()
+
+        # create and add the new metadata version
+
+        self.research_dataset['metadata_version_identifier'] = generate_identifier()
+
+        new_rdv = ResearchDatasetVersion(
+            date_created=self.date_modified,
+            metadata_version_identifier=self.research_dataset['metadata_version_identifier'],
+            preferred_identifier=self.preferred_identifier,
+            research_dataset=self.research_dataset,
+            catalog_record=self,
+        )
+        new_rdv.save()
+
+    def _create_new_dataset_version(self):
         """
+        Create a new dataset version of the record who calls this method.
+        """
+        assert hasattr(self, '_new_version'), 'self._new_version should have been set in a previous step'
         old_version = self
-        _logger.info('Creating new version from CatalogRecord %s...' % old_version.metadata_version_identifier)
 
-        if not old_version.metadata_version_set_id:
-            mvs = MetadataVersionSet()
-            mvs.save()
-            mvs.records.add(old_version)
+        if old_version.next_dataset_version_id:
+            raise ValidationError({ 'detail': ['Changing files in old dataset versions is not permitted.'] })
+            _logger.info(
+                'Files changed during CatalogRecord update. Creating new dataset version '
+                'from CatalogRecord %s...' % old_version.metadata_version_identifier
+            )
 
-        new_version = CatalogRecord.objects.get(pk=old_version.id)
-        new_version.id = None # setting id to None creates a new record
+        new_version = self._new_version
         new_version.contract = None
         new_version.date_created = old_version.date_modified
-        new_version.date_modified = old_version.date_modified
-        new_version.next_metadata_version = None
+        new_version.date_modified = None
         new_version.user_created = old_version.user_modified
-        new_version.user_modified = old_version.user_modified
+        new_version.user_modified = None
         new_version.preservation_description = None
         new_version.preservation_state = 0
         new_version.preservation_state_modified = None
-        new_version.previous_metadata_version_id = old_version.id
-        # note: copying research_dataset from the currently open instance 'old_version',
-        # contains the new field data from the request. this effectively transfers
-        # the changes to the new
-        new_version.research_dataset = deepcopy(old_version.research_dataset)
-        new_version.research_dataset.pop('metadata_version_identifier')
+        new_version.previous_dataset_version_id = old_version.id
+        new_version.next_dataset_version_id = None
         new_version.service_created = old_version.service_modified or old_version.service_created
         new_version.service_modified = None
+        new_version.alternate_record_set = None
+        new_version.dataset_version_set.records.add(new_version)
+
+        # note: copying research_dataset from the currently open instance 'old_version',
+        # contains the new field data from the request. this effectively transfers
+        # the changes to the new dataset version.
+        new_version.research_dataset = deepcopy(old_version.research_dataset)
+        new_version.research_dataset['metadata_version_identifier'] = generate_identifier()
+        new_version.research_dataset['preferred_identifier'] = generate_identifier()
+        new_version._calculate_total_ida_byte_size()
+
+        if 'remote_resources' in new_version.research_dataset:
+            new_version._calculate_total_remote_resources_byte_size()
 
         # nothing must change in the now old version of research_dataset, so copy
         # from _initial_data so that super().save() does not change it later.
         old_version.research_dataset = deepcopy(old_version._initial_data['research_dataset'])
+        old_version.next_dataset_version_id = new_version.id
 
         if new_version.editor:
             # some of the old editor fields cant be true in the new version, so keep
@@ -976,73 +995,13 @@ class CatalogRecord(Common):
             if 'creator_id' in old_editor:
                 new_version.editor['creator_id'] = old_editor['creator_id']
             if 'identifier' in old_editor:
+                # todo this probably does not make sense... ?
                 new_version.editor['identifier'] = old_editor['identifier']
 
-        if 'remote_resources' in new_version.research_dataset:
-            new_version._calculate_total_remote_resources_byte_size()
+        super(Common, new_version).save()
 
-        new_version.research_dataset['metadata_version_identifier'] = generate_identifier()
-
-        file_changes = new_version._find_file_changes()
-
-        # note: save() updates new_version._initial_data with data received from the request, so after this
-        # point checking changed fields need to be compared with new_version.previous_metadata_version, instead of
-        # new_version._initial_data, which is what field_changed() would do.
-        super(CatalogRecord, new_version).save()
-
-        # files can be processed only after creating the new version in the db, because
-        # the new record's id is needed for relations.
-        actual_files_changed = new_version._process_file_changes(file_changes)
-
-        if actual_files_changed:
-
-            if old_version.has_newer_dataset_versions():
-                raise ValidationError({ 'detail': ['Changing files in old dataset versions is not permitted.'] })
-
-            # new dataset version
-            _logger.info('Files changed during CatalogRecord update. Creating new dataset version...')
-
-            # break connection to old MetadataVersionSet, and create a new MetadataVersionSet for
-            # the new dataset version, and its coming different metadata versions.
-            new_version.metadata_version_set_id = None
-            new_version.previous_metadata_version_id = None
-            new_version.alternate_record_set = None
-
-            # create new metadata_version_set and set links...
-            mvs = MetadataVersionSet()
-            mvs.previous_dataset_version_id = old_version.metadata_version_set_id
-            mvs.save()
-            mvs.records.add(new_version)
-
-            # update old metadata_version_set links...
-            old_version.metadata_version_set.next_dataset_version_id = mvs.id
-            old_version.metadata_version_set.save()
-
-            new_version.research_dataset['preferred_identifier'] = generate_identifier()
-
-            # old_version is the one that is returned to the requestor from the api
-            old_version.new_dataset_version_created_in_current_request = True
-        else:
-            # new metadata version - new version automatically belongs to the same metadata_version_set
-
-            old_version.next_metadata_version_id = new_version.id
-
-            if new_version.has_alternate_records():
-                # note: this new version was implicitly placed in the same
-                # alternate_record_set as the previous version.
-
-                # remove previous previous version from alternate_record_set.
-                # alternate_record_set should always have the newest versions
-                # of records holding a specific preferred_identifier.
-                old_version.alternate_record_set = None
-
-            # old_version is the one that is returned to the requestor from the api
-            old_version.new_metadata_version_created_in_current_request = True
-
-        new_version.dataset_version_set.records.add(new_version)
-
-        super(CatalogRecord, new_version).save()
-        _logger.info('New CatalogRecord object %s created' % new_version.metadata_version_identifier)
+        _logger.info('New dataset version %s created' % new_version.preferred_identifier)
+        old_version.new_dataset_version_created_in_current_request = True
 
     def _get_metadata_file_changes(self):
         """

--- a/src/metax_api/services/catalog_record_service.py
+++ b/src/metax_api/services/catalog_record_service.py
@@ -55,7 +55,7 @@ class CatalogRecordService(CommonService, ReferenceDataMixin):
             queryset_search_params['preservation_state__in'] = state_vals
 
         if CommonService.get_boolean_query_param(request, 'latest'):
-            queryset_search_params['next_metadata_version_id'] = None
+            queryset_search_params['next_dataset_version_id'] = None
 
         if request.query_params.get('curator', False):
             queryset_search_params['research_dataset__contains'] = \

--- a/src/metax_api/services/file_service.py
+++ b/src/metax_api/services/file_service.py
@@ -55,7 +55,7 @@ class FileService(CommonService):
     def get_datasets_where_file_belongs_to(cls, file_identifiers):
         """
         Find out which (non-deprecated) datasets a list of files belongs to, and return
-        their metadata_version_identifiers as a list. Includes only latest versions of datasets.
+        their preferred_identifiers as a list.
 
         Parameter file_identifiers can be a list of pk's (integers), or file identifiers (strings).
         """
@@ -70,23 +70,23 @@ class FileService(CommonService):
         file_ids = cls._file_identifiers_to_ids(file_identifiers)
 
         sql_select_related_records = """
-            select research_dataset->>'metadata_version_identifier' as metadata_version_identifier
+            select research_dataset->>'preferred_identifier' as preferred_identifier
             from metax_api_catalogrecord cr
             inner join metax_api_catalogrecord_files cr_f on catalogrecord_id = cr.id
             where cr_f.file_id in %s and cr.removed = false and cr.active = true
-            group by metadata_version_identifier
+            group by preferred_identifier
             """
 
         with connection.cursor() as cr:
             cr.execute(sql_select_related_records, [tuple(file_ids)])
             if cr.rowcount == 0:
-                metadata_version_identifiers = []
+                preferred_identifiers = []
                 _logger.info('No datasets found for files')
             else:
-                metadata_version_identifiers = [ row[0] for row in cr.fetchall() ]
-                _logger.info('Found following datasets:\n%s' % '\n'.join(metadata_version_identifiers))
+                preferred_identifiers = [ row[0] for row in cr.fetchall() ]
+                _logger.info('Found following datasets:\n%s' % '\n'.join(preferred_identifiers))
 
-        return Response(metadata_version_identifiers, status=status.HTTP_200_OK)
+        return Response(preferred_identifiers, status=status.HTTP_200_OK)
 
     @classmethod
     def destroy_single(cls, file):

--- a/src/metax_api/tests/api/rest/base/views/common/read.py
+++ b/src/metax_api/tests/api/rest/base/views/common/read.py
@@ -104,19 +104,19 @@ class ApiReadHTTPHeaderTests(CatalogRecordApiReadCommon):
 
         if_modified_since_header_value = date_modified_in_gmt.strftime('%a, %d %b %Y %H:%M:%S GMT')
         headers = {'HTTP_IF_MODIFIED_SINCE': if_modified_since_header_value}
-        response = self.client.get('/rest/datasets/%s' % self.metadata_version_identifier, **headers)
+        response = self.client.get('/rest/datasets/%s' % self.identifier, **headers)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
         if_modified_since_header_value = (date_modified_in_gmt + timedelta(seconds=1)).strftime(
             '%a, %d %b %Y %H:%M:%S GMT')
         headers = {'HTTP_IF_MODIFIED_SINCE': if_modified_since_header_value}
-        response = self.client.get('/rest/datasets/%s' % self.metadata_version_identifier, **headers)
+        response = self.client.get('/rest/datasets/%s' % self.identifier, **headers)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
         if_modified_since_header_value = (date_modified_in_gmt - timedelta(seconds=1)).strftime(
             '%a, %d %b %Y %H:%M:%S GMT')
         headers = {'HTTP_IF_MODIFIED_SINCE': if_modified_since_header_value}
-        response = self.client.get('/rest/datasets/%s' % self.metadata_version_identifier, **headers)
+        response = self.client.get('/rest/datasets/%s' % self.identifier, **headers)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_get_with_if_modified_since_header_syntax_error(self):
@@ -126,7 +126,7 @@ class ApiReadHTTPHeaderTests(CatalogRecordApiReadCommon):
 
         if_modified_since_header_value = date_modified_in_gmt.strftime('%a, %d %b %Y %H:%M:%S UTC')
         headers = {'HTTP_IF_MODIFIED_SINCE': if_modified_since_header_value}
-        response = self.client.get('/rest/datasets/%s' % self.metadata_version_identifier, **headers)
+        response = self.client.get('/rest/datasets/%s' % self.identifier, **headers)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     #

--- a/src/metax_api/tests/api/rest/base/views/common/write.py
+++ b/src/metax_api/tests/api/rest/base/views/common/write.py
@@ -38,6 +38,7 @@ class ApiWriteCommon(APITestCase, TestClassUtils):
             "preferred_identifier": None,
         })
         record_from_test_data.pop('id', None)
+        record_from_test_data.pop('identifier', None)
         record_from_test_data.pop('contract', None)
         return record_from_test_data
 
@@ -190,6 +191,7 @@ class ApiWriteAtomicBulkOperations(CatalogRecordApiWriteCommon):
     def test_atomic_create(self):
         cr = self.client.get('/rest/datasets/1', format="json").data
         cr.pop('id')
+        cr.pop('identifier')
         cr['research_dataset'].pop('metadata_version_identifier')
         cr['research_dataset'].pop('preferred_identifier')
         cr2 = deepcopy(cr)
@@ -227,5 +229,5 @@ class ApiWriteAtomicBulkOperations(CatalogRecordApiWriteCommon):
 
         cr = self.client.get('/rest/datasets/1', format="json").data
         cr2 = self.client.get('/rest/datasets/2', format="json").data
-        self.assertEqual('next_metadata_version' in cr, False)
-        self.assertEqual('next_metadata_version' in cr2, False)
+        self.assertEqual(cr['research_dataset']['title']['en'] == 'updated', False)
+        self.assertEqual(cr2['research_dataset']['title']['en'] == 'updated', False)

--- a/src/metax_api/tests/api/rest/base/views/datasets/write.py
+++ b/src/metax_api/tests/api/rest/base/views/datasets/write.py
@@ -21,8 +21,8 @@ class CatalogRecordApiWriteCommon(APITestCase, TestClassUtils):
         """
         call_command('loaddata', test_data_file_path, verbosity=0)
         catalog_record_from_test_data = self._get_object_from_test_data('catalogrecord')
-        self.mvi = catalog_record_from_test_data['research_dataset']['metadata_version_identifier']
         self.preferred_identifier = catalog_record_from_test_data['research_dataset']['preferred_identifier']
+        self.identifier = catalog_record_from_test_data['identifier']
         self.pk = catalog_record_from_test_data['id']
 
         """
@@ -39,11 +39,9 @@ class CatalogRecordApiWriteCommon(APITestCase, TestClassUtils):
     def update_record(self, record):
         return self.client.put('/rest/datasets/%d' % record['id'], record, format="json")
 
-    def get_next_version(self, record, version_type):
-        version_field = 'next_%s_version' % version_type
-        if version_field not in record:
-            raise Exception('record has no next %s version' % version_type)
-        response = self.client.get('/rest/datasets/%d' % record[version_field]['id'], format="json")
+    def get_next_version(self, record):
+        self.assertEqual('next_dataset_version' in record, True)
+        response = self.client.get('/rest/datasets/%d' % record['next_dataset_version']['id'], format="json")
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
         return response.data
 
@@ -93,6 +91,7 @@ class CatalogRecordApiWriteCommon(APITestCase, TestClassUtils):
         })
         catalog_record_from_test_data['research_dataset'].pop('preferred_identifier', None)
         catalog_record_from_test_data['research_dataset'].pop('metadata_version_identifier', None)
+        catalog_record_from_test_data.pop('identifier', None)
         return catalog_record_from_test_data
 
     def _get_new_test_cr_data_with_updated_identifier(self):
@@ -125,6 +124,7 @@ class CatalogRecordApiWriteCommon(APITestCase, TestClassUtils):
         })
         cr_from_test_data['research_dataset'].pop('metadata_version_identifier')
         cr_from_test_data['research_dataset'].pop('preferred_identifier')
+        cr_from_test_data.pop('identifier')
         return cr_from_test_data
 
 class CatalogRecordApiWriteCreateTests(CatalogRecordApiWriteCommon):
@@ -698,7 +698,7 @@ class CatalogRecordApiWritePartialUpdateTests(CatalogRecordApiWriteCommon):
         new_data = {
             "data_catalog": new_data_catalog,
         }
-        response = self.client.patch('/rest/datasets/%s' % self.mvi, new_data, format="json")
+        response = self.client.patch('/rest/datasets/%s' % self.identifier, new_data, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
         self.assertEqual('research_dataset' in response.data.keys(), True, 'PATCH operation should return full content')
@@ -775,7 +775,7 @@ class CatalogRecordApiWriteDeleteTests(CatalogRecordApiWriteCommon):
     #
 
     def test_delete_catalog_record(self):
-        url = '/rest/datasets/%s' % self.mvi
+        url = '/rest/datasets/%s' % self.identifier
         response = self.client.delete(url)
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         response = self.client.get(url)
@@ -784,8 +784,7 @@ class CatalogRecordApiWriteDeleteTests(CatalogRecordApiWriteCommon):
         deleted_catalog_record = None
 
         try:
-            deleted_catalog_record = CatalogRecord.objects.get(
-                research_dataset__contains={'metadata_version_identifier': self.mvi})
+            deleted_catalog_record = CatalogRecord.objects.get(identifier=self.identifier)
         except CatalogRecord.DoesNotExist:
             pass
 
@@ -793,13 +792,12 @@ class CatalogRecordApiWriteDeleteTests(CatalogRecordApiWriteCommon):
             raise Exception('Deleted CatalogRecord should not be retrievable from the default objects table')
 
         try:
-            deleted_catalog_record = CatalogRecord.objects_unfiltered.get(
-                research_dataset__contains={'metadata_version_identifier': self.mvi})
+            deleted_catalog_record = CatalogRecord.objects_unfiltered.get(identifier=self.identifier)
         except CatalogRecord.DoesNotExist:
             raise Exception('Deleted CatalogRecord should not be deleted from the db, but marked as removed')
 
         self.assertEqual(deleted_catalog_record.removed, True)
-        self.assertEqual(deleted_catalog_record.metadata_version_identifier, self.mvi)
+        self.assertEqual(deleted_catalog_record.identifier, self.identifier)
 
     def test_delete_catalog_record_error_using_preferred_identifier(self):
         url = '/rest/datasets/%s' % self.preferred_identifier
@@ -839,7 +837,7 @@ class CatalogRecordApiWriteProposeToPasTests(CatalogRecordApiWriteCommon):
 
         response = self.client.post('/rest/datasets/%s/proposetopas?state=%d&contract=%s' %
                                     (
-                                        self.mvi,
+                                        self.identifier,
                                         CatalogRecord.PRESERVATION_STATE_PROPOSED_MIDTERM,
                                         self._get_object_from_test_data('contract', requested_index=0)['contract_json'][
                                             'identifier']
@@ -853,7 +851,7 @@ class CatalogRecordApiWriteProposeToPasTests(CatalogRecordApiWriteCommon):
     def test_catalog_record_propose_to_pas_missing_parameter_state(self):
         response = self.client.post('/rest/datasets/%s/proposetopas?contract=%s' %
                                     (
-                                        self.mvi,
+                                        self.identifier,
                                         self._get_object_from_test_data('contract', requested_index=0)['contract_json'][
                                             'identifier']
                                     ),
@@ -865,7 +863,7 @@ class CatalogRecordApiWriteProposeToPasTests(CatalogRecordApiWriteCommon):
     def test_catalog_record_propose_to_pas_wrong_parameter_state(self):
         response = self.client.post('/rest/datasets/%s/proposetopas?state=%d&contract=%s' %
                                     (
-                                        self.mvi,
+                                        self.identifier,
                                         15,
                                         self._get_object_from_test_data('contract', requested_index=0)['contract_json'][
                                             'identifier']
@@ -878,7 +876,7 @@ class CatalogRecordApiWriteProposeToPasTests(CatalogRecordApiWriteCommon):
     def test_catalog_record_propose_to_pas_missing_parameter_contract(self):
         response = self.client.post('/rest/datasets/%s/proposetopas?state=%s' %
                                     (
-                                        self.mvi,
+                                        self.identifier,
                                         CatalogRecord.PRESERVATION_STATE_PROPOSED_MIDTERM,
                                     ),
                                     format="json")
@@ -892,7 +890,7 @@ class CatalogRecordApiWriteProposeToPasTests(CatalogRecordApiWriteCommon):
 
         response = self.client.post('/rest/datasets/%s/proposetopas?state=%d&contract=%s' %
                                     (
-                                        self.mvi,
+                                        self.identifier,
                                         CatalogRecord.PRESERVATION_STATE_PROPOSED_MIDTERM,
                                         'does-not-exist'
                                     ),
@@ -907,7 +905,7 @@ class CatalogRecordApiWriteProposeToPasTests(CatalogRecordApiWriteCommon):
         catalog_record_before.save()
 
         response = self.client.post('/rest/datasets/%s/proposetopas?state=%d&contract=%s' %
-                                    (self.mvi, CatalogRecord.PRESERVATION_STATE_PROPOSED_MIDTERM,
+                                    (self.identifier, CatalogRecord.PRESERVATION_STATE_PROPOSED_MIDTERM,
                                      self._get_object_from_test_data('contract', requested_index=0)['contract_json'][
                                          'identifier']), format="json")
 
@@ -1345,20 +1343,20 @@ class CatalogRecordApiWriteAlternateRecords(CatalogRecordApiWriteCommon):
         For a particular record, the set should not contain its own metadata_version_identifier in the set.
         """
         self.cr_test_data['data_catalog'] = 3
-        msg_self_should_not_be_listed = 'metadata_version_identifier of the record itself should not be listed'
+        msg_self_should_not_be_listed = 'identifier of the record itself should not be listed'
 
         response_1 = self.client.post('/rest/datasets', self.cr_test_data, format="json")
         response_2 = self.client.get('/rest/datasets/1', format="json")
         self.assertEqual(response_1.status_code, status.HTTP_201_CREATED)
         self.assertEqual('alternate_record_set' in response_1.data, True)
         self.assertEqual(
-            response_1.data['research_dataset']['metadata_version_identifier']
+            response_1.data['identifier']
             not in response_1.data['alternate_record_set'],
             True,
             msg_self_should_not_be_listed
         )
         self.assertEqual(
-            response_2.data['research_dataset']['metadata_version_identifier']
+            response_2.data['identifier']
             in response_1.data['alternate_record_set'],
             True
         )
@@ -1368,17 +1366,17 @@ class CatalogRecordApiWriteAlternateRecords(CatalogRecordApiWriteCommon):
         self.assertEqual(response_3.status_code, status.HTTP_201_CREATED)
         self.assertEqual('alternate_record_set' in response_3.data, True)
         self.assertEqual(
-            response_1.data['research_dataset']['metadata_version_identifier']
+            response_1.data['identifier']
             in response_3.data['alternate_record_set'],
             True
         )
         self.assertEqual(
-            response_2.data['research_dataset']['metadata_version_identifier']
+            response_2.data['identifier']
             in response_3.data['alternate_record_set'],
             True
         )
         self.assertEqual(
-            response_3.data['research_dataset']['metadata_version_identifier']
+            response_3.data['identifier']
             not in response_3.data['alternate_record_set'],
             True,
             msg_self_should_not_be_listed
@@ -1387,17 +1385,17 @@ class CatalogRecordApiWriteAlternateRecords(CatalogRecordApiWriteCommon):
         response_2 = self.client.get('/rest/datasets/1', format="json")
         self.assertEqual('alternate_record_set' in response_2.data, True)
         self.assertEqual(
-            response_1.data['research_dataset']['metadata_version_identifier']
+            response_1.data['identifier']
             in response_2.data['alternate_record_set'],
             True
         )
         self.assertEqual(
-            response_3.data['research_dataset']['metadata_version_identifier']
+            response_3.data['identifier']
             in response_2.data['alternate_record_set'],
             True
         )
         self.assertEqual(
-            response_2.data['research_dataset']['metadata_version_identifier']
+            response_2.data['identifier']
             not in response_2.data['alternate_record_set'],
             True,
             msg_self_should_not_be_listed
@@ -1452,17 +1450,12 @@ class CatalogRecordApiWriteDatasetVersioning(CatalogRecordApiWriteCommon):
         self._set_cr_to_catalog(pk=self.pk, dc=3)
         response = self._get_and_update_title(self.pk)
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
-        self.assertEqual('next_metadata_version' not in response.data, True, response.data)
-        cr = CatalogRecord.objects.get(pk=self.pk)
-        self.assertEqual(cr.next_metadata_version, None)
+        self._assert_metadata_version_count(response.data, 0)
 
     def test_update_to_versioning_catalog_with_preserve_version_parameter_does_not_create_version(self):
         self._set_cr_to_catalog(pk=self.pk, dc=1)
         response = self._get_and_update_title(self.pk, params='?preserve_version')
-        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
-        self.assertEqual('next_metadata_version' not in response.data, True, response.data)
-        cr = CatalogRecord.objects.get(pk=self.pk)
-        self.assertEqual(cr.next_metadata_version, None)
+        self._assert_metadata_version_count(response.data, 0)
 
     def test_preserve_version_parameter_does_not_allow_file_changes(self):
         self._set_cr_to_catalog(pk=self.pk, dc=1)
@@ -1472,68 +1465,25 @@ class CatalogRecordApiWriteDatasetVersioning(CatalogRecordApiWriteCommon):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.data)
         self.assertEqual('not supported' in response.data['detail'][0], True, response.data)
 
-    def test_update_rd_title_creates_new_version(self):
+    def test_update_rd_title_creates_new_metadata_version(self):
         """
-        Updating the title should create a new version, but should not change the
-        preferred_identifier of the new version.
+        Updating the title of metadata should create a new metadata version.
         """
-        self._set_cr_to_catalog(pk=self.pk, dc=1)
-        cr = CatalogRecord.objects.get(pk=self.pk)
-        preferred_identifier_before = cr.preferred_identifier
+        response_1 = self._get_and_update_title(self.pk)
+        self.assertEqual(response_1.status_code, status.HTTP_200_OK, response_1.data)
+        self._assert_metadata_version_count(response_1.data, 2)
 
-        response = self._get_and_update_title(self.pk)
-        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
-        self.assertEqual('next_metadata_version' in response.data, True, response.data)
+        # get list of metadata versions to access contents...
+        response = self.client.get('/rest/datasets/%d/metadata_versions' % response_1.data['id'], format="json")
 
-        old_version, next_metadata_version = self._get_old_and_new_metadata_version(self.pk)
+        response_2 = self.client.get('/rest/datasets/%d/metadata_versions/%s' %
+            (self.pk, response.data[0]['metadata_version_identifier']), format="json")
+        self.assertEqual(response_2.status_code, status.HTTP_200_OK, response_2.data)
+        self.assertEqual('preferred_identifier' in response_2.data, True)
 
-        # new version id in the response is correctly set
-        self.assertEqual(next_metadata_version.id, response.data['next_metadata_version']['id'])
-
-        # information about a new version being created is present
-        self.assertEqual('new_version_created' in response.data, True)
-        self.assertEqual(response.data['new_version_created']['version_type'], 'metadata')
-
-        # pref_id did not change for the previous version
-        self.assertEqual(preferred_identifier_before, old_version.preferred_identifier)
-
-        # pref_id did not change for the new version
-        self.assertEqual(preferred_identifier_before, next_metadata_version.preferred_identifier)
-
-    def test_prevent_update_of_dataset_metadata_in_old_versions(self):
-        """
-        Updating any metadata in a CR which has newer versions available should not be allowed.
-        """
-        self._set_cr_to_catalog(pk=self.pk, dc=1)
-
-        # updates the record, creates a new version
-        response = self._get_and_update_title(self.pk)
-        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
-
-        data = self.client.get('/rest/datasets/%d' % self.pk, format="json").data
-        data['research_dataset']['title']['en'] = 'modified title again'
-
-        # attempt updating the record again, which should result in an error, since it
-        # has newer versions available
-        response = self.client.put('/rest/datasets/%d' % self.pk, data, format="json")
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.data)
-        self.assertEqual('permitted' in response.data['detail'][0], True, response.data)
-
-    def test_update_cr_fields_in_old_versions_is_ok(self):
-        """
-        Updating any OTHER field than metadata in a CR which has newer versions available,
-        is ok.
-        """
-        self._set_cr_to_catalog(pk=self.pk, dc=1)
-
-        # updates the record, creates a new version
-        response = self._get_and_update_title(self.pk)
-        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
-
-        data = { 'preservation_state_description': 'this edit should be ok' }
-        response = self.client.patch('/rest/datasets/%d' % self.pk, data, format="json")
-        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
-        self.assertEqual('new_version_created' in response.data, False)
+        # note! response_1 == cr, response_2 == rd
+        self.assertEqual(response_1.data['research_dataset']['preferred_identifier'],
+            response_2.data['preferred_identifier'])
 
     def test_changing_files_creates_new_dataset_version(self):
         cr = self.client.get('/rest/datasets/1').data
@@ -1541,7 +1491,10 @@ class CatalogRecordApiWriteDatasetVersioning(CatalogRecordApiWriteCommon):
         response = self.client.put('/rest/datasets/1', cr, format="json")
         self.assertEqual('next_dataset_version' in response.data, True)
         self.assertEqual('new_version_created' in response.data, True)
-        self.assertEqual(response.data['new_version_created']['version_type'], 'dataset')
+
+    def _assert_metadata_version_count(self, record, count):
+        response = self.client.get('/rest/datasets/%d/metadata_versions' % record['id'], format="json")
+        self.assertEqual(len(response.data), count)
 
     def _set_cr_to_catalog(self, pk=None, dc=None):
         cr = CatalogRecord.objects.get(pk=pk)
@@ -1558,21 +1511,6 @@ class CatalogRecordApiWriteDatasetVersioning(CatalogRecordApiWriteCommon):
         data = self.client.get('/rest/datasets/%d' % pk, format="json").data
         data['research_dataset']['title']['en'] = 'modified title'
         return self.client.put('/rest/datasets/%d%s' % (pk, params or ''), data, format="json")
-
-    def _get_and_update_preferred_identifier(self, pk, params=None):
-        """
-        Get, modify, and update data for given pk. The modification should cause a new
-        version to be created if the catalog permits.
-
-        Should force preferred_identifier to change.
-        """
-        new_pref_id = 'modified-preferred-identifier'
-        data = self.client.get('/rest/datasets/%d' % pk, format="json").data
-        data['research_dataset']['preferred_identifier'] = new_pref_id
-        return (
-            self.client.put('/rest/datasets/%d%s' % (pk, params or ''), data, format="json"),
-            new_pref_id
-        )
 
     def _get_and_update_files(self, pk, update_preferred_identifier=False, params=None):
         """
@@ -1600,10 +1538,6 @@ class CatalogRecordApiWriteDatasetVersioning(CatalogRecordApiWriteCommon):
                 new_pref_id
             )
         return self.client.put('/rest/datasets/%d%s' % (pk, params or ''), data, format="json")
-
-    def _get_old_and_new_metadata_version(self, pk):
-        old_version = CatalogRecord.objects.get(pk=pk)
-        return old_version, old_version.next_metadata_version
 
 
 class CatalogRecordApiWriteAssignFilesToDataset(CatalogRecordApiWriteCommon):
@@ -1956,7 +1890,7 @@ class CatalogRecordApiWriteAssignFilesToDataset(CatalogRecordApiWriteCommon):
         self._add_directory(original_version, '/TestExperiment/Directory_2/Group_2')
         response = self.update_record(original_version)
         self.assert_preferred_identifier_changed(response, True)
-        new_version = self.get_next_version(response.data, version_type='dataset')
+        new_version = self.get_next_version(response.data)
         self.assert_file_count(new_version, 5)
         self.assert_total_ida_byte_size(new_version, self._single_file_byte_size * 5)
 
@@ -1964,17 +1898,14 @@ class CatalogRecordApiWriteAssignFilesToDataset(CatalogRecordApiWriteCommon):
         # no new files are added
         self._add_directory(new_version, '/TestExperiment/Directory_2/Group_2/Group_2_deeper')
         response = self.update_record(new_version)
-        self.assert_preferred_identifier_changed(response, False)
-        new_version = self.get_next_version(response.data, version_type='metadata')
-        self.assert_file_count(new_version, 5)
-        self.assert_total_ida_byte_size(new_version, self._single_file_byte_size * 5)
+        self.assertEqual('new_dataset_version' in response.data, False)
 
         # add a single new file not included by the previously added directories.
         # new files are added
         self._add_file(new_version, '/TestExperiment/Directory_2/file_14.txt')
         response = self.update_record(new_version)
         self.assert_preferred_identifier_changed(response, True)
-        new_version = self.get_next_version(response.data, version_type='dataset')
+        new_version = self.get_next_version(response.data)
         self.assert_file_count(new_version, 6)
         self.assert_total_ida_byte_size(new_version, self._single_file_byte_size * 6)
 
@@ -1983,7 +1914,7 @@ class CatalogRecordApiWriteAssignFilesToDataset(CatalogRecordApiWriteCommon):
         self._remove_file(new_version, '/TestExperiment/Directory_2/file_14.txt')
         response = self.update_record(new_version)
         self.assert_preferred_identifier_changed(response, True)
-        new_version = self.get_next_version(response.data, version_type='dataset')
+        new_version = self.get_next_version(response.data)
         self.assert_file_count(new_version, 5)
         self.assert_total_ida_byte_size(new_version, self._single_file_byte_size * 5)
 
@@ -1991,28 +1922,19 @@ class CatalogRecordApiWriteAssignFilesToDataset(CatalogRecordApiWriteCommon):
         # new files are not added
         self._add_file(new_version, '/TestExperiment/Directory_2/Group_2/Group_2_deeper/file_11.txt')
         response = self.update_record(new_version)
-        self.assert_preferred_identifier_changed(response, False)
-        new_version = self.get_next_version(response.data, version_type='metadata')
-        self.assert_file_count(new_version, 5)
-        self.assert_total_ida_byte_size(new_version, self._single_file_byte_size * 5)
+        self.assertEqual('new_dataset_version' in response.data, False)
 
         # remove the sub dir added previously. files are also still contained by the other upper dir.
         # files are not removed
         self._remove_directory(new_version, '/TestExperiment/Directory_2/Group_2/Group_2_deeper')
         response = self.update_record(new_version)
-        self.assert_preferred_identifier_changed(response, False)
-        new_version = self.get_next_version(response.data, version_type='metadata')
-        self.assert_file_count(new_version, 5)
-        self.assert_total_ida_byte_size(new_version, self._single_file_byte_size * 5)
+        self.assertEqual('new_dataset_version' in response.data, False)
 
         # remove a previously added file, the file is still contained by the other upper dir.
         # files are not removed
         self._remove_file(new_version, '/TestExperiment/Directory_2/Group_2/Group_2_deeper/file_11.txt')
         response = self.update_record(new_version)
-        self.assert_preferred_identifier_changed(response, False)
-        new_version = self.get_next_version(response.data, version_type='metadata')
-        self.assert_file_count(new_version, 5)
-        self.assert_total_ida_byte_size(new_version, self._single_file_byte_size * 5)
+        self.assertEqual('new_dataset_version' in response.data, False)
 
         # remove the last directory, which should remove the 4 files included by this dir and the sub dir.
         # files are removed.
@@ -2020,7 +1942,7 @@ class CatalogRecordApiWriteAssignFilesToDataset(CatalogRecordApiWriteCommon):
         self._remove_directory(new_version, '/TestExperiment/Directory_2/Group_2')
         response = self.update_record(new_version)
         self.assert_preferred_identifier_changed(response, True)
-        new_version = self.get_next_version(response.data, version_type='dataset')
+        new_version = self.get_next_version(response.data)
         self.assert_file_count(new_version, 1)
         self.assert_total_ida_byte_size(new_version, self._single_file_byte_size * 1)
 
@@ -2047,7 +1969,7 @@ class CatalogRecordApiWriteAssignFilesToDataset(CatalogRecordApiWriteCommon):
         self._add_file(original_version, '/TestExperiment/Directory_2/Group_3/file_90.txt')
         response = self.update_record(original_version)
         self.assert_preferred_identifier_changed(response, True)
-        new_version = self.get_next_version(response.data, version_type='dataset')
+        new_version = self.get_next_version(response.data)
         self.assert_file_count(new_version, 9)
         self.assert_total_ida_byte_size(new_version, self._single_file_byte_size * 9)
 
@@ -2055,7 +1977,7 @@ class CatalogRecordApiWriteAssignFilesToDataset(CatalogRecordApiWriteCommon):
         self._add_directory(new_version, '/TestExperiment/Directory_2/Group_3')
         response = self.update_record(new_version)
         self.assert_preferred_identifier_changed(response, True)
-        new_version = self.get_next_version(response.data, version_type='dataset')
+        new_version = self.get_next_version(response.data)
         self.assert_file_count(new_version, 10)
         self.assert_total_ida_byte_size(new_version, self._single_file_byte_size * 10)
 
@@ -2077,10 +1999,8 @@ class CatalogRecordApiWriteAssignFilesToDataset(CatalogRecordApiWriteCommon):
 
         original_version['research_dataset']['version_notes'] = [str(datetime.now())]
         response = self.update_record(original_version)
-        self.assert_preferred_identifier_changed(response, False)
-        new_version = self.get_next_version(response.data, version_type='metadata')
-        self.assert_file_count(new_version, 8)
-        self.assert_total_ida_byte_size(new_version, self._single_file_byte_size * 8)
+        self.assertEqual('next_dataset_version' in response.data, False)
+        self.assert_file_count(response.data, 8)
 
     def test_removing_top_level_directory_does_not_remove_all_files(self):
         """
@@ -2109,7 +2029,7 @@ class CatalogRecordApiWriteAssignFilesToDataset(CatalogRecordApiWriteCommon):
         self._remove_directory(original_version, '/TestExperiment/Directory_2')
         response = self.update_record(original_version)
         self.assert_preferred_identifier_changed(response, True)
-        new_version = self.get_next_version(response.data, version_type='dataset')
+        new_version = self.get_next_version(response.data)
         self.assert_file_count(new_version, 10)
         self.assert_total_ida_byte_size(new_version, self._single_file_byte_size * 10)
 
@@ -2131,7 +2051,7 @@ class CatalogRecordApiWriteAssignFilesToDataset(CatalogRecordApiWriteCommon):
         self._add_directory(original_version, '/SecondExperiment/Directory_1/Group_1')
         response = self.update_record(original_version)
         self.assert_preferred_identifier_changed(response, True)
-        new_version = self.get_next_version(response.data, version_type='dataset')
+        new_version = self.get_next_version(response.data)
         self.assert_file_count(new_version, 8)
         self.assert_total_ida_byte_size(new_version, self._single_file_byte_size * 8)
 
@@ -2153,7 +2073,7 @@ class CatalogRecordApiWriteAssignFilesToDataset(CatalogRecordApiWriteCommon):
         self._add_directory(original_version, '/TestExperiment/Directory_2/Group_2')
         response = self.update_record(original_version)
         self.assert_preferred_identifier_changed(response, True)
-        new_version = self.get_next_version(response.data, version_type='dataset')
+        new_version = self.get_next_version(response.data)
         self.assert_file_count(new_version, 6)
         self.assert_total_ida_byte_size(new_version, self._single_file_byte_size * 6)
 
@@ -2162,7 +2082,7 @@ class CatalogRecordApiWriteAssignFilesToDataset(CatalogRecordApiWriteCommon):
         self._remove_directory(new_version, '/TestExperiment/Directory_2/Group_2')
         response = self.update_record(new_version)
         self.assert_preferred_identifier_changed(response, True)
-        new_version = self.get_next_version(response.data, version_type='dataset')
+        new_version = self.get_next_version(response.data)
         self.assert_file_count(new_version, 4)
         self.assert_total_ida_byte_size(new_version, self._single_file_byte_size * 4)
 
@@ -2171,7 +2091,7 @@ class CatalogRecordApiWriteAssignFilesToDataset(CatalogRecordApiWriteCommon):
         self._remove_directory(new_version, '/SecondExperiment/Directory_1/Group_1')
         response = self.update_record(new_version)
         self.assert_preferred_identifier_changed(response, True)
-        new_version = self.get_next_version(response.data, version_type='dataset')
+        new_version = self.get_next_version(response.data)
         self.assert_file_count(new_version, 2)
         self.assert_total_ida_byte_size(new_version, self._single_file_byte_size * 2)
 

--- a/src/metax_api/tests/models/catalog_record.py
+++ b/src/metax_api/tests/models/catalog_record.py
@@ -22,8 +22,12 @@ class CatalogRecordModelBasicTest(TestCase, TestClassUtils):
     def setUp(self):
         dataset_from_test_data = self._get_object_from_test_data('catalogrecord')
         self.metadata_version_identifier = dataset_from_test_data['research_dataset']['metadata_version_identifier']
+        self.identifier = dataset_from_test_data['identifier']
 
-    def test_get_by_identifier(self):
+    def test_get_by_identifiers(self):
+        catalog_record = CatalogRecord.objects.get(identifier=self.identifier)
+        self.assertEqual(catalog_record.identifier, self.identifier)
+
         catalog_record = CatalogRecord.objects.get(
             research_dataset__contains={'metadata_version_identifier': self.metadata_version_identifier}
         )

--- a/src/metax_api/tests/testdata/generate_test_data.py
+++ b/src/metax_api/tests/testdata/generate_test_data.py
@@ -503,6 +503,7 @@ def generate_catalog_records(mode, basic_catalog_record_max_rows, data_catalogs_
             new['fields']['data_catalog'] = data_catalog_id
             new['fields']['research_dataset']['metadata_version_identifier'] = generate_test_identifier(cr_type, i)
             new['fields']['research_dataset']['preferred_identifier'] = "pid:urn:preferred:dataset%d" % i
+            new['fields']['identifier'] = generate_test_identifier('cr', i)
             new['fields']['date_modified'] = '2017-06-23T10:07:22Z'
             new['fields']['date_created'] = '2017-05-23T10:07:22Z'
             new['fields']['editor'] = {
@@ -737,6 +738,7 @@ def generate_catalog_records(mode, basic_catalog_record_max_rows, data_catalogs_
         new['fields']['research_dataset']['metadata_version_identifier'] = \
             generate_test_identifier(cr_type, len(test_data_list) + 1)
         new['fields']['research_dataset']['preferred_identifier'] = 'very:unique:urn-%d' % (len(test_data_list) + 1)
+        new['fields']['identifier'] = generate_test_identifier('cr', len(test_data_list) + 1)
 
         if type == 'ida':
             if j in [0, 1]:
@@ -896,6 +898,7 @@ def generate_alt_catalog_records(test_data_list):
     alt_rec['fields']['research_dataset']['preferred_identifier'] = test_data_list[9]['fields']['research_dataset'][
         'preferred_identifier']
     alt_rec['fields']['research_dataset']['metadata_version_identifier'] += '-alt-1'
+    alt_rec['fields']['identifier'] = generate_test_identifier('cr', len(test_data_list) + 1)
     alt_rec['fields']['data_catalog'] = 2
     alt_rec['fields']['alternate_record_set'] = 1
     test_data_list.append(alt_rec)
@@ -906,6 +909,7 @@ def generate_alt_catalog_records(test_data_list):
     alt_rec['fields']['research_dataset']['preferred_identifier'] = test_data_list[9]['fields']['research_dataset'][
         'preferred_identifier']
     alt_rec['fields']['research_dataset']['metadata_version_identifier'] += '-alt-2'
+    alt_rec['fields']['identifier'] = generate_test_identifier('cr', len(test_data_list) + 1)
     alt_rec['fields']['data_catalog'] = 3
     alt_rec['fields']['alternate_record_set'] = 1
     test_data_list.append(alt_rec)

--- a/src/metax_api/tests/testdata/test_data.json
+++ b/src/metax_api/tests/testdata/test_data.json
@@ -5744,6 +5744,7 @@
                 1,
                 2
             ],
+            "identifier": "urn:nbn:fi:att:cr955e904-e3dd-4d7e-99f1-3fed446f96d1",
             "mets_object_identifier": null,
             "preservation_state": 0,
             "preservation_state_modified": null,
@@ -5835,6 +5836,7 @@
                 3,
                 4
             ],
+            "identifier": "urn:nbn:fi:att:cr955e904-e3dd-4d7e-99f1-3fed446f96d2",
             "mets_object_identifier": null,
             "preservation_state": 1,
             "preservation_state_modified": "2017-05-23T10:07:22.559656Z",
@@ -5929,6 +5931,7 @@
                 5,
                 6
             ],
+            "identifier": "urn:nbn:fi:att:cr955e904-e3dd-4d7e-99f1-3fed446f96d3",
             "mets_object_identifier": null,
             "preservation_state": 2,
             "preservation_state_modified": "2017-05-23T10:07:22.559656Z",
@@ -6023,6 +6026,7 @@
                 7,
                 8
             ],
+            "identifier": "urn:nbn:fi:att:cr955e904-e3dd-4d7e-99f1-3fed446f96d4",
             "mets_object_identifier": [
                 "a",
                 "b",
@@ -6121,6 +6125,7 @@
                 9,
                 10
             ],
+            "identifier": "urn:nbn:fi:att:cr955e904-e3dd-4d7e-99f1-3fed446f96d5",
             "mets_object_identifier": [
                 "a",
                 "b",
@@ -6219,6 +6224,7 @@
                 11,
                 12
             ],
+            "identifier": "urn:nbn:fi:att:cr955e904-e3dd-4d7e-99f1-3fed446f96d6",
             "mets_object_identifier": null,
             "preservation_state": 5,
             "preservation_state_modified": "2017-05-23T10:07:22.559656Z",
@@ -6312,6 +6318,7 @@
                 13,
                 14
             ],
+            "identifier": "urn:nbn:fi:att:cr955e904-e3dd-4d7e-99f1-3fed446f96d7",
             "mets_object_identifier": null,
             "preservation_state": 0,
             "preservation_state_modified": null,
@@ -6405,6 +6412,7 @@
                 15,
                 16
             ],
+            "identifier": "urn:nbn:fi:att:cr955e904-e3dd-4d7e-99f1-3fed446f96d8",
             "mets_object_identifier": null,
             "preservation_state": 0,
             "preservation_state_modified": null,
@@ -6495,6 +6503,7 @@
                 17,
                 18
             ],
+            "identifier": "urn:nbn:fi:att:cr955e904-e3dd-4d7e-99f1-3fed446f96d9",
             "mets_object_identifier": null,
             "preservation_state": 0,
             "preservation_state_modified": null,
@@ -6583,6 +6592,7 @@
                 19,
                 20
             ],
+            "identifier": "urn:nbn:fi:att:cr955e904-e3dd-4d7e-99f1-3fed446f9610",
             "mets_object_identifier": null,
             "preservation_state": 0,
             "preservation_state_modified": null,
@@ -6686,6 +6696,7 @@
                 19,
                 20
             ],
+            "identifier": "urn:nbn:fi:att:cr955e904-e3dd-4d7e-99f1-3fed446f9611",
             "research_dataset": {
                 "access_rights": {
                     "access_type": {
@@ -7453,6 +7464,7 @@
                 19,
                 20
             ],
+            "identifier": "urn:nbn:fi:att:cr955e904-e3dd-4d7e-99f1-3fed446f9612",
             "research_dataset": {
                 "access_rights": {
                     "access_type": {
@@ -8288,6 +8300,7 @@
                 114,
                 115
             ],
+            "identifier": "urn:nbn:fi:att:cr955e904-e3dd-4d7e-99f1-3fed446f9613",
             "research_dataset": {
                 "access_rights": {
                     "access_type": {
@@ -9059,6 +9072,7 @@
                 "owner_id": "053bffbcc41edad4853bea91fc42ea18"
             },
             "files": [],
+            "identifier": "urn:nbn:fi:att:cr955e904-e3dd-4d7e-99f1-3fed446f9614",
             "mets_object_identifier": null,
             "preservation_state": 0,
             "preservation_state_modified": null,
@@ -9150,6 +9164,7 @@
                 "owner_id": "053d18ecb29e752cb7a35cd77b34f5fd"
             },
             "files": [],
+            "identifier": "urn:nbn:fi:att:cr955e904-e3dd-4d7e-99f1-3fed446f9615",
             "mets_object_identifier": null,
             "preservation_state": 1,
             "preservation_state_modified": "2017-05-23T10:07:22.559656Z",
@@ -9244,6 +9259,7 @@
                 "owner_id": "05593961536b76fa825281ccaedd4d4f"
             },
             "files": [],
+            "identifier": "urn:nbn:fi:att:cr955e904-e3dd-4d7e-99f1-3fed446f9616",
             "mets_object_identifier": null,
             "preservation_state": 2,
             "preservation_state_modified": "2017-05-23T10:07:22.559656Z",
@@ -9338,6 +9354,7 @@
                 "owner_id": "055ea4dade5ab2145954f56d4b51cef0"
             },
             "files": [],
+            "identifier": "urn:nbn:fi:att:cr955e904-e3dd-4d7e-99f1-3fed446f9617",
             "mets_object_identifier": null,
             "preservation_state": 3,
             "preservation_state_modified": "2017-05-23T10:07:22.559656Z",
@@ -9432,6 +9449,7 @@
                 "owner_id": "055ea531a6cac569425bed94459266ee"
             },
             "files": [],
+            "identifier": "urn:nbn:fi:att:cr955e904-e3dd-4d7e-99f1-3fed446f9618",
             "mets_object_identifier": null,
             "preservation_state": 4,
             "preservation_state_modified": "2017-05-23T10:07:22.559656Z",
@@ -9526,6 +9544,7 @@
                 "owner_id": "053bffbcc41edad4853bea91fc42ea18"
             },
             "files": [],
+            "identifier": "urn:nbn:fi:att:cr955e904-e3dd-4d7e-99f1-3fed446f9619",
             "mets_object_identifier": null,
             "preservation_state": 5,
             "preservation_state_modified": "2017-05-23T10:07:22.559656Z",
@@ -9619,6 +9638,7 @@
                 "owner_id": "053d18ecb29e752cb7a35cd77b34f5fd"
             },
             "files": [],
+            "identifier": "urn:nbn:fi:att:cr955e904-e3dd-4d7e-99f1-3fed446f9620",
             "mets_object_identifier": null,
             "preservation_state": 0,
             "preservation_state_modified": null,
@@ -9712,6 +9732,7 @@
                 "owner_id": "05593961536b76fa825281ccaedd4d4f"
             },
             "files": [],
+            "identifier": "urn:nbn:fi:att:cr955e904-e3dd-4d7e-99f1-3fed446f9621",
             "mets_object_identifier": null,
             "preservation_state": 0,
             "preservation_state_modified": null,
@@ -9805,6 +9826,7 @@
                 "owner_id": "055ea4dade5ab2145954f56d4b51cef0"
             },
             "files": [],
+            "identifier": "urn:nbn:fi:att:cr955e904-e3dd-4d7e-99f1-3fed446f9622",
             "mets_object_identifier": null,
             "preservation_state": 0,
             "preservation_state_modified": null,
@@ -9898,6 +9920,7 @@
                 "owner_id": "055ea531a6cac569425bed94459266ee"
             },
             "files": [],
+            "identifier": "urn:nbn:fi:att:cr955e904-e3dd-4d7e-99f1-3fed446f9623",
             "mets_object_identifier": null,
             "preservation_state": 0,
             "preservation_state_modified": null,
@@ -9988,6 +10011,7 @@
                 "creator_id": "053bffbcc41edad4853bea91fc42ea18",
                 "owner_id": "053bffbcc41edad4853bea91fc42ea18"
             },
+            "identifier": "urn:nbn:fi:att:cr955e904-e3dd-4d7e-99f1-3fed446f9624",
             "research_dataset": {
                 "access_rights": {
                     "access_type": {
@@ -10780,6 +10804,7 @@
                 "creator_id": "053bffbcc41edad4853bea91fc42ea18",
                 "owner_id": "053d18ecb29e752cb7a35cd77b34f5fd"
             },
+            "identifier": "urn:nbn:fi:att:cr955e904-e3dd-4d7e-99f1-3fed446f9625",
             "research_dataset": {
                 "access_rights": {
                     "access_type": {
@@ -11572,6 +11597,7 @@
                 "creator_id": "053bffbcc41edad4853bea91fc42ea18",
                 "owner_id": "05593961536b76fa825281ccaedd4d4f"
             },
+            "identifier": "urn:nbn:fi:att:cr955e904-e3dd-4d7e-99f1-3fed446f9626",
             "research_dataset": {
                 "access_rights": {
                     "access_type": {
@@ -12372,6 +12398,7 @@
                 19,
                 20
             ],
+            "identifier": "urn:nbn:fi:att:cr955e904-e3dd-4d7e-99f1-3fed446f9627",
             "mets_object_identifier": null,
             "preservation_state": 0,
             "preservation_state_modified": null,
@@ -12460,6 +12487,7 @@
                 19,
                 20
             ],
+            "identifier": "urn:nbn:fi:att:cr955e904-e3dd-4d7e-99f1-3fed446f9628",
             "mets_object_identifier": null,
             "preservation_state": 0,
             "preservation_state_modified": null,

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -361,7 +361,7 @@ paths:
           type: string
       responses:
         '200':
-          description: a list of metadata_version_identifiers. if the files were not found to belong to any datasets, an empty list is returned
+          description: a list of preferred_identifiers. if the files were not found to belong to any datasets, an empty list is returned
         '404':
           description: files given in the list not found
       tags:
@@ -758,7 +758,7 @@ paths:
     patch:
       summary: bulk update partial
       description: |
-        The payload must include a field that can be used to identify the resource being updated. Acceptable identifier fields are: <b>id, research_dataset->metadata_version_identifier</b>
+        The payload must include a field that can be used to identify the resource being updated. Acceptable identifier fields are: <b>id, identifier</b>
       consumes:
         - application/json
       parameters:
@@ -773,9 +773,28 @@ paths:
           description: All updates failed. A list of errors is returned.
       tags:
         - Dataset API
-  /datasets/metadata_version_identifiers:
+  /datasets/{PID}/metadata_versions:
     get:
-      summary: "list all dataset metadata version identifiers"
+      summary: "list old research_dataset entries of a record"
+      responses:
+        "200":
+          description: successful operation, return a list of entries. may return an empty list.
+      tags:
+        - Dataset API
+  /datasets/{PID}/metadata_versions/{MVI}:
+    get:
+      summary: "get contents of a specific old research_dataset of a record."
+      description: "{MVI} is the metadata_version_identifier of the research_dataset."
+      responses:
+        "200":
+          description: successful operation, return a list of entries. may return an empty list.
+        "404":
+          description: resource not found.
+      tags:
+        - Dataset API
+  /datasets/identifiers:
+    get:
+      summary: "list all dataset identifiers"
       parameters:
         - name: latest
           in: query


### PR DESCRIPTION
- Instead of creating separate CatalogRecord objects of each new metadata version, always keep modifying the same record, but create a new table ResearchDatasetVersions, where research_dataset field is stored on each update to research_dataset.
- New dataset versions (files change) still create new CatalogRecords.
- Since we are now primarily operating always on the same CR, it does not make sense to use metadata_version_identifier for targeting a specific CR in the API, since it changes after updating research_dataset. Therefore, introduce new field 'identifier' to CatalogRecord, which will be the primary identifier required for interacting with a specific CR using the API. This identifier is located on the root-level of the CR.
- New API /datasets/<pid>/metadata_versions to list old research_dataset entries (this list is no longer included among the other data of a CR from API (previously known as field 'metadata_version_set'))
- New API /datasets/<pid>/metadata_versions/<metadata_version_identifier> to list contents of a specific old research_dataset
- When a new metadata version is created, it is only visible to the API user in that the field metadata_version_identifier content has changed. The field "new_version_created" still needs to be checked, in case new dataset version was created (files changed)
- Associated refactoring, simplification of queries and API's, fixed tests, updated test data...
- Updated swagger, api_schemas...