### PR TITLE
CSCMETAX-333: [REF] preferred_identifier can no longer be used to GET…

### DIFF
--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -670,6 +670,14 @@ paths:
           description: curator identifier (field research_dataset-> curator-> identifier)
           required: false
           type: string
+        - name: preferred_identifier
+          in: query
+          description: |
+            Use given preferred_identifier as filter. Returns a best guess of the record (always a single record!), by
+            looking from Fairdata catalogs first, then from harvested catalogs. If the value of preferred_identifier
+            contains special characters such as ampersands, the value has to be urlencoded.
+          required: false
+          type: string
         - name: state
           in: query
           description: TPAS state (field preservation_state). multiple states using OR-logic are queriable in the same request, e.g. state=5,6. see valid values from http://iow.csc.fi/model/mrd/CatalogRecord/ field preservation_state


### PR DESCRIPTION
… using /datasets/pid. Instead, /datasets?preferred_identifier=pid has to be used. If pid contains special chars such as ampersands (&), the value has to be urlencoded.

There appeared to be some screwup in a previous PR, and the meat of the PR was already included previously. This one only contains an addition to swagger. Nevermind the commit msg