### PR TITLE
CSCMETAX-400: [ADD] Datasets api: Add query param ?migration_override…

### DIFF
--- a/src/metax_api/models/catalog_record.py
+++ b/src/metax_api/models/catalog_record.py
@@ -292,9 +292,9 @@ class CatalogRecord(Common):
             self._post_create_operations()
             _logger.info(
                 'Created a new <CatalogRecord id: %d, '
-                'metadata_version_identifier: %s, '
+                'identifier: %s, '
                 'preferred_identifier: %s >'
-                % (self.id, self.metadata_version_identifier, self.preferred_identifier)
+                % (self.id, self.identifier, self.preferred_identifier)
             )
         else:
             self._pre_update_operations()

--- a/src/metax_api/tests/api/rest/base/views/datasets/write.py
+++ b/src/metax_api/tests/api/rest/base/views/datasets/write.py
@@ -289,6 +289,18 @@ class CatalogRecordApiWriteCreateTests(CatalogRecordApiWriteCommon):
         response = self.client.put('/rest/datasets/%d' % new['id'], new, format="json")
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
 
+    def test_parameter_migration_override_preferred_identifier_when_creating(self):
+        """
+        Normally, when saving to att/ida catalogs, providing a custom preferred_identifier is not
+        permitted. Using the optional query parameter ?migration_override=bool a custom preferred_identifier
+        can be passed.
+        """
+        custom_pid = 'custom-pid-value'
+        self.cr_test_data['research_dataset']['preferred_identifier'] = custom_pid
+        response = self.client.post('/rest/datasets?migration_override', self.cr_test_data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.data)
+        self.assertEqual(response.data['research_dataset']['preferred_identifier'], custom_pid)
+
 
 class CatalogRecordApiWriteIdentifierUniqueness(CatalogRecordApiWriteCommon):
     """


### PR DESCRIPTION
…=bool which enables passing a custom preferred_identifier when creating datasets