### PR TITLE
CSCMETAX-371: [ADD] Return specified fields only from various GET api's

### DIFF
--- a/src/metax_api/api/rest/base/router.py
+++ b/src/metax_api/api/rest/base/router.py
@@ -29,11 +29,10 @@ from .views import (
 
 class CustomRouter(DefaultRouter):
 
-    """
-    Override default router to allow PUT and PATCH methods in resource list url
-    """
-
     def __init__(self, *args, **kwargs):
+        """
+        Override to allow PUT and PATCH methods in resource list url.
+        """
         self.routes.pop(0)
         self.routes.insert(0, Route(
             url=r'^{prefix}{trailing_slash}$',
@@ -49,6 +48,13 @@ class CustomRouter(DefaultRouter):
         ))
         super(CustomRouter, self).__init__(*args, **kwargs)
 
+    def get_default_base_name(self, viewset):
+        """
+        When a viewset has no queryset set, or base_name is not passed to a router as the
+        3rd parameter, automatically determine base name.
+        """
+        return viewset.__class__.__name__.split('View')[0]
+
 
 router = CustomRouter(trailing_slash=False)
 router.register(r'apierrors/?', ApiErrorViewSet)
@@ -58,7 +64,7 @@ router.register(r'datacatalogs/?', DataCatalogViewSet)
 router.register(r'directories/?', DirectoryViewSet)
 router.register(r'files/?', FileViewSet)
 router.register(r'filestorages/?', FileStorageViewSet)
-router.register(r'schemas/?', SchemaViewSet, 'schema')
+router.register(r'schemas/?', SchemaViewSet)
 
 # note: this somehow maps to list-api... but the end result works when
 # the presence of the parameters is inspected in the list-api method.

--- a/src/metax_api/api/rest/base/serializers/catalog_record_serializer.py
+++ b/src/metax_api/api/rest/base/serializers/catalog_record_serializer.py
@@ -34,6 +34,9 @@ class CatalogRecordSerializer(CommonSerializer):
             'preservation_state_modified',
             'preservation_description',
             'preservation_reason_description',
+            'dataset_version_set',
+            'next_dataset_version',
+            'previous_dataset_version',
             'mets_object_identifier',
             'editor',
             'removed',
@@ -92,13 +95,14 @@ class CatalogRecordSerializer(CommonSerializer):
     def to_representation(self, instance):
         res = super(CatalogRecordSerializer, self).to_representation(instance)
 
-        if self.expand_relation_requested('data_catalog'):
-            res['data_catalog'] = DataCatalogSerializer(instance.data_catalog).data
-        else:
-            res['data_catalog'] = {
-                'id': instance.data_catalog.id,
-                'identifier': instance.data_catalog.catalog_json['identifier'],
-            }
+        if 'data_catalog' in res:
+            if self.expand_relation_requested('data_catalog'):
+                res['data_catalog'] = DataCatalogSerializer(instance.data_catalog).data
+            else:
+                res['data_catalog'] = {
+                    'id': instance.data_catalog.id,
+                    'identifier': instance.data_catalog.catalog_json['identifier'],
+                }
 
         if 'contract' in res:
             if self.expand_relation_requested('contract'):
@@ -117,14 +121,14 @@ class CatalogRecordSerializer(CommonSerializer):
         if 'dataset_version_set' in res:
             res['dataset_version_set'] = instance.dataset_version_set.get_listing()
 
-        if instance.next_dataset_version_id:
+        if 'next_dataset_version' in res:
             res['next_dataset_version'] = {
                 'id': instance.next_dataset_version.id,
                 'identifier': instance.next_dataset_version.identifier,
                 'preferred_identifier': instance.next_dataset_version.preferred_identifier,
             }
 
-        if instance.previous_dataset_version_id:
+        if 'previous_dataset_version' in res:
             res['previous_dataset_version'] = {
                 'id': instance.previous_dataset_version.id,
                 'identifier': instance.previous_dataset_version.identifier,

--- a/src/metax_api/api/rest/base/serializers/common_serializer.py
+++ b/src/metax_api/api/rest/base/serializers/common_serializer.py
@@ -41,8 +41,21 @@ class CommonSerializer(ModelSerializer):
         }
 
     def __init__(self, *args, **kwargs):
+        """
+        For most usual GET requests, the fields to retrieve for an object can be
+        specified via the query param ?fields=x,y,z. Retrieve those fields from the
+        implicitly passed request object for processing in the to_representation() method.
+
+        The list of fields can also be explicitly passed to the serializer as a list
+        in the kw arg 'only_fields', when serializing objects outside of the common GET
+        api's.
+        """
+        if 'only_fields' in kwargs:
+            self.requested_fields = kwargs.pop('only_fields')
+
         super(CommonSerializer, self).__init__(*args, **kwargs)
-        if 'request' in self.context and 'fields' in self.context['request'].query_params:
+
+        if not self.requested_fields and 'request' in self.context and 'fields' in self.context['request'].query_params:
             self.requested_fields = self.context['request'].query_params['fields'].split(',')
 
     @transaction.atomic

--- a/src/metax_api/api/rest/base/serializers/common_serializer.py
+++ b/src/metax_api/api/rest/base/serializers/common_serializer.py
@@ -14,6 +14,9 @@ d = _logger.debug
 
 class CommonSerializer(ModelSerializer):
 
+    # when query parameter ?fields=x,y is used, will include a list of fields to return
+    requested_fields = None
+
     class Meta:
         model = Common
         fields = (
@@ -37,6 +40,11 @@ class CommonSerializer(ModelSerializer):
             'service_created':     { 'required': False },
         }
 
+    def __init__(self, *args, **kwargs):
+        super(CommonSerializer, self).__init__(*args, **kwargs)
+        if 'request' in self.context and 'fields' in self.context['request'].query_params:
+            self.requested_fields = self.context['request'].query_params['fields'].split(',')
+
     @transaction.atomic
     def save(self, *args, **kwargs):
         """
@@ -55,7 +63,9 @@ class CommonSerializer(ModelSerializer):
 
     def to_representation(self, instance):
         """
-        Copy-pasta / overrided from rest_framework code. Only return fields which have a non-null value
+        Copy-pasta / overrided from rest_framework code with the following modifications:
+        - Only return fields which have a non-null value
+        - When only specific fields are requested, skip fields accordingly
 
         Object instance -> Dict of primitive datatypes.
         """
@@ -63,6 +73,10 @@ class CommonSerializer(ModelSerializer):
         fields = self._readable_fields
 
         for field in fields:
+
+            if self.requested_fields and field.field_name not in self.requested_fields:
+                continue
+
             try:
                 attribute = field.get_attribute(instance)
             except SkipField:
@@ -75,7 +89,7 @@ class CommonSerializer(ModelSerializer):
             # resolve the pk value.
             check_for_none = attribute.pk if isinstance(attribute, PKOnlyObject) else attribute
             if check_for_none is None:
-                # this is the overrided block. dont return nulls
+                # this is an overrided block. dont return nulls
                 # ret[field.field_name] = None
                 pass
             else:

--- a/src/metax_api/api/rest/base/serializers/directory_serializer.py
+++ b/src/metax_api/api/rest/base/serializers/directory_serializer.py
@@ -62,7 +62,7 @@ class DirectorySerializer(CommonSerializer):
     def to_representation(self, instance):
         res = super(DirectorySerializer, self).to_representation(instance)
 
-        if instance.parent_directory:
+        if 'parent_directory' in res and instance.parent_directory:
             res['parent_directory'] = {
                 'id': instance.parent_directory.id,
                 'identifier': instance.parent_directory.identifier,

--- a/src/metax_api/api/rest/base/serializers/file_serializer.py
+++ b/src/metax_api/api/rest/base/serializers/file_serializer.py
@@ -62,23 +62,26 @@ class FileSerializer(CommonSerializer):
     def to_representation(self, instance):
         res = super(FileSerializer, self).to_representation(instance)
 
-        if self.expand_relation_requested('file_storage'):
-            res['file_storage'] = FileStorageSerializer(instance.file_storage).data
-        else:
-            res['file_storage'] = {
-                'id': instance.file_storage.id,
-                'identifier': instance.file_storage.file_storage_json['identifier'],
-            }
+        if 'file_storage' in res:
+            if self.expand_relation_requested('file_storage'):
+                res['file_storage'] = FileStorageSerializer(instance.file_storage).data
+            else:
+                res['file_storage'] = {
+                    'id': instance.file_storage.id,
+                    'identifier': instance.file_storage.file_storage_json['identifier'],
+                }
 
-        if self.expand_relation_requested('parent_directory'):
-            res['parent_directory'] = DirectorySerializer(instance.parent_directory).data
-        else:
-            res['parent_directory'] = {
-                'id': instance.parent_directory.id,
-                'identifier': instance.parent_directory.identifier,
-            }
+        if 'parent_directory' in res:
+            if self.expand_relation_requested('parent_directory'):
+                res['parent_directory'] = DirectorySerializer(instance.parent_directory).data
+            else:
+                res['parent_directory'] = {
+                    'id': instance.parent_directory.id,
+                    'identifier': instance.parent_directory.identifier,
+                }
 
-        res['checksum'] = self._form_checksum(res)
+        if not self.requested_fields or 'checksum' in self.requested_fields:
+            res['checksum'] = self._form_checksum(res)
 
         return res
 

--- a/src/metax_api/api/rest/base/views/api_error_view.py
+++ b/src/metax_api/api/rest/base/views/api_error_view.py
@@ -4,10 +4,8 @@ from rest_framework.decorators import list_route
 from rest_framework.response import Response
 
 from metax_api.exceptions import Http403, Http501
-from metax_api.models import File
 from metax_api.services import ApiErrorService
 from .common_view import CommonViewSet
-from ..serializers import FileSerializer
 
 
 """
@@ -27,10 +25,6 @@ class ApiErrorViewSet(CommonViewSet):
 
     authentication_classes = ()
     permission_classes = ()
-
-    # required to make viewset work, dont serve a purpose...
-    queryset = File.objects.all()
-    serializer_class = FileSerializer
 
     def initial(self, request, *args, **kwargs):
         if request.user.username != 'metax':

--- a/src/metax_api/api/rest/base/views/common_view.py
+++ b/src/metax_api/api/rest/base/views/common_view.py
@@ -26,9 +26,24 @@ class CommonViewSet(ModelViewSet):
     lookup_field_internal = None
     cache = RedisSentinelCache()
 
+    # get_queryset() automatically includes these in .select_related(field1, field2...) when returning
+    # queryset to the caller
+    select_related = []
+
     # assigning the create_bulk method here allows for other views to assing their other,
     # customized method to be called instead instead of the generic one.
     create_bulk_method = CS.create_bulk
+
+    def __init__(self, *args, **kwargs):
+        super(CommonViewSet, self).__init__(*args, **kwargs)
+        if (hasattr(self, 'object') and self.object) and (not hasattr(self, 'queryset') or self.queryset is None):
+            # ^ must have attribute 'object' set, AND queryset not set.
+
+            # the primary location where a queryset is initialized for
+            # any inheriting viewset, in case not already specified in their ViewSet class.
+            # avoids having to specify queryset in each ViewSet separately.
+            self.queryset = self.object.objects.all()
+            self.queryset_unfiltered = self.object.objects_unfiltered.all()
 
     def handle_exception(self, exc):
         """
@@ -47,12 +62,25 @@ class CommonViewSet(ModelViewSet):
     def get_queryset(self):
         additional_filters = {}
 
-        removed = CS.get_boolean_query_param(self.request, 'removed')
-        if removed:
+        if CS.get_boolean_query_param(self.request, 'removed'):
             additional_filters.update({'removed': True})
             self.queryset = self.queryset_unfiltered
 
-        return super(CommonViewSet, self).get_queryset().filter(**additional_filters)
+        if self.request.query_params.get('fields', False):
+            # only specified fields are requested to be returned
+
+            fields = self.request.query_params['fields'].split(',')
+
+            # causes only requested fields to be loaded from the db
+            self.queryset = self.queryset.only(*fields)
+
+            # check if requested fields are relations, so that we know to include them in select_related.
+            # if no fields is relation, select_related will be made empty.
+            self.select_related = [ rel for rel in self.select_related if rel in fields ]
+
+        return super(CommonViewSet, self).get_queryset() \
+            .select_related(*self.select_related) \
+            .filter(**additional_filters)
 
     def get_object(self, search_params=None):
         """

--- a/src/metax_api/api/rest/base/views/contract_view.py
+++ b/src/metax_api/api/rest/base/views/contract_view.py
@@ -18,9 +18,6 @@ class ContractViewSet(CommonViewSet):
     authentication_classes = ()
     permission_classes = ()
 
-    queryset = Contract.objects.all()
-    queryset_unfiltered = Contract.objects_unfiltered.all()
-
     serializer_class = ContractSerializer
     object = Contract
 

--- a/src/metax_api/api/rest/base/views/data_catalog_view.py
+++ b/src/metax_api/api/rest/base/views/data_catalog_view.py
@@ -15,10 +15,6 @@ class DataCatalogViewSet(CommonViewSet):
     authentication_classes = ()
     permission_classes = ()
 
-    # note: override get_queryset() to get more control
-    queryset = DataCatalog.objects.filter(active=True, removed=False)
-    queryset_unfiltered = DataCatalog.objects_unfiltered.all()
-
     serializer_class = DataCatalogSerializer
     object = DataCatalog
 

--- a/src/metax_api/api/rest/base/views/dataset_view.py
+++ b/src/metax_api/api/rest/base/views/dataset_view.py
@@ -46,7 +46,6 @@ class DatasetViewSet(CommonViewSet):
         return self._search_using_dataset_identifiers()
 
     def get_queryset(self):
-
         additional_filters = {}
         q_filters = []
 

--- a/src/metax_api/api/rest/base/views/dataset_view.py
+++ b/src/metax_api/api/rest/base/views/dataset_view.py
@@ -70,7 +70,7 @@ class DatasetViewSet(CommonViewSet):
             res.data = CRS.transform_datasets_to_format(res.data, request.query_params['dataset_format'])
             request.accepted_renderer = XMLRenderer()
         elif 'file_details' in request.query_params:
-            CRS.populate_file_details(res.data)
+            CRS.populate_file_details(res.data, request)
 
         return res
 

--- a/src/metax_api/api/rest/base/views/dataset_view.py
+++ b/src/metax_api/api/rest/base/views/dataset_view.py
@@ -24,12 +24,9 @@ class DatasetViewSet(CommonViewSet):
     authentication_classes = ()
     permission_classes = ()
 
-    # note: override get_queryset() to get more control
-    queryset = CatalogRecord.objects.select_related('data_catalog', 'contract').all()
-    queryset_unfiltered = CatalogRecord.objects_unfiltered.select_related('data_catalog', 'contract').all()
-
     serializer_class = CatalogRecordSerializer
     object = CatalogRecord
+    select_related = ['data_catalog', 'contract']
 
     lookup_field = 'pk'
 

--- a/src/metax_api/api/rest/base/views/directory_view.py
+++ b/src/metax_api/api/rest/base/views/directory_view.py
@@ -73,7 +73,8 @@ class DirectoryViewSet(CommonViewSet):
             max_depth=max_depth,
             dirs_only=dirs_only,
             include_parent=include_parent,
-            cr_identifier=cr_identifier
+            cr_identifier=cr_identifier,
+            request=request
         )
 
         return Response(files_and_dirs)

