### PR TITLE
CSCMETAX-364: [FIX] Remove empty 'files' and 'directories' arrays fro…

### DIFF
--- a/src/metax_api/api/rest/base/serializers/catalog_record_serializer.py
+++ b/src/metax_api/api/rest/base/serializers/catalog_record_serializer.py
@@ -155,6 +155,14 @@ class CatalogRecordSerializer(CommonSerializer):
         if self._operation_is_create() or self._preferred_identifier_is_changed():
             self._validate_research_dataset_uniqueness(value)
         CRS.validate_reference_data(value, self.context['view'].cache)
+
+        if 'directories' in value and not value['directories']:
+            # remove if empty list
+            del value['directories']
+        if 'files' in value and not value['files']:
+            # remove if empty list
+            del value['files']
+
         return value
 
     def _validate_json_schema(self, value):

--- a/src/metax_api/models/catalog_record.py
+++ b/src/metax_api/models/catalog_record.py
@@ -612,7 +612,7 @@ class CatalogRecord(Common):
             ]
             self._previous_highest_level_dirs_by_project = self._get_top_level_parent_dirs_by_project(dir_identifiers)
         return any(
-            True for dr_path in self._previous_highest_level_dirs_by_project[project]
+            True for dr_path in self._previous_highest_level_dirs_by_project.get(project, [])
             if path != dr_path and path.startswith(dr_path)
         )
 


### PR DESCRIPTION
…m research_dataset during update. Make file handling code more error-proof