### PR TITLE
CSCMETAX 374, 372, 61: Improve testdata

### DIFF
--- a/src/metax_api/tests/api/rest/base/views/datasets/read.py
+++ b/src/metax_api/tests/api/rest/base/views/datasets/read.py
@@ -93,7 +93,6 @@ class CatalogRecordApiReadBasicTests(CatalogRecordApiReadCommon):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertTrue(isinstance(response.data, list))
         self.assertTrue(len(response.data) > 0)
-        self.assertTrue(response.data[0].startswith('urn:'))
 
     def test_get_unique_preferred_identifiers(self):
         """

--- a/src/metax_api/tests/api/rest/base/views/datasets/write.py
+++ b/src/metax_api/tests/api/rest/base/views/datasets/write.py
@@ -170,9 +170,11 @@ class CatalogRecordApiWriteCreateTests(CatalogRecordApiWriteCommon):
         )
 
     def test_create_catalog_contract_string_identifier(self):
-        self.cr_test_data['contract'] = 'optional:contract:identifier1'
+        contract_identifier = Contract.objects.first().contract_json['identifier']
+        self.cr_test_data['contract'] = contract_identifier
         response = self.client.post('/rest/datasets', self.cr_test_data, format="json")
         self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.data)
+        self.assertEqual(response.data['contract']['identifier'], contract_identifier, response.data)
 
     def test_create_catalog_error_contract_string_identifier_not_found(self):
         self.cr_test_data['contract'] = 'doesnotexist'

--- a/src/metax_api/tests/testdata/contract_test_data_template.json
+++ b/src/metax_api/tests/testdata/contract_test_data_template.json
@@ -1,3 +1,41 @@
+[{
+    "contract_json": {
+        "quota": 1000000,
+        "title": "Helsingin yliopiston biotieteiden laitoksen muuttolintujen laskentatulosten säilytyssopimus",
+        "contact": [
+            {
+                "name": "Taito Tieto",
+                "email": "taito.tieto@helsinki.fi",
+                "phone": "+358501231234"
+            },
+            {
+                "name": "Seppo Pykälä",
+                "email": "seppo.pykala'@helsinki.fi",
+                "phone": "+358501231234"
+            }
+        ],
+        "created": "2018-04-05T08:19:58Z",
+        "modified": "2018-04-05T08:19:58Z",
+        "validity": {
+            "start_date": "2018-07-01T00:00:00Z"
+        },
+        "identifier": "urn:uuid:99ddffff-2f73-46b0-92d1-614409d83001",
+        "description": "Muuttolintujen laskentatulosten säilytys",
+        "organization": {
+            "name": "Helsingin Yliopisto",
+            "organization_identifier": "1234567-1"
+        },
+        "related_service": [
+            {
+                "name": "Fairdata-PAS",
+                "identifier": "local:service:id"
+            }
+        ]
+    },
+    "date_modified": "2018-04-05T08:19:58+03:00",
+    "date_created": "2018-04-05T08:19:58+03:00",
+    "service_created": "metax"
+},
 {
   "contract_json": {
     "title": "Title of contract",
@@ -28,4 +66,4 @@
     }
   },
   "service_created": "metax"
-}
+}]

--- a/src/metax_api/tests/testdata/generate_test_data.py
+++ b/src/metax_api/tests/testdata/generate_test_data.py
@@ -501,9 +501,10 @@ def generate_catalog_records(mode, basic_catalog_record_max_rows, data_catalogs_
             # for real tho, required to prevent some strange behaving references to old data
             new['fields']['research_dataset'] = row_template['research_dataset'].copy()
             new['fields']['data_catalog'] = data_catalog_id
-            new['fields']['research_dataset']['metadata_version_identifier'] = generate_test_identifier(cr_type, i)
-            new['fields']['research_dataset']['preferred_identifier'] = "pid:urn:preferred:dataset%d" % i
-            new['fields']['identifier'] = generate_test_identifier('cr', i)
+            new['fields']['research_dataset']['metadata_version_identifier'] = generate_test_identifier(cr_type, i,
+                                                                                                        urn=False)
+            new['fields']['research_dataset']['preferred_identifier'] = generate_test_identifier(cr_type, i)
+            new['fields']['identifier'] = generate_test_identifier('cr', i, urn=False)
             new['fields']['date_modified'] = '2017-06-23T10:07:22Z'
             new['fields']['date_created'] = '2017-05-23T10:07:22Z'
             new['fields']['editor'] = {
@@ -736,9 +737,10 @@ def generate_catalog_records(mode, basic_catalog_record_max_rows, data_catalogs_
         }
 
         new['fields']['research_dataset']['metadata_version_identifier'] = \
+            generate_test_identifier(cr_type, len(test_data_list) + 1, urn=False)
+        new['fields']['research_dataset']['preferred_identifier'] = \
             generate_test_identifier(cr_type, len(test_data_list) + 1)
-        new['fields']['research_dataset']['preferred_identifier'] = 'very:unique:urn-%d' % (len(test_data_list) + 1)
-        new['fields']['identifier'] = generate_test_identifier('cr', len(test_data_list) + 1)
+        new['fields']['identifier'] = generate_test_identifier('cr', len(test_data_list) + 1, urn=False)
 
         if type == 'ida':
             if j in [0, 1]:
@@ -898,7 +900,7 @@ def generate_alt_catalog_records(test_data_list):
     alt_rec['fields']['research_dataset']['preferred_identifier'] = test_data_list[9]['fields']['research_dataset'][
         'preferred_identifier']
     alt_rec['fields']['research_dataset']['metadata_version_identifier'] += '-alt-1'
-    alt_rec['fields']['identifier'] = generate_test_identifier('cr', len(test_data_list) + 1)
+    alt_rec['fields']['identifier'] = generate_test_identifier('cr', len(test_data_list) + 1, urn=False)
     alt_rec['fields']['data_catalog'] = 2
     alt_rec['fields']['alternate_record_set'] = 1
     test_data_list.append(alt_rec)
@@ -909,7 +911,7 @@ def generate_alt_catalog_records(test_data_list):
     alt_rec['fields']['research_dataset']['preferred_identifier'] = test_data_list[9]['fields']['research_dataset'][
         'preferred_identifier']
     alt_rec['fields']['research_dataset']['metadata_version_identifier'] += '-alt-2'
-    alt_rec['fields']['identifier'] = generate_test_identifier('cr', len(test_data_list) + 1)
+    alt_rec['fields']['identifier'] = generate_test_identifier('cr', len(test_data_list) + 1, urn=False)
     alt_rec['fields']['data_catalog'] = 3
     alt_rec['fields']['alternate_record_set'] = 1
     test_data_list.append(alt_rec)

--- a/src/metax_api/tests/testdata/generate_test_data.py
+++ b/src/metax_api/tests/testdata/generate_test_data.py
@@ -284,10 +284,19 @@ def generate_contracts(contract_max_rows, validate_json):
     with open('contract_test_data_template.json') as json_file:
         row_template = json_load(json_file)
 
-    for i in range(1, contract_max_rows + 1):
+    # sample contract provided by PAS
+    new = {
+        'fields': deepcopy(row_template[0]),
+        'model': "metax_api.contract",
+        'pk': 1,
+    }
+    json_validate(new['fields']['contract_json'], json_schema)
+    test_contract_list.append(new)
+
+    for i in range(2, contract_max_rows + 1):
 
         new = {
-            'fields': deepcopy(row_template),
+            'fields': deepcopy(row_template[1]),
             'model': "metax_api.contract",
             'pk': i,
         }

--- a/src/metax_api/tests/testdata/generate_test_data.py
+++ b/src/metax_api/tests/testdata/generate_test_data.py
@@ -1,43 +1,16 @@
-import json
 import os
 import sys
-import time
 from copy import deepcopy
 from json import dump as json_dump
-from json import dumps as json_dumps
 from json import load as json_load
-from uuid import uuid4
-
-import requests
-import urllib3
 from jsonschema import validate as json_validate
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from utils import get_json_schema, generate_test_identifier
 
 """