--- a/src/metax_api/api/rest/base/views/directory_view.py
+++ b/src/metax_api/api/rest/base/views/directory_view.py
@@ -19,15 +19,11 @@ class DirectoryViewSet(CommonViewSet):
     authentication_classes = ()
     permission_classes = ()
 
-    object = Directory
-
-    queryset = Directory.objects.select_related('parent_directory').all()
-    queryset_unfiltered = Directory.objects_unfiltered.select_related('parent_directory').all()
-
     serializer_class = DirectorySerializer
+    object = Directory
+    select_related = ['parent_directory']
 
     lookup_field_other = 'identifier'
-    create_bulk_method = FileService.create_bulk
 
     def list(self, request, *args, **kwargs):
         raise Http501()

--- a/src/metax_api/api/rest/base/views/file_storage_view.py
+++ b/src/metax_api/api/rest/base/views/file_storage_view.py
@@ -13,9 +13,6 @@ class FileStorageViewSet(CommonViewSet):
     authentication_classes = ()
     permission_classes = ()
 
-    queryset = FileStorage.objects.filter(active=True, removed=False)
-    queryset_unfiltered = FileStorage.objects_unfiltered.all()
-
     serializer_class = FileStorageSerializer
     object = FileStorage
 

--- a/src/metax_api/api/rest/base/views/file_view.py
+++ b/src/metax_api/api/rest/base/views/file_view.py
@@ -28,12 +28,9 @@ class FileViewSet(CommonViewSet):
     authentication_classes = ()
     permission_classes = ()
 
