### PR TITLE
CSCMETAX-385: [ADD] Fix breaking changes in new 3.8.x versions of DRF

### DIFF
--- a/src/metax_api/api/rest/base/router.py
+++ b/src/metax_api/api/rest/base/router.py
@@ -44,6 +44,7 @@ class CustomRouter(DefaultRouter):
                 'delete': 'destroy_bulk'        # custom
             },
             name='{basename}-list',
+            detail=False,
             initkwargs={'suffix': 'List'}
         ))
         super(CustomRouter, self).__init__(*args, **kwargs)


### PR DESCRIPTION
HOX

Requires djangorestframework 3.8 or newer to be installed before deploying, old versions will break