-Execute this file to generate rows to metax_api_file table. Uses
-file_test_data_template.json as template, and slightly modifies fields each loop.
-
-When sending generated files immediately using requests for the first time, make sure to
-load data from a json-generated list first, because file storages are only generated when
-usind mode=json for now. After that, sending requests will work too because then they can
-use the file_storage from the json-generated file. If you are flushing the db at times,
-remember to load file storages from json-file again.
-
-Data input options:
-
-- Generate rows as a json list to file file_test_data_list.json. Note that manage.py wont
-  handle very large files very well, i.e. dont try to load half a million rows in one file.
-  Execute the following to load the json data to django db:
-  python manage.py loaddata metax_api/tests/file_test_data_list.json
-
-- Send generated rows directly as http POST requests to your api.
-  Optionally send either one by one, or in bulk in one request, or in bulk in batches.
-  Note that nginx max request size restriction applies.
-
-todo:
-- run with proper cmd line parameters ?
+A script to generate test data. Loaded for automated tests, and as content for
+test environments.
 """
 
 # how many file rows to generate
@@ -69,24 +42,8 @@ catalog_records_owner_ids = [
     '055ea531a6cac569425bed94459266ee',
 ]
 
-# mode: json for json-file, request for request per row, request_list for bulk post
-mode = 'json'
-
-# how many rows to send in one request when using request_list.
-# sends requests in batches until all rows sent. value 0 means send all at once
-batch_size = 0
-
 # very slow with a large number of rows. we'll always validate the first loop tho
 validate_json = False
-
-# where to send POST requests if using it
-url = 'https://metax.csc.local/rest/files/'
-
-# print tasty debug information from POST requests
-DEBUG = False
-
-#  to disable self-signed certificate warnings
-urllib3.disable_warnings()
 
 # Location of schema files
 schema_path = os.path.dirname(__file__) + '../api.rest.base/schemas'
@@ -96,38 +53,37 @@ cr_type = 1  # catalog record
 dc_type = 2  # data catalog
 
 
-def generate_file_storages(mode, file_storage_max_rows):
+def generate_file_storages(file_storage_max_rows):
+    print('generating file storages...')
     test_file_storage_list = []
 
-    if mode == 'json':
+    with open('file_storage_test_data_template.json') as json_file:
+        row_template = json_load(json_file)
 
-        with open('file_storage_test_data_template.json') as json_file:
-            row_template = json_load(json_file)
+    title = row_template['file_storage_json']['title']
+    identifier = "pid:urn:storage" + row_template['file_storage_json']['identifier']
 
-        title = row_template['file_storage_json']['title']
-        identifier = "pid:urn:storage" + row_template['file_storage_json']['identifier']
-
-        for i in range(1, file_storage_max_rows + 1):
-            new = {
-                'fields': {
-                    'date_modified': '2017-06-23T10:07:22Z',
-                    'date_created': '2017-05-23T10:07:22Z',
-                    'file_storage_json': {
-                        'title': title % str(i),
-                        'identifier': identifier % str(i),
-                        'url': url,
-                    }
-                },
-                'model': "metax_api.filestorage",
-                'pk': i
-            }
-            test_file_storage_list.append(new)
+    for i in range(1, file_storage_max_rows + 1):
+        new = {
+            'fields': {
+                'date_modified': '2017-06-23T10:07:22Z',
+                'date_created': '2017-05-23T10:07:22Z',
+                'file_storage_json': {
+                    'title': title % str(i),
+                    'identifier': identifier % str(i),
+                    'url': 'https://metax-test.csc.fi/rest/filestorages/%d' % i,
+                }
+            },
+            'model': "metax_api.filestorage",
+            'pk': i
+        }
+        test_file_storage_list.append(new)
 
     return test_file_storage_list
 
 
-def generate_files(mode, test_file_storage_list, validate_json, url):
-    print('generating files%s...' % ('' if mode in ('json', 'request_list') else ' and uploading'))
+def generate_files(test_file_storage_list, validate_json):
+    print('generating files...')
 
     with open('file_test_data_template.json') as json_file:
         row_template = json_load(json_file)
@@ -141,17 +97,7 @@ def generate_files(mode, test_file_storage_list, validate_json, url):
     file_test_data_list = []
     directory_test_data_list = []
     json_schema = get_json_schema('file')
-    total_time_elapsed = 0
-
-    if mode == "json":
-        # use the file storage id from the file storage created previously during this script execution
-        file_storage = test_file_storage_list[0]['pk']
-    else:
-        # with POST requests, new file storages are not generated. instead, it is expected that they have
-        # been already loaded in from previous test data
-        with open('file_test_data_list.json') as old_test_data_file:
-            file_test_data = json_load(old_test_data_file)
-            file_storage = file_test_data[0]['pk']
+    file_storage = test_file_storage_list[0]['pk']
 
     for i in range(1, file_max_rows + 1):
         if i <= 20:
@@ -162,124 +108,72 @@ def generate_files(mode, test_file_storage_list, validate_json, url):
             project_root_folder = 'prj_112_root'
 
         loop = str(i)
-        if mode == 'json':
+        new = {
+            'fields': row_template.copy(),
+            'model': 'metax_api.file',
+        }
 
-            new = {
-                'fields': row_template.copy(),
-                'model': 'metax_api.file',
-            }
+        file_path = row_template['file_path']
 
-            file_path = row_template['file_path']
+        # assing files to different directories to have something to browse
+        if 1 <= i < 6:
+            file_path = file_path.replace('/some/path/', '/{0}/Experiment_X/'.
+                                          format(project_root_folder))
+        elif 6 <= i < 11:
+            file_path = file_path.replace('/some/path/', '/{0}/Experiment_X/Phase_1/'.
+                                          format(project_root_folder))
+        elif 11 <= i <= 20:
+            file_path = file_path.replace('/some/path/', '/{0}/Experiment_X/Phase_1/2017/01/'.
+                                          format(project_root_folder))
+        if i == 21:
+            file_path = file_path.replace('/some/path/', '/{0}/science_data_A/'.
+                                          format(project_root_folder))
+        if 22 <= i < 25:
+            file_path = file_path.replace('/some/path/', '/{0}/science_data_A/phase_1/2018/01/'.
+                                          format(project_root_folder))
+        if i == 25:
+            file_path = file_path.replace('/some/path/', '/{0}/science_data_B/'.
+                                          format(project_root_folder))
+        if i == 26:
+            file_path = file_path.replace('/some/path/', '/{0}/other/items/'.
+                                          format(project_root_folder))
+        if 27 <= i < 30:
+            file_path = file_path.replace('/some/path/', '/{0}/random_folder/'.
+                                          format(project_root_folder))
+        if 30 <= i < 35:
+            file_path = file_path.replace('/some/path/', '/{0}/science_data_C/'.
+                                          format(project_root_folder))
+        elif 35 <= i < 40:
+            file_path = file_path.replace('/some/path/', '/{0}/science_data_C/phase_1/'.
+                                          format(project_root_folder))
+        elif 40 <= i < 50:
+            file_path = file_path.replace('/some/path/', '/{0}/science_data_C/phase_1/2017/01/'.
+                                          format(project_root_folder))
+        elif 50 <= i < 70:
+            file_path = file_path.replace('/some/path/', '/{0}/science_data_C/phase_1/2017/02/'.
+                                          format(project_root_folder))
+        elif 70 <= i <= file_max_rows:
+            file_path = file_path.replace('/some/path/', '/{0}/science_data_C/phase_2/2017/10/'.
+                                          format(project_root_folder))
 
-            # assing files to different directories to have something to browse
-            if 1 <= i < 6:
-                file_path = file_path.replace('/some/path/', '/{0}/Experiment_X/'.
-                                              format(project_root_folder))
-            elif 6 <= i < 11:
-                file_path = file_path.replace('/some/path/', '/{0}/Experiment_X/Phase_1/'.
-                                              format(project_root_folder))
-            elif 11 <= i <= 20:
-                file_path = file_path.replace('/some/path/', '/{0}/Experiment_X/Phase_1/2017/01/'.
-                                              format(project_root_folder))
-            if i == 21:
-                file_path = file_path.replace('/some/path/', '/{0}/science_data_A/'.
-                                              format(project_root_folder))
-            if 22 <= i < 25:
-                file_path = file_path.replace('/some/path/', '/{0}/science_data_A/phase_1/2018/01/'.
-                                              format(project_root_folder))
-            if i == 25:
-                file_path = file_path.replace('/some/path/', '/{0}/science_data_B/'.
-                                              format(project_root_folder))
-            if i == 26:
-                file_path = file_path.replace('/some/path/', '/{0}/other/items/'.
-                                              format(project_root_folder))
-            if 27 <= i < 30:
-                file_path = file_path.replace('/some/path/', '/{0}/random_folder/'.
-                                              format(project_root_folder))
-            if 30 <= i < 35:
-                file_path = file_path.replace('/some/path/', '/{0}/science_data_C/'.
-                                              format(project_root_folder))
-            elif 35 <= i < 40:
-                file_path = file_path.replace('/some/path/', '/{0}/science_data_C/phase_1/'.
-                                              format(project_root_folder))
-            elif 40 <= i < 50:
-                file_path = file_path.replace('/some/path/', '/{0}/science_data_C/phase_1/2017/01/'.
-                                              format(project_root_folder))
-            elif 50 <= i < 70:
-                file_path = file_path.replace('/some/path/', '/{0}/science_data_C/phase_1/2017/02/'.
-                                              format(project_root_folder))
-            elif 70 <= i <= file_max_rows:
-                file_path = file_path.replace('/some/path/', '/{0}/science_data_C/phase_2/2017/10/'.
-                                              format(project_root_folder))
+        directory_id = get_parent_directory_for_path(directories, file_path, directory_test_data_list,
+                                                     project_identifier)
 
-            directory_id = get_parent_directory_for_path(directories, file_path, directory_test_data_list,
-                                                         project_identifier)
+        new['fields']['parent_directory'] = directory_id
+        new['fields']['project_identifier'] = project_identifier
+        new['fields']['file_name'] = file_name % loop
+        new['fields']['file_path'] = file_path % loop
+        new['fields']['identifier'] = "pid:urn:" + loop
+        new['fields']['file_characteristics']['title'] = json_title % loop
+        new['fields']['file_characteristics']['description'] = json_description % loop
+        new['fields']['file_storage'] = file_storage
+        new['fields']['byte_size'] = i * 100
+        new['pk'] = i
 
-            new['fields']['parent_directory'] = directory_id
-            new['fields']['project_identifier'] = project_identifier
-            new['fields']['file_name'] = file_name % loop
-            new['fields']['file_path'] = file_path % loop
-            new['fields']['identifier'] = "pid:urn:" + loop
-            new['fields']['file_characteristics']['title'] = json_title % loop
-            new['fields']['file_characteristics']['description'] = json_description % loop
-            new['fields']['file_storage'] = file_storage
-            new['fields']['byte_size'] = i * 100
-            new['pk'] = i
+        if validate_json or i == 1:
+            json_validate(new['fields']['file_characteristics'], json_schema)
 
-            if validate_json or i == 1:
-                json_validate(new['fields']['file_characteristics'], json_schema)
-
-            file_test_data_list.append(new)
-
-        else:
-            # http POST requests
-
-            new = row_template.copy()
-            uuid_str = str(uuid4())
-
-            new['file_name'] = file_name % loop
-            new['identifier'] = "pid:urn:" + uuid_str
-            new['file_characteristics']['title'] = json_title % loop
-            new['file_characteristics']['description'] = json_description % loop
-            new['file_storage'] = file_storage
-
-            if validate_json or i == 1:
-                json_validate(new['file_characteristics'], json_schema)
-
-            if mode == 'request':
-                start = time.time()
-                res = requests.post(url, data=json_dumps(new), headers={'Content-Type': 'application/json'},
-                                    verify=False)
-                end = time.time()
-                total_time_elapsed += (end - start)
-
-                if res.status_code == 201:
-                    # to be used in creating datasets
-                    file_test_data_list.append(res.data)
-
-                if DEBUG:
-                    print(res.status_code)
-                    if res.status_code == 201:
-                        print(res.text)
-                    else:
-                        print('request failed:')
-                        print(res.text)
-                        print('------------------------------------------')
-                        return
-            else:
-                # sent later in bulk request
-                file_test_data_list.append(new)
-
-        percent = i / float(file_max_rows) * 100.0
-
-        if percent % 10 == 0:
-            print("%d%%%s" % (percent, '' if percent == 100.0 else '...'))
-
-    if mode in ("json", 'request_list'):
-        print('generated files into a list')
-    elif mode == 'request':
-        print('collected created objects from responses into a list')
-        print('total time elapsed for %d rows: %.3f seconds' % (file_max_rows, total_time_elapsed))
+        file_test_data_list.append(new)
 
     return file_test_data_list, directory_test_data_list
 
@@ -329,330 +223,236 @@ def create_parent_directory_for_path(directories, file_path, directory_test_data
     return new_id
 
 
-def save_test_data(mode, file_storage_list, file_list, directory_list, data_catalogs_list, contract_list,
-        catalog_record_list, dataset_version_sets, batch_size):
-    if mode == 'json':
-
-        with open('test_data.json', 'w') as f:
-            print('dumping test data as json to metax_api/tests/test_data.json...')
-            json_dump(file_storage_list + directory_list + file_list + data_catalogs_list + contract_list +
-                      dataset_version_sets + catalog_record_list, f, indent=4, sort_keys=True)
-
-    elif mode == 'request_list':
-
-        total_rows_count = len(file_list)
-        start = 0
-        end = batch_size or total_rows_count
-        i = 0
-        total_time_elapsed = 0
-
-        print('uploading to db using POST requests...')
-
-        while end <= total_rows_count:
-
-            batch_start = time.time()
-            res = requests.post(url, data=json_dumps(file_list[start:end]),
-                                headers={'Content-Type': 'application/json'}, verify=False)
-            batch_end = time.time()
-            batch_time_elapsed = batch_end - batch_start
-            total_time_elapsed += batch_time_elapsed
-            print('completed batch #%d: %d rows in %.3f seconds'
-                  % (i, batch_size or total_rows_count, batch_time_elapsed))
-
-            start += batch_size
-            end += batch_size or total_rows_count
-            i += 1
-
-            try:
-                res_json = json.loads(res.text)
-            except Exception:
-                print('something went wrong when loading res.text to json, here is the text:')
-                print(res.text)
-                return
-
-            if DEBUG and res_json and res_json['failed']:
-                print('some insertions failed. here is the object and the errors from the first row:')
-                print(res_json['failed'][0])
-                return
-
-        print('total time elapsed for %d rows in %d requests: %.3f seconds' % (total_rows_count, i, total_time_elapsed))
-
-    else:
-        pass
+def save_test_data(file_storage_list, file_list, directory_list, data_catalogs_list, contract_list,
+        catalog_record_list, dataset_version_sets):
+    with open('test_data.json', 'w') as f:
+        print('dumping test data as json to metax_api/tests/test_data.json...')
+        json_dump(file_storage_list + directory_list + file_list + data_catalogs_list + contract_list +
+                  dataset_version_sets + catalog_record_list, f, indent=4, sort_keys=True)
 
 
-def generate_data_catalogs(mode, start_idx, data_catalog_max_rows, validate_json, type):
+def generate_data_catalogs(start_idx, data_catalog_max_rows, validate_json, type):
+    print('generating %s data catalogs...' % type)
     test_data_catalog_list = []
     json_schema = get_json_schema('datacatalog')
 
-    if mode == 'json':
+    with open('data_catalog_test_data_template.json') as json_file:
+        row_template = json_load(json_file)
 
-        with open('data_catalog_test_data_template.json') as json_file:
-            row_template = json_load(json_file)
+    for i in range(start_idx, start_idx + data_catalog_max_rows):
 
-        for i in range(start_idx, start_idx + data_catalog_max_rows):
+        new = {
+            'fields': deepcopy(row_template),
+            'model': "metax_api.datacatalog",
+            'pk': i,
+        }
+        new['fields']['date_modified'] = '2017-06-15T10:07:22Z'
+        new['fields']['date_created'] = '2017-05-15T10:07:22Z'
+        new['fields']['catalog_json']['identifier'] = generate_test_identifier(dc_type, i)
 
-            new = {
-                'fields': deepcopy(row_template),
-                'model': "metax_api.datacatalog",
-                'pk': i,
-            }
-            new['fields']['date_modified'] = '2017-06-15T10:07:22Z'
-            new['fields']['date_created'] = '2017-05-15T10:07:22Z'
-            new['fields']['catalog_json']['identifier'] = generate_test_identifier(dc_type, i)
+        if type == 'ida':
+            new['fields']['catalog_json']['research_dataset_schema'] = 'ida'
+        elif type == 'att':
+            new['fields']['catalog_json']['research_dataset_schema'] = 'att'
 
-            if type == 'ida':
-                new['fields']['catalog_json']['research_dataset_schema'] = 'ida'
-            elif type == 'att':
-                new['fields']['catalog_json']['research_dataset_schema'] = 'att'
+        if i in (start_idx, start_idx + 1):
+            # lets pretend that the first two data catalogs will support versioning,
+            # they are "fairdata catalogs"
+            dataset_versioning = True
+            new['fields']['catalog_json']['harvested'] = False
+        else:
+            dataset_versioning = False
 
-            if i in (start_idx, start_idx + 1):
-                # lets pretend that the first two data catalogs will support versioning,
-                # they are "fairdata catalogs"
-                dataset_versioning = True
-                new['fields']['catalog_json']['harvested'] = False
-            else:
-                dataset_versioning = False
+            # rest of the catalogs are harvested
+            new['fields']['catalog_json']['harvested'] = True
 
-                # rest of the catalogs are harvested
-                new['fields']['catalog_json']['harvested'] = True
+        new['fields']['catalog_json']['dataset_versioning'] = dataset_versioning
 
-            new['fields']['catalog_json']['dataset_versioning'] = dataset_versioning
+        test_data_catalog_list.append(new)
 
-            test_data_catalog_list.append(new)
-
-            if validate_json or i == start_idx:
-                json_validate(new['fields']['catalog_json'], json_schema)
+        if validate_json or i == start_idx:
+            json_validate(new['fields']['catalog_json'], json_schema)
 
     return test_data_catalog_list
 
 
-def generate_contracts(mode, contract_max_rows, validate_json):
+def generate_contracts(contract_max_rows, validate_json):
+    print('generating contracts...')
     test_contract_list = []
     json_schema = get_json_schema('contract')
 
-    if mode == 'json':
+    with open('contract_test_data_template.json') as json_file:
+        row_template = json_load(json_file)
 
-        with open('contract_test_data_template.json') as json_file:
-            row_template = json_load(json_file)
+    for i in range(1, contract_max_rows + 1):
 
-        for i in range(1, contract_max_rows + 1):
+        new = {
+            'fields': deepcopy(row_template),
+            'model': "metax_api.contract",
+            'pk': i,
+        }
 
-            new = {
-                'fields': deepcopy(row_template),
-                'model': "metax_api.contract",
-                'pk': i,
-            }
+        new['fields']['contract_json']['identifier'] = "optional:contract:identifier%d" % i
+        new['fields']['contract_json']['title'] = "Title of Contract %d" % i
+        new['fields']['contract_json']['organization']['organization_identifier'] = "1234567-%d" % i
+        new['fields']['date_modified'] = '2017-06-15T10:07:22Z'
+        new['fields']['date_created'] = '2017-05-15T10:07:22Z'
+        test_contract_list.append(new)
 
-            new['fields']['contract_json']['identifier'] = "optional:contract:identifier%d" % i
-            new['fields']['contract_json']['title'] = "Title of Contract %d" % i
-            new['fields']['contract_json']['organization']['organization_identifier'] = "1234567-%d" % i
-            new['fields']['date_modified'] = '2017-06-15T10:07:22Z'
-            new['fields']['date_created'] = '2017-05-15T10:07:22Z'
-            test_contract_list.append(new)
-
-            if validate_json or i == 1:
-                json_validate(new['fields']['contract_json'], json_schema)
+        if validate_json or i == 1:
+            json_validate(new['fields']['contract_json'], json_schema)
 
     return test_contract_list
 
 
-def generate_catalog_records(mode, basic_catalog_record_max_rows, data_catalogs_list, contract_list, file_list,
-                             validate_json, url, type, test_data_list=[], dataset_version_sets=[]):
-    print('generating {0} catalog records{1}...' .format(type,
-                                                         '' if mode in ('json', 'request_list') else ' and uploading'))
+def generate_catalog_records(basic_catalog_record_max_rows, data_catalogs_list, contract_list, file_list,
+                             validate_json, type, test_data_list=[], dataset_version_sets=[]):
+    print('generating %s catalog records...' % type)
 
     with open('catalog_record_test_data_template.json') as json_file:
         row_template = json_load(json_file)
 
-    total_time_elapsed = 0
     files_start_idx = 1
     data_catalog_id = data_catalogs_list[0]['pk']
     owner_idx = 0
-    loop_counter = 0
     start_idx = len(test_data_list) + 1
 
     for i in range(start_idx, start_idx + basic_catalog_record_max_rows):
-        loop_counter += 1
-        if mode == 'json':
+        json_schema = None
 
-            json_schema = None
-            if type == 'ida':
-                json_schema = get_json_schema('ida_dataset')
-            elif type == 'att':
-                json_schema = get_json_schema('att_dataset')
+        if type == 'ida':
+            json_schema = get_json_schema('ida_dataset')
+        elif type == 'att':
+            json_schema = get_json_schema('att_dataset')
 
-            new = {
-                'fields': row_template.copy(),
-                'model': 'metax_api.catalogrecord',
+        new = {
+            'fields': row_template.copy(),
+            'model': 'metax_api.catalogrecord',
+            'pk': i,
+        }
+
+        if data_catalog_id in (1, 2): # versioned catalogs only
+            dataset_version_set = {
+                'fields': {},
+                'model': 'metax_api.datasetversionset',
                 'pk': i,
             }
+            new['fields']['dataset_version_set'] = dataset_version_set['pk']
+            dataset_version_sets.append(dataset_version_set)
 
-            if data_catalog_id in (1, 2): # versioned catalogs only
-                dataset_version_set = {
-                    'fields': {},
-                    'model': 'metax_api.datasetversionset',
-                    'pk': i,
-                }
-                new['fields']['dataset_version_set'] = dataset_version_set['pk']
-                dataset_version_sets.append(dataset_version_set)
+        # comment this line. i dare you.
+        # for real tho, required to prevent some strange behaving references to old data
+        new['fields']['research_dataset'] = row_template['research_dataset'].copy()
+        new['fields']['data_catalog'] = data_catalog_id
+        new['fields']['research_dataset']['metadata_version_identifier'] = generate_test_identifier(cr_type, i,
+                                                                                                    urn=False)
+        new['fields']['research_dataset']['preferred_identifier'] = generate_test_identifier(cr_type, i)
+        new['fields']['identifier'] = generate_test_identifier('cr', i, urn=False)
+        new['fields']['date_modified'] = '2017-06-23T10:07:22Z'
+        new['fields']['date_created'] = '2017-05-23T10:07:22Z'
+        new['fields']['editor'] = {
+            'owner_id': catalog_records_owner_ids[owner_idx],
+            'creator_id': catalog_records_owner_ids[owner_idx],
+            'identifier': 'qvain',
+        }
+        new['fields']['files'] = []
 
-            # comment this line. i dare you.
-            # for real tho, required to prevent some strange behaving references to old data
-            new['fields']['research_dataset'] = row_template['research_dataset'].copy()
-            new['fields']['data_catalog'] = data_catalog_id
-            new['fields']['research_dataset']['metadata_version_identifier'] = generate_test_identifier(cr_type, i,
-                                                                                                        urn=False)
-            new['fields']['research_dataset']['preferred_identifier'] = generate_test_identifier(cr_type, i)
-            new['fields']['identifier'] = generate_test_identifier('cr', i, urn=False)
-            new['fields']['date_modified'] = '2017-06-23T10:07:22Z'
-            new['fields']['date_created'] = '2017-05-23T10:07:22Z'
-            new['fields']['editor'] = {
-                'owner_id': catalog_records_owner_ids[owner_idx],
-                'creator_id': catalog_records_owner_ids[owner_idx],
-                'identifier': 'qvain',
-            }
+        owner_idx += 1
+        if owner_idx >= len(catalog_records_owner_ids):
+            owner_idx = 0
+
+        # add files
+
+        if type == 'ida':
             new['fields']['files'] = []
+            dataset_files = []
+            total_ida_byte_size = 0
+            file_divider = 4
 
-            owner_idx += 1
-            if owner_idx >= len(catalog_records_owner_ids):
-                owner_idx = 0
+            for j in range(files_start_idx, files_start_idx + files_per_dataset):
 
-            # add files
+                total_ida_byte_size += file_list[j - 1]['fields']['byte_size']
 
-            if type == 'ida':
-                new['fields']['files'] = []
-                dataset_files = []
-                total_ida_byte_size = 0
-                file_divider = 4
+                # note - this field will go in the m2m table in the db when importing generated testdata...
+                new['fields']['files'].append(file_list[j - 1]['pk'])
 
-                for j in range(files_start_idx, files_start_idx + files_per_dataset):
+                # ... while every API operation will look at research_dataset.files.identifier
+                # to lookup the file - be careful the identifier below matches with the m2m id set above
+                dataset_files.append({
+                    'identifier': file_list[j - 1]['fields']['identifier'],
+                    'title': 'File metadata title %d' % j
+                })
 
-                    total_ida_byte_size += file_list[j - 1]['fields']['byte_size']
-
-                    # note - this field will go in the m2m table in the db when importing generated testdata...
-                    new['fields']['files'].append(file_list[j - 1]['pk'])
-
-                    # ... while every API operation will look at research_dataset.files.identifier
-                    # to lookup the file - be careful the identifier below matches with the m2m id set above
-                    dataset_files.append({
-                        'identifier': file_list[j - 1]['fields']['identifier'],
-                        'title': 'File metadata title %d' % j
-                    })
-
-                    if j < file_divider:
-                        # first fifth of files
-                        dataset_files[-1]['file_type'] = {
-                            "identifier": "http://purl.org/att/es/reference_data/file_type/file_type_text",
-                        }
-                        dataset_files[-1]['use_category'] = {
-                            'identifier': 'source'
-                        }
-
-                    elif file_divider <= j < (file_divider * 2):
-                        # second fifth of files
-                        dataset_files[-1]['file_type'] = {
-                            "identifier": "http://purl.org/att/es/reference_data/file_type/file_type_video"
-                        }
-                        dataset_files[-1]['use_category'] = {
-                            'identifier': 'outcome'
-                        }
-                    elif (file_divider * 2) <= j < (file_divider * 3):
-                        # third fifth of files
-                        dataset_files[-1]['file_type'] = {
-                            "identifier": "http://purl.org/att/es/reference_data/file_type/file_type_image"
-                        }
-                        dataset_files[-1]['use_category'] = {
-                            'identifier': 'publication'
-                        }
-                    elif (file_divider * 3) <= j < (file_divider * 4):
-                        # fourth fifth of files
-                        dataset_files[-1]['file_type'] = {
-                            "identifier": "http://purl.org/att/es/reference_data/file_type/file_type_source_code"
-                        }
-                        dataset_files[-1]['use_category'] = {
-                            'identifier': 'documentation'
-                        }
-                    else:
-                        # the rest of files
-                        dataset_files[-1]['use_category'] = {
-                            'identifier': 'configuration'
-                        }
-
-                new['fields']['research_dataset']['files'] = dataset_files
-                new['fields']['research_dataset']['total_ida_byte_size'] = total_ida_byte_size
-                files_start_idx += files_per_dataset
-
-            elif type == 'att':
-                new['fields']['research_dataset']['remote_resources'] = [
-                    {
-                        "title": "Remote resource {0}".format(str(i)),
-                        "modified": "2014-01-12T17:11:54Z",
-                        "use_category": {"identifier": "outcome"},
-                        "checksum": {"algorithm": "SHA-256", "checksum_value": "u5y6f4y68765ngf6ry8n"},
-                        "byte_size": i * 512
-                    },
-                    {
-                        "title": "Other remote resource {0}".format(str(i)),
-                        "modified": "2013-01-12T11:11:54Z",
-                        "use_category": {"identifier": "source"},
-                        "checksum": {"algorithm": "SHA-512", "checksum_value": "u3k4kn7n1g56l6rq5a5s"},
-                        "byte_size": i * 1024
+                if j < file_divider:
+                    # first fifth of files
+                    dataset_files[-1]['file_type'] = {
+                        "identifier": "http://purl.org/att/es/reference_data/file_type/file_type_text",
                     }
-                ]
-                total_remote_resources_byte_size = 0
-                for rr in new['fields']['research_dataset']['remote_resources']:
-                    total_remote_resources_byte_size += rr.get('byte_size', 0)
-                new['fields']['research_dataset'][
-                    'total_remote_resources_byte_size'] = total_remote_resources_byte_size
+                    dataset_files[-1]['use_category'] = {
+                        'identifier': 'source'
+                    }
 
-            if validate_json or i == start_idx:
-                json_validate(new['fields']['research_dataset'], json_schema)
+                elif file_divider <= j < (file_divider * 2):
+                    # second fifth of files
+                    dataset_files[-1]['file_type'] = {
+                        "identifier": "http://purl.org/att/es/reference_data/file_type/file_type_video"
+                    }
+                    dataset_files[-1]['use_category'] = {
+                        'identifier': 'outcome'
+                    }
+                elif (file_divider * 2) <= j < (file_divider * 3):
+                    # third fifth of files
+                    dataset_files[-1]['file_type'] = {
+                        "identifier": "http://purl.org/att/es/reference_data/file_type/file_type_image"
+                    }
+                    dataset_files[-1]['use_category'] = {
+                        'identifier': 'publication'
+                    }
+                elif (file_divider * 3) <= j < (file_divider * 4):
+                    # fourth fifth of files
+                    dataset_files[-1]['file_type'] = {
+                        "identifier": "http://purl.org/att/es/reference_data/file_type/file_type_source_code"
+                    }
+                    dataset_files[-1]['use_category'] = {
+                        'identifier': 'documentation'
+                    }
+                else:
+                    # the rest of files
+                    dataset_files[-1]['use_category'] = {
+                        'identifier': 'configuration'
+                    }
 
-            test_data_list.append(new)
+            new['fields']['research_dataset']['files'] = dataset_files
+            new['fields']['research_dataset']['total_ida_byte_size'] = total_ida_byte_size
+            files_start_idx += files_per_dataset
 
-        # else:
-        #     # http POST requests
+        elif type == 'att':
+            new['fields']['research_dataset']['remote_resources'] = [
+                {
+                    "title": "Remote resource {0}".format(str(i)),
+                    "modified": "2014-01-12T17:11:54Z",
+                    "use_category": {"identifier": "outcome"},
+                    "checksum": {"algorithm": "SHA-256", "checksum_value": "u5y6f4y68765ngf6ry8n"},
+                    "byte_size": i * 512
+                },
+                {
+                    "title": "Other remote resource {0}".format(str(i)),
+                    "modified": "2013-01-12T11:11:54Z",
+                    "use_category": {"identifier": "source"},
+                    "checksum": {"algorithm": "SHA-512", "checksum_value": "u3k4kn7n1g56l6rq5a5s"},
+                    "byte_size": i * 1024
+                }
+            ]
+            total_remote_resources_byte_size = 0
+            for rr in new['fields']['research_dataset']['remote_resources']:
+                total_remote_resources_byte_size += rr.get('byte_size', 0)
+            new['fields']['research_dataset'][
+                'total_remote_resources_byte_size'] = total_remote_resources_byte_size
 
-        #     new = row_template.copy()
+        if validate_json or i == start_idx:
+            json_validate(new['fields']['research_dataset'], json_schema)
 
-        #     new['file_name'] = file_name % loop
-        #     new['identifier'] = uuid_str
-        #     new['file_characteristics']['title'] = json_title % loop
-        #     new['file_characteristics']['description'] = json_description % loop
-        #     new['file_storage'] = file_storage
-
-        #     if validate_json or i == 1:
-        #         json_validate(new['file_characteristics'], json_schema)
-
-        #     if mode == 'request':
-        #         start = time.time()
-        #         res = requests.post(url, data=json_dumps(new),
-        # headers={ 'Content-Type': 'application/json' }, verify=False)
-        #         end = time.time()
-        #         total_time_elapsed += (end - start)
-
-        #         if res.status_code == 201:
-        #             # to be used in creating datasets
-        #             test_data_list.append(res.data)
-
-        #         if DEBUG:
-        #             print(res.status_code)
-        #             if res.status_code == 201:
-        #                 print(res.text)
-        #             else:
-        #                 print('request failed:')
-        #                 print(res.text)
-        #                 print('------------------------------------------')
-        #                 return
-        #     else:
-        #         # sent later in bulk request
-        #         test_data_list.append(new)
-
-        percent = loop_counter / float(basic_catalog_record_max_rows) * 100.0
-
-        if percent % 10 == 0:
-            print("%d%%%s" % (percent, '' if percent == 100.0 else '...'))
+        test_data_list.append(new)
 
     # set some preservation_state dependent values
     pres_state_value = 1
@@ -869,12 +669,6 @@ def generate_catalog_records(mode, basic_catalog_record_max_rows, data_catalogs_
         json_validate(new['fields']['research_dataset'], json_schema)
         test_data_list.append(new)
 
-    if mode in ("json", 'request_list'):
-        print('generated catalog records into a list')
-    elif mode == 'request':
-        print('collected created objects from responses into a list')
-        print('total time elapsed for %d rows: %.3f seconds' % (basic_catalog_record_max_rows, total_time_elapsed))
-
     return test_data_list, dataset_version_sets
 
 
@@ -885,6 +679,7 @@ def generate_alt_catalog_records(test_data_list):
     # note, these alt records wont have an editor-field set, since they presumably
     # originated to metax from somewhere else than qvain (were harvested).
     #
+    print('generating alternate catalog records...')
     alternate_record_set = {
         'fields': {},
         'model': 'metax_api.alternaterecordset',
@@ -920,30 +715,26 @@ def generate_alt_catalog_records(test_data_list):
     test_data_list.insert(0, alternate_record_set)
     return test_data_list
 
-print('generating %d test file rows' % file_max_rows)
-print('mode: %s' % mode)
-if 'request' in mode:
-    print('POST requests to url: %s' % url)
-print('validate json: %s' % str(validate_json))
-print('generating %d test file storage rows' % file_storage_max_rows)
-print('DEBUG: %s' % str(DEBUG))
 
-contract_list = generate_contracts(mode, contract_max_rows, validate_json)
-file_storage_list = generate_file_storages(mode, file_storage_max_rows)
-file_list, directory_list = generate_files(mode, file_storage_list, validate_json, url)
+if __name__ == '__main__':
+    print('begin generating test data...')
 
-ida_data_catalogs_list = generate_data_catalogs(mode, 1, ida_data_catalog_max_rows, validate_json, 'ida')
-att_data_catalogs_list = generate_data_catalogs(mode, ida_data_catalog_max_rows + 1, att_data_catalog_max_rows,
-                                                validate_json, 'att')
+    contract_list = generate_contracts(contract_max_rows, validate_json)
+    file_storage_list = generate_file_storages(file_storage_max_rows)
+    file_list, directory_list = generate_files(file_storage_list, validate_json)
 
-catalog_record_list, dataset_version_sets = generate_catalog_records(mode, ida_catalog_record_max_rows,
-    ida_data_catalogs_list, contract_list, file_list, validate_json, url, 'ida')
+    ida_data_catalogs_list = generate_data_catalogs(1, ida_data_catalog_max_rows, validate_json, 'ida')
+    att_data_catalogs_list = generate_data_catalogs(ida_data_catalog_max_rows + 1, att_data_catalog_max_rows,
+                                                    validate_json, 'att')
 
-catalog_record_list, dataset_version_sets = generate_catalog_records(mode, att_catalog_record_max_rows,
-    att_data_catalogs_list, contract_list, [], validate_json, url, 'att', catalog_record_list, dataset_version_sets)
+    catalog_record_list, dataset_version_sets = generate_catalog_records(ida_catalog_record_max_rows,
+        ida_data_catalogs_list, contract_list, file_list, validate_json, 'ida')
 
-catalog_record_list = generate_alt_catalog_records(catalog_record_list)
-save_test_data(mode, file_storage_list, directory_list, file_list, ida_data_catalogs_list + att_data_catalogs_list,
-               contract_list, catalog_record_list, dataset_version_sets, batch_size)
+    catalog_record_list, dataset_version_sets = generate_catalog_records(att_catalog_record_max_rows,
+        att_data_catalogs_list, contract_list, [], validate_json, 'att', catalog_record_list, dataset_version_sets)
 
-print('done')
+    catalog_record_list = generate_alt_catalog_records(catalog_record_list)
+    save_test_data(file_storage_list, directory_list, file_list, ida_data_catalogs_list + att_data_catalogs_list,
+                   contract_list, catalog_record_list, dataset_version_sets)
+
+    print('done')

--- a/src/metax_api/tests/testdata/test_data.json
+++ b/src/metax_api/tests/testdata/test_data.json
@@ -5478,33 +5478,38 @@
             "contract_json": {
                 "contact": [
                     {
-                        "email": "contact.email@csc.fi",
-                        "name": "Contact Name",
+                        "email": "taito.tieto@helsinki.fi",
+                        "name": "Taito Tieto",
+                        "phone": "+358501231234"
+                    },
+                    {
+                        "email": "seppo.pykala'@helsinki.fi",
+                        "name": "Seppo Pyk\u00e4l\u00e4",
                         "phone": "+358501231234"
                     }
                 ],
-                "created": "2014-01-17T08:19:58Z",
-                "description": "Description of unknown length",
-                "identifier": "optional:contract:identifier1",
-                "modified": "2014-01-17T08:19:58Z",
+                "created": "2018-04-05T08:19:58Z",
+                "description": "Muuttolintujen laskentatulosten s\u00e4ilytys",
+                "identifier": "urn:uuid:99ddffff-2f73-46b0-92d1-614409d83001",
+                "modified": "2018-04-05T08:19:58Z",
                 "organization": {
-                    "name": "Mysterious organization",
+                    "name": "Helsingin Yliopisto",
                     "organization_identifier": "1234567-1"
                 },
-                "quota": 111204,
+                "quota": 1000000,
                 "related_service": [
                     {
                         "identifier": "local:service:id",
-                        "name": "Name of Service"
+                        "name": "Fairdata-PAS"
                     }
                 ],
-                "title": "Title of Contract 1",
+                "title": "Helsingin yliopiston biotieteiden laitoksen muuttolintujen laskentatulosten s\u00e4ilytyssopimus",
                 "validity": {
-                    "start_date": "2014-01-17T08:19:58Z"
+                    "start_date": "2018-07-01T00:00:00Z"
                 }
             },
-            "date_created": "2017-05-15T10:07:22Z",
-            "date_modified": "2017-06-15T10:07:22Z",
+            "date_created": "2018-04-05T08:19:58+03:00",
+            "date_modified": "2018-04-05T08:19:58+03:00",
             "service_created": "metax"
         },
         "model": "metax_api.contract",

--- a/src/metax_api/tests/testdata/test_data.json
+++ b/src/metax_api/tests/testdata/test_data.json
@@ -6,7 +6,7 @@
             "file_storage_json": {
                 "identifier": "pid:urn:storageidentifier1",
                 "title": "Title 1",
-                "url": "https://metax.csc.local/rest/files/"
+                "url": "https://metax-test.csc.fi/rest/filestorages/1"
             }
         },
         "model": "metax_api.filestorage",
@@ -19,7 +19,7 @@
             "file_storage_json": {
                 "identifier": "pid:urn:storageidentifier2",
                 "title": "Title 2",
-                "url": "https://metax.csc.local/rest/files/"
+                "url": "https://metax-test.csc.fi/rest/filestorages/2"
             }
         },
         "model": "metax_api.filestorage",

--- a/src/metax_api/tests/testdata/test_data.json
+++ b/src/metax_api/tests/testdata/test_data.json
@@ -5744,7 +5744,7 @@
                 1,
                 2
             ],
-            "identifier": "urn:nbn:fi:att:cr955e904-e3dd-4d7e-99f1-3fed446f96d1",
+            "identifier": "cr955e904-e3dd-4d7e-99f1-3fed446f96d1",
             "mets_object_identifier": null,
             "preservation_state": 0,
             "preservation_state_modified": null,
@@ -5803,9 +5803,9 @@
                         "identifier": "http://lexvo.org/id/iso639-3/eng"
                     }
                 ],
-                "metadata_version_identifier": "urn:nbn:fi:att:1955e904-e3dd-4d7e-99f1-3fed446f96d1",
+                "metadata_version_identifier": "1955e904-e3dd-4d7e-99f1-3fed446f96d1",
                 "modified": "2014-01-17T08:19:58Z",
-                "preferred_identifier": "pid:urn:preferred:dataset1",
+                "preferred_identifier": "urn:nbn:fi:att:1955e904-e3dd-4d7e-99f1-3fed446f96d1",
                 "title": {
                     "en": "Wonderful Title"
                 },
@@ -5836,7 +5836,7 @@
                 3,
                 4
             ],
-            "identifier": "urn:nbn:fi:att:cr955e904-e3dd-4d7e-99f1-3fed446f96d2",
+            "identifier": "cr955e904-e3dd-4d7e-99f1-3fed446f96d2",
             "mets_object_identifier": null,
             "preservation_state": 1,
             "preservation_state_modified": "2017-05-23T10:07:22.559656Z",
@@ -5898,9 +5898,9 @@
                         "identifier": "http://lexvo.org/id/iso639-3/eng"
                     }
                 ],
-                "metadata_version_identifier": "urn:nbn:fi:att:1955e904-e3dd-4d7e-99f1-3fed446f96d2",
+                "metadata_version_identifier": "1955e904-e3dd-4d7e-99f1-3fed446f96d2",
                 "modified": "2014-01-17T08:19:58Z",
-                "preferred_identifier": "pid:urn:preferred:dataset2",
+                "preferred_identifier": "urn:nbn:fi:att:1955e904-e3dd-4d7e-99f1-3fed446f96d2",
                 "title": {
                     "en": "Wonderful Title"
                 },
@@ -5931,7 +5931,7 @@
                 5,
                 6
             ],
-            "identifier": "urn:nbn:fi:att:cr955e904-e3dd-4d7e-99f1-3fed446f96d3",
+            "identifier": "cr955e904-e3dd-4d7e-99f1-3fed446f96d3",
             "mets_object_identifier": null,
             "preservation_state": 2,
             "preservation_state_modified": "2017-05-23T10:07:22.559656Z",
@@ -5993,9 +5993,9 @@
                         "identifier": "http://lexvo.org/id/iso639-3/eng"
                     }
                 ],
-                "metadata_version_identifier": "urn:nbn:fi:att:1955e904-e3dd-4d7e-99f1-3fed446f96d3",
+                "metadata_version_identifier": "1955e904-e3dd-4d7e-99f1-3fed446f96d3",
                 "modified": "2014-01-17T08:19:58Z",
-                "preferred_identifier": "pid:urn:preferred:dataset3",
+                "preferred_identifier": "urn:nbn:fi:att:1955e904-e3dd-4d7e-99f1-3fed446f96d3",
                 "title": {
                     "en": "Wonderful Title"
                 },
@@ -6026,7 +6026,7 @@
                 7,
                 8
             ],
-            "identifier": "urn:nbn:fi:att:cr955e904-e3dd-4d7e-99f1-3fed446f96d4",
+            "identifier": "cr955e904-e3dd-4d7e-99f1-3fed446f96d4",
             "mets_object_identifier": [
                 "a",
                 "b",
@@ -6092,9 +6092,9 @@
                         "identifier": "http://lexvo.org/id/iso639-3/eng"
                     }
                 ],
-                "metadata_version_identifier": "urn:nbn:fi:att:1955e904-e3dd-4d7e-99f1-3fed446f96d4",
+                "metadata_version_identifier": "1955e904-e3dd-4d7e-99f1-3fed446f96d4",
                 "modified": "2014-01-17T08:19:58Z",
-                "preferred_identifier": "pid:urn:preferred:dataset4",
+                "preferred_identifier": "urn:nbn:fi:att:1955e904-e3dd-4d7e-99f1-3fed446f96d4",
                 "title": {
                     "en": "Wonderful Title"
                 },
@@ -6125,7 +6125,7 @@
                 9,
                 10
             ],
-            "identifier": "urn:nbn:fi:att:cr955e904-e3dd-4d7e-99f1-3fed446f96d5",
+            "identifier": "cr955e904-e3dd-4d7e-99f1-3fed446f96d5",
             "mets_object_identifier": [
                 "a",
                 "b",
@@ -6191,9 +6191,9 @@
                         "identifier": "http://lexvo.org/id/iso639-3/eng"
                     }
                 ],
-                "metadata_version_identifier": "urn:nbn:fi:att:1955e904-e3dd-4d7e-99f1-3fed446f96d5",
+                "metadata_version_identifier": "1955e904-e3dd-4d7e-99f1-3fed446f96d5",
                 "modified": "2014-01-17T08:19:58Z",
-                "preferred_identifier": "pid:urn:preferred:dataset5",
+                "preferred_identifier": "urn:nbn:fi:att:1955e904-e3dd-4d7e-99f1-3fed446f96d5",
                 "title": {
                     "en": "Wonderful Title"
                 },
@@ -6224,7 +6224,7 @@
                 11,
                 12
             ],
-            "identifier": "urn:nbn:fi:att:cr955e904-e3dd-4d7e-99f1-3fed446f96d6",
+            "identifier": "cr955e904-e3dd-4d7e-99f1-3fed446f96d6",
             "mets_object_identifier": null,
             "preservation_state": 5,
             "preservation_state_modified": "2017-05-23T10:07:22.559656Z",
@@ -6286,9 +6286,9 @@
                         "identifier": "http://lexvo.org/id/iso639-3/eng"
                     }
                 ],
-                "metadata_version_identifier": "urn:nbn:fi:att:1955e904-e3dd-4d7e-99f1-3fed446f96d6",
+                "metadata_version_identifier": "1955e904-e3dd-4d7e-99f1-3fed446f96d6",
                 "modified": "2014-01-17T08:19:58Z",
-                "preferred_identifier": "pid:urn:preferred:dataset6",
+                "preferred_identifier": "urn:nbn:fi:att:1955e904-e3dd-4d7e-99f1-3fed446f96d6",
                 "title": {
                     "en": "Wonderful Title"
                 },
@@ -6318,7 +6318,7 @@
                 13,
                 14
             ],
-            "identifier": "urn:nbn:fi:att:cr955e904-e3dd-4d7e-99f1-3fed446f96d7",
+            "identifier": "cr955e904-e3dd-4d7e-99f1-3fed446f96d7",
             "mets_object_identifier": null,
             "preservation_state": 0,
             "preservation_state_modified": null,
@@ -6380,9 +6380,9 @@
                         "identifier": "http://lexvo.org/id/iso639-3/eng"
                     }
                 ],
-                "metadata_version_identifier": "urn:nbn:fi:att:1955e904-e3dd-4d7e-99f1-3fed446f96d7",
+                "metadata_version_identifier": "1955e904-e3dd-4d7e-99f1-3fed446f96d7",
                 "modified": "2014-01-17T08:19:58Z",
-                "preferred_identifier": "pid:urn:preferred:dataset7",
+                "preferred_identifier": "urn:nbn:fi:att:1955e904-e3dd-4d7e-99f1-3fed446f96d7",
                 "title": {
                     "en": "Wonderful Title"
                 },
@@ -6412,7 +6412,7 @@
                 15,
                 16
             ],
-            "identifier": "urn:nbn:fi:att:cr955e904-e3dd-4d7e-99f1-3fed446f96d8",
+            "identifier": "cr955e904-e3dd-4d7e-99f1-3fed446f96d8",
             "mets_object_identifier": null,
             "preservation_state": 0,
             "preservation_state_modified": null,
@@ -6471,9 +6471,9 @@
                         "identifier": "http://lexvo.org/id/iso639-3/eng"
                     }
                 ],
-                "metadata_version_identifier": "urn:nbn:fi:att:1955e904-e3dd-4d7e-99f1-3fed446f96d8",
+                "metadata_version_identifier": "1955e904-e3dd-4d7e-99f1-3fed446f96d8",
                 "modified": "2014-01-17T08:19:58Z",
-                "preferred_identifier": "pid:urn:preferred:dataset8",
+                "preferred_identifier": "urn:nbn:fi:att:1955e904-e3dd-4d7e-99f1-3fed446f96d8",
                 "title": {
                     "en": "Wonderful Title"
                 },
@@ -6503,7 +6503,7 @@
                 17,
                 18
             ],
-            "identifier": "urn:nbn:fi:att:cr955e904-e3dd-4d7e-99f1-3fed446f96d9",
+            "identifier": "cr955e904-e3dd-4d7e-99f1-3fed446f96d9",
             "mets_object_identifier": null,
             "preservation_state": 0,
             "preservation_state_modified": null,
@@ -6559,9 +6559,9 @@
                         "identifier": "http://lexvo.org/id/iso639-3/eng"
                     }
                 ],
-                "metadata_version_identifier": "urn:nbn:fi:att:1955e904-e3dd-4d7e-99f1-3fed446f96d9",
+                "metadata_version_identifier": "1955e904-e3dd-4d7e-99f1-3fed446f96d9",
                 "modified": "2014-01-17T08:19:58Z",
-                "preferred_identifier": "pid:urn:preferred:dataset9",
+                "preferred_identifier": "urn:nbn:fi:att:1955e904-e3dd-4d7e-99f1-3fed446f96d9",
                 "title": {
                     "en": "Wonderful Title"
                 },
@@ -6592,7 +6592,7 @@
                 19,
                 20
             ],
-            "identifier": "urn:nbn:fi:att:cr955e904-e3dd-4d7e-99f1-3fed446f9610",
+            "identifier": "cr955e904-e3dd-4d7e-99f1-3fed446f9610",
             "mets_object_identifier": null,
             "preservation_state": 0,
             "preservation_state_modified": null,
@@ -6648,9 +6648,9 @@
                         "identifier": "http://lexvo.org/id/iso639-3/eng"
                     }
                 ],
-                "metadata_version_identifier": "urn:nbn:fi:att:1955e904-e3dd-4d7e-99f1-3fed446f9610",
+                "metadata_version_identifier": "1955e904-e3dd-4d7e-99f1-3fed446f9610",
                 "modified": "2014-01-17T08:19:58Z",
-                "preferred_identifier": "pid:urn:preferred:dataset10",
+                "preferred_identifier": "urn:nbn:fi:att:1955e904-e3dd-4d7e-99f1-3fed446f9610",
                 "title": {
                     "en": "Wonderful Title"
                 },
@@ -6696,7 +6696,7 @@
                 19,
                 20
             ],
-            "identifier": "urn:nbn:fi:att:cr955e904-e3dd-4d7e-99f1-3fed446f9611",
+            "identifier": "cr955e904-e3dd-4d7e-99f1-3fed446f9611",
             "research_dataset": {
                 "access_rights": {
                     "access_type": {
@@ -7001,7 +7001,7 @@
                         "identifier": "http://lexvo.org/id/iso639-3/eng"
                     }
                 ],
-                "metadata_version_identifier": "urn:nbn:fi:att:1955e904-e3dd-4d7e-99f1-3fed446f9611",
+                "metadata_version_identifier": "1955e904-e3dd-4d7e-99f1-3fed446f9611",
                 "modified": "2014-01-17T08:19:58Z",
                 "other_identifier": [
                     {
@@ -7075,7 +7075,7 @@
                         }
                     }
                 ],
-                "preferred_identifier": "very:unique:urn-11",
+                "preferred_identifier": "urn:nbn:fi:att:1955e904-e3dd-4d7e-99f1-3fed446f9611",
                 "provenance": [
                     {
                         "description": {
@@ -7464,7 +7464,7 @@
                 19,
                 20
             ],
-            "identifier": "urn:nbn:fi:att:cr955e904-e3dd-4d7e-99f1-3fed446f9612",
+            "identifier": "cr955e904-e3dd-4d7e-99f1-3fed446f9612",
             "research_dataset": {
                 "access_rights": {
                     "access_type": {
@@ -7769,7 +7769,7 @@
                         "identifier": "http://lexvo.org/id/iso639-3/eng"
                     }
                 ],
-                "metadata_version_identifier": "urn:nbn:fi:att:1955e904-e3dd-4d7e-99f1-3fed446f9612",
+                "metadata_version_identifier": "1955e904-e3dd-4d7e-99f1-3fed446f9612",
                 "modified": "2014-01-17T08:19:58Z",
                 "other_identifier": [
                     {
@@ -7843,7 +7843,7 @@
                         }
                     }
                 ],
-                "preferred_identifier": "very:unique:urn-12",
+                "preferred_identifier": "urn:nbn:fi:att:1955e904-e3dd-4d7e-99f1-3fed446f9612",
                 "provenance": [
                     {
                         "description": {
@@ -8300,7 +8300,7 @@
                 114,
                 115
             ],
-            "identifier": "urn:nbn:fi:att:cr955e904-e3dd-4d7e-99f1-3fed446f9613",
+            "identifier": "cr955e904-e3dd-4d7e-99f1-3fed446f9613",
             "research_dataset": {
                 "access_rights": {
                     "access_type": {
@@ -8629,7 +8629,7 @@
                         "identifier": "http://lexvo.org/id/iso639-3/eng"
                     }
                 ],
-                "metadata_version_identifier": "urn:nbn:fi:att:1955e904-e3dd-4d7e-99f1-3fed446f9613",
+                "metadata_version_identifier": "1955e904-e3dd-4d7e-99f1-3fed446f9613",
                 "modified": "2014-01-17T08:19:58Z",
                 "other_identifier": [
                     {
@@ -8703,7 +8703,7 @@
                         }
                     }
                 ],
-                "preferred_identifier": "very:unique:urn-13",
+                "preferred_identifier": "urn:nbn:fi:att:1955e904-e3dd-4d7e-99f1-3fed446f9613",
                 "provenance": [
                     {
                         "description": {
@@ -9072,7 +9072,7 @@
                 "owner_id": "053bffbcc41edad4853bea91fc42ea18"
             },
             "files": [],
-            "identifier": "urn:nbn:fi:att:cr955e904-e3dd-4d7e-99f1-3fed446f9614",
+            "identifier": "cr955e904-e3dd-4d7e-99f1-3fed446f9614",
             "mets_object_identifier": null,
             "preservation_state": 0,
             "preservation_state_modified": null,
@@ -9109,9 +9109,9 @@
                         "identifier": "http://lexvo.org/id/iso639-3/eng"
                     }
                 ],
-                "metadata_version_identifier": "urn:nbn:fi:att:1955e904-e3dd-4d7e-99f1-3fed446f9614",
+                "metadata_version_identifier": "1955e904-e3dd-4d7e-99f1-3fed446f9614",
                 "modified": "2014-01-17T08:19:58Z",
-                "preferred_identifier": "pid:urn:preferred:dataset14",
+                "preferred_identifier": "urn:nbn:fi:att:1955e904-e3dd-4d7e-99f1-3fed446f9614",
                 "remote_resources": [
                     {
                         "byte_size": 7168,
@@ -9164,7 +9164,7 @@
                 "owner_id": "053d18ecb29e752cb7a35cd77b34f5fd"
             },
             "files": [],
-            "identifier": "urn:nbn:fi:att:cr955e904-e3dd-4d7e-99f1-3fed446f9615",
+            "identifier": "cr955e904-e3dd-4d7e-99f1-3fed446f9615",
             "mets_object_identifier": null,
             "preservation_state": 1,
             "preservation_state_modified": "2017-05-23T10:07:22.559656Z",
@@ -9204,9 +9204,9 @@
                         "identifier": "http://lexvo.org/id/iso639-3/eng"
                     }
                 ],
-                "metadata_version_identifier": "urn:nbn:fi:att:1955e904-e3dd-4d7e-99f1-3fed446f9615",
+                "metadata_version_identifier": "1955e904-e3dd-4d7e-99f1-3fed446f9615",
                 "modified": "2014-01-17T08:19:58Z",
-                "preferred_identifier": "pid:urn:preferred:dataset15",
+                "preferred_identifier": "urn:nbn:fi:att:1955e904-e3dd-4d7e-99f1-3fed446f9615",
                 "remote_resources": [
                     {
                         "byte_size": 7680,
@@ -9259,7 +9259,7 @@
                 "owner_id": "05593961536b76fa825281ccaedd4d4f"
             },
             "files": [],
-            "identifier": "urn:nbn:fi:att:cr955e904-e3dd-4d7e-99f1-3fed446f9616",
+            "identifier": "cr955e904-e3dd-4d7e-99f1-3fed446f9616",
             "mets_object_identifier": null,
             "preservation_state": 2,
             "preservation_state_modified": "2017-05-23T10:07:22.559656Z",
@@ -9299,9 +9299,9 @@
                         "identifier": "http://lexvo.org/id/iso639-3/eng"
                     }
                 ],
-                "metadata_version_identifier": "urn:nbn:fi:att:1955e904-e3dd-4d7e-99f1-3fed446f9616",
+                "metadata_version_identifier": "1955e904-e3dd-4d7e-99f1-3fed446f9616",
                 "modified": "2014-01-17T08:19:58Z",
-                "preferred_identifier": "pid:urn:preferred:dataset16",
+                "preferred_identifier": "urn:nbn:fi:att:1955e904-e3dd-4d7e-99f1-3fed446f9616",
                 "remote_resources": [
                     {
                         "byte_size": 8192,
@@ -9354,7 +9354,7 @@
                 "owner_id": "055ea4dade5ab2145954f56d4b51cef0"
             },
             "files": [],
-            "identifier": "urn:nbn:fi:att:cr955e904-e3dd-4d7e-99f1-3fed446f9617",
+            "identifier": "cr955e904-e3dd-4d7e-99f1-3fed446f9617",
             "mets_object_identifier": null,
             "preservation_state": 3,
             "preservation_state_modified": "2017-05-23T10:07:22.559656Z",
@@ -9394,9 +9394,9 @@
                         "identifier": "http://lexvo.org/id/iso639-3/eng"
                     }
                 ],
-                "metadata_version_identifier": "urn:nbn:fi:att:1955e904-e3dd-4d7e-99f1-3fed446f9617",
+                "metadata_version_identifier": "1955e904-e3dd-4d7e-99f1-3fed446f9617",
                 "modified": "2014-01-17T08:19:58Z",
-                "preferred_identifier": "pid:urn:preferred:dataset17",
+                "preferred_identifier": "urn:nbn:fi:att:1955e904-e3dd-4d7e-99f1-3fed446f9617",
                 "remote_resources": [
                     {
                         "byte_size": 8704,
@@ -9449,7 +9449,7 @@
                 "owner_id": "055ea531a6cac569425bed94459266ee"
             },
             "files": [],
-            "identifier": "urn:nbn:fi:att:cr955e904-e3dd-4d7e-99f1-3fed446f9618",
+            "identifier": "cr955e904-e3dd-4d7e-99f1-3fed446f9618",
             "mets_object_identifier": null,
             "preservation_state": 4,
             "preservation_state_modified": "2017-05-23T10:07:22.559656Z",
@@ -9489,9 +9489,9 @@
                         "identifier": "http://lexvo.org/id/iso639-3/eng"
                     }
                 ],
-                "metadata_version_identifier": "urn:nbn:fi:att:1955e904-e3dd-4d7e-99f1-3fed446f9618",
+                "metadata_version_identifier": "1955e904-e3dd-4d7e-99f1-3fed446f9618",
                 "modified": "2014-01-17T08:19:58Z",
-                "preferred_identifier": "pid:urn:preferred:dataset18",
+                "preferred_identifier": "urn:nbn:fi:att:1955e904-e3dd-4d7e-99f1-3fed446f9618",
                 "remote_resources": [
                     {
                         "byte_size": 9216,
@@ -9544,7 +9544,7 @@
                 "owner_id": "053bffbcc41edad4853bea91fc42ea18"
             },
             "files": [],
-            "identifier": "urn:nbn:fi:att:cr955e904-e3dd-4d7e-99f1-3fed446f9619",
+            "identifier": "cr955e904-e3dd-4d7e-99f1-3fed446f9619",
             "mets_object_identifier": null,
             "preservation_state": 5,
             "preservation_state_modified": "2017-05-23T10:07:22.559656Z",
@@ -9584,9 +9584,9 @@
                         "identifier": "http://lexvo.org/id/iso639-3/eng"
                     }
                 ],
-                "metadata_version_identifier": "urn:nbn:fi:att:1955e904-e3dd-4d7e-99f1-3fed446f9619",
+                "metadata_version_identifier": "1955e904-e3dd-4d7e-99f1-3fed446f9619",
                 "modified": "2014-01-17T08:19:58Z",
-                "preferred_identifier": "pid:urn:preferred:dataset19",
+                "preferred_identifier": "urn:nbn:fi:att:1955e904-e3dd-4d7e-99f1-3fed446f9619",
                 "remote_resources": [
                     {
                         "byte_size": 9728,
@@ -9638,7 +9638,7 @@
                 "owner_id": "053d18ecb29e752cb7a35cd77b34f5fd"
             },
             "files": [],
-            "identifier": "urn:nbn:fi:att:cr955e904-e3dd-4d7e-99f1-3fed446f9620",
+            "identifier": "cr955e904-e3dd-4d7e-99f1-3fed446f9620",
             "mets_object_identifier": null,
             "preservation_state": 0,
             "preservation_state_modified": null,
@@ -9678,9 +9678,9 @@
                         "identifier": "http://lexvo.org/id/iso639-3/eng"
                     }
                 ],
-                "metadata_version_identifier": "urn:nbn:fi:att:1955e904-e3dd-4d7e-99f1-3fed446f9620",
+                "metadata_version_identifier": "1955e904-e3dd-4d7e-99f1-3fed446f9620",
                 "modified": "2014-01-17T08:19:58Z",
-                "preferred_identifier": "pid:urn:preferred:dataset20",
+                "preferred_identifier": "urn:nbn:fi:att:1955e904-e3dd-4d7e-99f1-3fed446f9620",
                 "remote_resources": [
                     {
                         "byte_size": 10240,
@@ -9732,7 +9732,7 @@
                 "owner_id": "05593961536b76fa825281ccaedd4d4f"
             },
             "files": [],
-            "identifier": "urn:nbn:fi:att:cr955e904-e3dd-4d7e-99f1-3fed446f9621",
+            "identifier": "cr955e904-e3dd-4d7e-99f1-3fed446f9621",
             "mets_object_identifier": null,
             "preservation_state": 0,
             "preservation_state_modified": null,
@@ -9772,9 +9772,9 @@
                         "identifier": "http://lexvo.org/id/iso639-3/eng"
                     }
                 ],
-                "metadata_version_identifier": "urn:nbn:fi:att:1955e904-e3dd-4d7e-99f1-3fed446f9621",
+                "metadata_version_identifier": "1955e904-e3dd-4d7e-99f1-3fed446f9621",
                 "modified": "2014-01-17T08:19:58Z",
-                "preferred_identifier": "pid:urn:preferred:dataset21",
+                "preferred_identifier": "urn:nbn:fi:att:1955e904-e3dd-4d7e-99f1-3fed446f9621",
                 "remote_resources": [
                     {
                         "byte_size": 10752,
@@ -9826,7 +9826,7 @@
                 "owner_id": "055ea4dade5ab2145954f56d4b51cef0"
             },
             "files": [],
-            "identifier": "urn:nbn:fi:att:cr955e904-e3dd-4d7e-99f1-3fed446f9622",
+            "identifier": "cr955e904-e3dd-4d7e-99f1-3fed446f9622",
             "mets_object_identifier": null,
             "preservation_state": 0,
             "preservation_state_modified": null,
@@ -9866,9 +9866,9 @@
                         "identifier": "http://lexvo.org/id/iso639-3/eng"
                     }
                 ],
-                "metadata_version_identifier": "urn:nbn:fi:att:1955e904-e3dd-4d7e-99f1-3fed446f9622",
+                "metadata_version_identifier": "1955e904-e3dd-4d7e-99f1-3fed446f9622",
                 "modified": "2014-01-17T08:19:58Z",
-                "preferred_identifier": "pid:urn:preferred:dataset22",
+                "preferred_identifier": "urn:nbn:fi:att:1955e904-e3dd-4d7e-99f1-3fed446f9622",
                 "remote_resources": [
                     {
                         "byte_size": 11264,
@@ -9920,7 +9920,7 @@
                 "owner_id": "055ea531a6cac569425bed94459266ee"
             },
             "files": [],
-            "identifier": "urn:nbn:fi:att:cr955e904-e3dd-4d7e-99f1-3fed446f9623",
+            "identifier": "cr955e904-e3dd-4d7e-99f1-3fed446f9623",
             "mets_object_identifier": null,
             "preservation_state": 0,
             "preservation_state_modified": null,
@@ -9960,9 +9960,9 @@
                         "identifier": "http://lexvo.org/id/iso639-3/eng"
                     }
                 ],
-                "metadata_version_identifier": "urn:nbn:fi:att:1955e904-e3dd-4d7e-99f1-3fed446f9623",
+                "metadata_version_identifier": "1955e904-e3dd-4d7e-99f1-3fed446f9623",
                 "modified": "2014-01-17T08:19:58Z",
-                "preferred_identifier": "pid:urn:preferred:dataset23",
+                "preferred_identifier": "urn:nbn:fi:att:1955e904-e3dd-4d7e-99f1-3fed446f9623",
                 "remote_resources": [
                     {
                         "byte_size": 11776,
@@ -10011,7 +10011,7 @@
                 "creator_id": "053bffbcc41edad4853bea91fc42ea18",
                 "owner_id": "053bffbcc41edad4853bea91fc42ea18"
             },
-            "identifier": "urn:nbn:fi:att:cr955e904-e3dd-4d7e-99f1-3fed446f9624",
+            "identifier": "cr955e904-e3dd-4d7e-99f1-3fed446f9624",
             "research_dataset": {
                 "access_rights": {
                     "access_type": {
@@ -10248,7 +10248,7 @@
                         "identifier": "http://lexvo.org/id/iso639-3/eng"
                     }
                 ],
-                "metadata_version_identifier": "urn:nbn:fi:att:1955e904-e3dd-4d7e-99f1-3fed446f9624",
+                "metadata_version_identifier": "1955e904-e3dd-4d7e-99f1-3fed446f9624",
                 "modified": "2014-01-17T08:19:58Z",
                 "other_identifier": [
                     {
@@ -10322,7 +10322,7 @@
                         }
                     }
                 ],
-                "preferred_identifier": "very:unique:urn-24",
+                "preferred_identifier": "urn:nbn:fi:att:1955e904-e3dd-4d7e-99f1-3fed446f9624",
                 "provenance": [
                     {
                         "description": {
@@ -10804,7 +10804,7 @@
                 "creator_id": "053bffbcc41edad4853bea91fc42ea18",
                 "owner_id": "053d18ecb29e752cb7a35cd77b34f5fd"
             },
-            "identifier": "urn:nbn:fi:att:cr955e904-e3dd-4d7e-99f1-3fed446f9625",
+            "identifier": "cr955e904-e3dd-4d7e-99f1-3fed446f9625",
             "research_dataset": {
                 "access_rights": {
                     "access_type": {
@@ -11041,7 +11041,7 @@
                         "identifier": "http://lexvo.org/id/iso639-3/eng"
                     }
                 ],
-                "metadata_version_identifier": "urn:nbn:fi:att:1955e904-e3dd-4d7e-99f1-3fed446f9625",
+                "metadata_version_identifier": "1955e904-e3dd-4d7e-99f1-3fed446f9625",
                 "modified": "2014-01-17T08:19:58Z",
                 "other_identifier": [
                     {
@@ -11115,7 +11115,7 @@
                         }
                     }
                 ],
-                "preferred_identifier": "very:unique:urn-25",
+                "preferred_identifier": "urn:nbn:fi:att:1955e904-e3dd-4d7e-99f1-3fed446f9625",
                 "provenance": [
                     {
                         "description": {
@@ -11597,7 +11597,7 @@
                 "creator_id": "053bffbcc41edad4853bea91fc42ea18",
                 "owner_id": "05593961536b76fa825281ccaedd4d4f"
             },
-            "identifier": "urn:nbn:fi:att:cr955e904-e3dd-4d7e-99f1-3fed446f9626",
+            "identifier": "cr955e904-e3dd-4d7e-99f1-3fed446f9626",
             "research_dataset": {
                 "access_rights": {
                     "access_type": {
@@ -11834,7 +11834,7 @@
                         "identifier": "http://lexvo.org/id/iso639-3/eng"
                     }
                 ],
-                "metadata_version_identifier": "urn:nbn:fi:att:1955e904-e3dd-4d7e-99f1-3fed446f9626",
+                "metadata_version_identifier": "1955e904-e3dd-4d7e-99f1-3fed446f9626",
                 "modified": "2014-01-17T08:19:58Z",
                 "other_identifier": [
                     {
@@ -11908,7 +11908,7 @@
                         }
                     }
                 ],
-                "preferred_identifier": "very:unique:urn-26",
+                "preferred_identifier": "urn:nbn:fi:att:1955e904-e3dd-4d7e-99f1-3fed446f9626",
                 "provenance": [
                     {
                         "description": {
@@ -12398,7 +12398,7 @@
                 19,
                 20
             ],
-            "identifier": "urn:nbn:fi:att:cr955e904-e3dd-4d7e-99f1-3fed446f9627",
+            "identifier": "cr955e904-e3dd-4d7e-99f1-3fed446f9627",
             "mets_object_identifier": null,
             "preservation_state": 0,
             "preservation_state_modified": null,
@@ -12454,9 +12454,9 @@
                         "identifier": "http://lexvo.org/id/iso639-3/eng"
                     }
                 ],
-                "metadata_version_identifier": "urn:nbn:fi:att:1955e904-e3dd-4d7e-99f1-3fed446f9610-alt-1",
+                "metadata_version_identifier": "1955e904-e3dd-4d7e-99f1-3fed446f9610-alt-1",
                 "modified": "2014-01-17T08:19:58Z",
-                "preferred_identifier": "pid:urn:preferred:dataset10",
+                "preferred_identifier": "urn:nbn:fi:att:1955e904-e3dd-4d7e-99f1-3fed446f9610",
                 "title": {
                     "en": "Wonderful Title"
                 },
@@ -12487,7 +12487,7 @@
                 19,
                 20
             ],
-            "identifier": "urn:nbn:fi:att:cr955e904-e3dd-4d7e-99f1-3fed446f9628",
+            "identifier": "cr955e904-e3dd-4d7e-99f1-3fed446f9628",
             "mets_object_identifier": null,
             "preservation_state": 0,
             "preservation_state_modified": null,
@@ -12543,9 +12543,9 @@
                         "identifier": "http://lexvo.org/id/iso639-3/eng"
                     }
                 ],
-                "metadata_version_identifier": "urn:nbn:fi:att:1955e904-e3dd-4d7e-99f1-3fed446f9610-alt-2",
+                "metadata_version_identifier": "1955e904-e3dd-4d7e-99f1-3fed446f9610-alt-2",
                 "modified": "2014-01-17T08:19:58Z",
-                "preferred_identifier": "pid:urn:preferred:dataset10",
+                "preferred_identifier": "urn:nbn:fi:att:1955e904-e3dd-4d7e-99f1-3fed446f9610",
                 "title": {
                     "en": "Wonderful Title"
                 },

--- a/src/metax_api/tests/utils.py
+++ b/src/metax_api/tests/utils.py
@@ -15,19 +15,22 @@ def get_json_schema(model_name):
         return json_load(f)
 
 
-def generate_test_identifier(itype, index):
+def generate_test_identifier(itype, index, urn=True):
     '''
     Generate urn-type identifier ending with uuid4
 
     :param index: positive integer for making test identifiers unique. Replaces characters from the end of uuid
     :param itype: to separate identifiers from each other on model level (e.g. is it a catalog record or data catalog)
+    :param urn: use urn prefix or not
     :return: test identifier
     '''
 
     postfix = str(index)
     # Use the same base identifier for the tests and vary by the identifier type and the incoming positive integer
     uuid = str(itype) + '955e904-e3dd-4d7e-99f1-3fed446f96d5'
-    return 'urn:nbn:fi:att:%s' % (uuid[:-len(postfix)] + postfix)
+    if urn:
+        return 'urn:nbn:fi:att:%s' % (uuid[:-len(postfix)] + postfix)
+    return uuid[:-len(postfix)] + postfix
 
 
 class TestClassUtils():


### PR DESCRIPTION
Decided not to include production data catalogs in current test data generation, as it quickly devolved into a clusterfuck with tests breaking...

What I would recommend instead, keep the current test data as is. Either create a separate script to copy (not move, just copy) existing datasets from testdata and push them to production catalogs during test env deployment if it is really important to have data in those datalogs already. The catalogs themselves can be browsed in test envs already anyway.

Or even better, wait until we have real IDA projects as files test data, and create test datasets out of those, and store into related production catalogs.