-    # note: override get_queryset() to get more control
-    queryset = File.objects.select_related('file_storage', 'parent_directory').all()
-    queryset_unfiltered = File.objects_unfiltered.select_related('file_storage', 'parent_directory').all()
-
     serializer_class = FileSerializer
     object = File
+    select_related = ['file_storage', 'parent_directory']
 
     lookup_field = 'pk'
 

--- a/src/metax_api/tests/api/rest/base/views/common/read.py
+++ b/src/metax_api/tests/api/rest/base/views/common/read.py
@@ -163,3 +163,30 @@ class ApiReadHTTPHeaderTests(CatalogRecordApiReadCommon):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertTrue(len(response.data.get('results')) > 6)
         self.assertTrue(len(response.data.get('results')) == 28)
+
+
+class ApiReadQueryParamTests(CatalogRecordApiReadCommon):
+
+    """
+    Misc common query params tests
+    """
+
+    def test_return_requested_fields_only(self):
+        """
+        While the param ?fields works with write operations too, the primary use case is when GETting.
+        """
+        response = self.client.get('/rest/datasets?fields=identifier')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual('identifier' in response.data['results'][0], True)
+        self.assertEqual(len(response.data['results'][0].keys()), 1)
+        self.assertEqual(len(response.data['results'][1].keys()), 1)
+
+        response = self.client.get('/rest/datasets/1?fields=identifier')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual('identifier' in response.data, True)
+        self.assertEqual(len(response.data.keys()), 1)
+
+        response = self.client.get('/rest/datasets/1?fields=identifier,data_catalog')
+        self.assertEqual('identifier' in response.data, True)
+        self.assertEqual('data_catalog' in response.data, True)
+        self.assertEqual(len(response.data.keys()), 2)

--- a/src/metax_api/tests/api/rest/base/views/directories/read.py
+++ b/src/metax_api/tests/api/rest/base/views/directories/read.py
@@ -213,6 +213,48 @@ class DirectoryApiReadFileBrowsingTests(DirectoryApiReadCommon):
         self.assertEqual(response.data.get('id', None), 3)
 
 
+class DirectoryApiReadFileBrowsingRetrieveSpecificFieldsTests(DirectoryApiReadCommon):
+
+    def test_retrieve_requested_directory_fields_only(self):
+        response = self.client.get('/rest/directories/3/files?directory_fields=identifier,directory_path')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data['directories'][0].keys()), 2)
+        self.assertEqual('identifier' in response.data['directories'][0], True)
+        self.assertEqual('directory_path' in response.data['directories'][0], True)
+
+    def test_retrieve_directory_byte_size_and_file_count(self):
+        """
+        There is some additional logic involved in retrieving byte_size and file_count, which warrants
+        targeted tests for just those fields.
+        """
+        response = self.client.get('/rest/directories/3/files?directory_fields=identifier,byte_size')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data['directories'][0].keys()), 2)
+        self.assertEqual('identifier' in response.data['directories'][0], True)
+        self.assertEqual('byte_size' in response.data['directories'][0], True)
+
+        response = self.client.get('/rest/directories/3/files?directory_fields=identifier,file_count')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data['directories'][0].keys()), 2)
+        self.assertEqual('identifier' in response.data['directories'][0], True)
+        self.assertEqual('file_count' in response.data['directories'][0], True)
+
+    def test_retrieve_requested_file_fields_only(self):
+        response = self.client.get('/rest/directories/3/files?file_fields=identifier,file_path')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data['files'][0].keys()), 2)
+        self.assertEqual('identifier' in response.data['files'][0], True)
+        self.assertEqual('file_path' in response.data['files'][0], True)
+
+    def test_retrieve_requested_file_and_directory_fields_only(self):
+        response = self.client.get('/rest/directories/3/files?file_fields=identifier&directory_fields=id')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data['files'][0].keys()), 1)
+        self.assertEqual('identifier' in response.data['files'][0], True)
+        self.assertEqual(len(response.data['directories'][0].keys()), 1)
+        self.assertEqual('id' in response.data['directories'][0], True)
+
+
 class DirectoryApiReadCatalogRecordFileBrowsingTests(DirectoryApiReadCommon):
 
     """
@@ -309,3 +351,45 @@ class DirectoryApiReadCatalogRecordFileBrowsingTests(DirectoryApiReadCommon):
         self.assertEqual('file_count' in response.data, True)
         self.assertEqual(response.data['byte_size'], byte_size)
         self.assertEqual(response.data['file_count'], file_count)
+
+
+class DirectoryApiReadCatalogRecordFileBrowsingRetrieveSpecificFieldsTests(DirectoryApiReadCommon):
+
+    def test_retrieve_requested_directory_fields_only(self):
+        response = self.client.get('/rest/datasets/12?file_details&directory_fields=identifier,directory_path')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data['research_dataset']['directories'][0]['details'].keys()), 2)
+        self.assertEqual('identifier' in response.data['research_dataset']['directories'][0]['details'], True)
+        self.assertEqual('directory_path' in response.data['research_dataset']['directories'][0]['details'], True)
+
+    def test_retrieve_directory_byte_size_and_file_count(self):
+        """
+        There is some additional logic involved in retrieving byte_size and file_count, which warrants
+        targeted tests for just those fields.
+        """
+        response = self.client.get('/rest/datasets/12?file_details&directory_fields=identifier,byte_size')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data['research_dataset']['directories'][0]['details'].keys()), 2)
+        self.assertEqual('identifier' in response.data['research_dataset']['directories'][0]['details'], True)
+        self.assertEqual('byte_size' in response.data['research_dataset']['directories'][0]['details'], True)
+
+        response = self.client.get('/rest/datasets/12?file_details&directory_fields=identifier,file_count')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data['research_dataset']['directories'][0]['details'].keys()), 2)
+        self.assertEqual('identifier' in response.data['research_dataset']['directories'][0]['details'], True)
+        self.assertEqual('file_count' in response.data['research_dataset']['directories'][0]['details'], True)
+
+    def test_retrieve_requested_file_fields_only(self):
+        response = self.client.get('/rest/datasets/12?file_details&file_fields=identifier,file_path')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data['research_dataset']['files'][0]['details'].keys()), 2)
+        self.assertEqual('identifier' in response.data['research_dataset']['files'][0]['details'], True)
+        self.assertEqual('file_path' in response.data['research_dataset']['files'][0]['details'], True)
+
+    def test_retrieve_requested_file_and_directory_fields_only(self):
+        response = self.client.get('/rest/datasets/12?file_details&file_fields=identifier&directory_fields=id')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data['research_dataset']['files'][0]['details'].keys()), 1)
+        self.assertEqual('identifier' in response.data['research_dataset']['files'][0]['details'], True)
+        self.assertEqual(len(response.data['research_dataset']['directories'][0]['details'].keys()), 1)
+        self.assertEqual('id' in response.data['research_dataset']['directories'][0]['details'], True)

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -462,6 +462,16 @@ paths:
           description: identifier of a catalog record. browse only files that have been selected for that record.
           required: false
           type: string
+        - name: file_fields
+          in: query
+          description: Comma-separated list of field names to retrieve for files
+          required: false
+          type: string
+        - name: directory_fields
+          in: query
+          description: Comma-separated list of field names to retrieve for directories
+          required: false
+          type: string
       responses:
         '200':
           description: |
@@ -902,6 +912,16 @@ paths:
             byte_size and file_count in each directory's details as extra information.
           required: false
           type: boolean
+        - name: file_fields
+          in: query
+          description: Comma-separated list of field names to retrieve for file details, when details are requested (query param file_details=true is passed)
+          required: false
+          type: string
+        - name: directory_fields
+          in: query
+          description: Comma-separated list of field names to retrieve for directory details, when details are requested (query param file_details=true is passed)
+          required: false
+          type: string
         - name: preferred_identifier
           in: query
           description: |


### PR DESCRIPTION
In short, supported API's:
- all common GET list, and GET detail, i.e. /files/1?fields=x,y
- file browsing /directories/pid/files?file_fields=x,y&directory_fields=x,y
- /datasets/pid?file_details&file_fields=x,y&directory_fields=x,y