### PR TITLE
CSCMETAX-442: [FIX|REF] Fix datacite convert errors. Convert metax da…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 coveralls==1.3.0 # code coverage reportin in travis
+datacite==1.0.1 # BSD-license. convert datasets to datacite xml. datacite metadata store api wrappers
 dicttoxml==1.7.4
 python-dateutil==2.7.3
 Django==2.0  # BSD-license

--- a/src/metax_api/api/rest/base/schemas/datacite_4.1_schema.json
+++ b/src/metax_api/api/rest/base/schemas/datacite_4.1_schema.json
@@ -1,0 +1,700 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "datacite-v4.1.json",
+  "title": "DataCite v4.1",
+  "description": "JSON representation of the DataCite v4.1 schema.",
+  "additionalProperties": false,
+  "definitions": {
+    "doi": {
+      "description": "Digital object identifier.",
+      "type": "string",
+      "pattern": "10\\..+/.+"
+    },
+    "year": {
+      "type": "string"
+    },
+    "language": {
+      "description": "Allowed values are taken from IETF BCP 47, ISO 639-1 language codes.",
+      "type": "string"
+    },
+    "uri": {
+      "description": "For adding future URI validation.",
+      "type": "string"
+    },
+    "nameIdentifiers": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "nameIdentifier": {
+            "type": "string"
+          },
+          "nameIdentifierScheme": {
+            "type": "string"
+          },
+          "schemeURI": {
+            "$ref": "#/definitions/uri"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "nameIdentifier",
+          "nameIdentifierScheme"
+        ]
+      }
+    }
+  },
+  "type": "object",
+  "properties": {
+    "identifier": {
+      "description": "A persistent identifier that identifies a resource. Currently, only DOI is allowed.",
+      "type": "object",
+      "properties": {
+        "identifier": {
+          "$ref": "#/definitions/doi"
+        },
+        "identifierType": {
+          "enum": [
+            "DOI"
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "identifier",
+        "identifierType"
+      ]
+    },
+    "creators": {
+      "description": "The main researchers involved working on the data, or the authors of the publication in priority order. May be a corporate/institutional or personal name. Format: Family, Given",
+      "type": "array",
+      "items": {
+        "creatorName": {
+          "type": "string"
+        },
+        "nameType": {
+          "enum": [
+            "Organisational",
+            "Personal"
+          ]
+        },
+        "nameIdentifiers": {
+          "$ref": "#/definitions/nameIdentifiers"
+        },
+        "affiliations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "familyName": {
+          "type": "string"
+        },
+        "givenName": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "creatorName"
+      ]
+    },
+    "titles": {
+      "type": "array",
+      "items": {
+        "description": "A name or title by which a resource is known.",
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "minLength": 1
+          },
+          "type": {
+            "description": "WARNING: This field has been superseded by 'titleType'",
+            "enum": [
+              "AlternativeTitle",
+              "Subtitle",
+              "TranslatedTitle",
+              "Other"
+            ]
+          },
+          "titleType": {
+            "enum": [
+              "AlternativeTitle",
+              "Subtitle",
+              "TranslatedTitle",
+              "Other"
+            ]
+          },
+          "lang": {
+            "$ref": "#/definitions/language"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "title"
+        ]
+      }
+    },
+    "publisher": {
+      "description": "The name of the entity that holds, archives, publishes prints, distributes, releases, issues, or produces the resource. This property will be used to formulate the citation, so consider the prominence of the role. In the case of datasets, \"publish\" is understood to mean making the data available to the community of researchers.",
+      "type": "string",
+      "minLength": 1
+    },
+    "publicationYear": {
+      "description": "Year when the data is made publicly available. If an embargo period has been in effect, use the date when the embargo period ends. In the case of datasets, \"publish\" is understood to mean making the data available on a specific date to the community of researchers. If there is no standard publication year value, use the date that would be preferred from a citation perspective.",
+      "$ref": "#/definitions/year"
+    },
+    "subjects": {
+      "type": "array",
+      "items": {
+        "description": "Subject, keywords, classification codes, or key phrases describing the resource.",
+        "type": "object",
+        "properties": {
+          "subject": {
+            "type": "string"
+          },
+          "subjectScheme": {
+            "type": "string"
+          },
+          "schemeURI": {
+            "$ref": "#/definitions/uri"
+          },
+          "valueURI": {
+            "$ref": "#/definitions/uri"
+          },
+          "lang": {
+            "$ref": "#/definitions/language"
+          }
+        },
+        "additionalProperties": false,
+        "minProperties": 1
+      }
+    },
+    "contributors": {
+      "description": "The institution or person responsible for collecting, creating, or otherwise contributing to the developement of the dataset. The personal name format should be: Family, Given.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "contributorType": {
+            "enum": [
+              "ContactPerson",
+              "DataCollector",
+              "DataCurator",
+              "DataManager",
+              "Distributor",
+              "Editor",
+              "HostingInstitution",
+              "Other",
+              "Producer",
+              "ProjectLeader",
+              "ProjectManager",
+              "ProjectMember",
+              "RegistrationAgency",
+              "RegistrationAuthority",
+              "RelatedPerson",
+              "ResearchGroup",
+              "RightsHolder",
+              "Researcher",
+              "Sponsor",
+              "Supervisor",
+              "WorkPackageLeader"
+            ]
+          },
+          "contributorName": {
+            "type": "string"
+          },
+          "nameType": {
+            "enum": [
+              "Organisational",
+              "Personal"
+            ]
+          },
+          "nameIdentifiers": {
+            "$ref": "#/definitions/nameIdentifiers"
+          },
+          "affiliations": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "familyName": {
+            "type": "string"
+          },
+          "givenName": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "contributorName",
+          "contributorType"
+        ]
+      }
+    },
+    "dates": {
+      "description": "Different dates relevant to the work.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "date": {
+            "description": "YYYY,YYYY-MM-DD, YYYY-MM-DDThh:mm:ssTZD or any other format or level of granularity described in W3CDTF. Use RKMS-ISO8601 standard for depicting date ranges.",
+            "type": "string"
+          },
+          "dateType": {
+            "enum": [
+              "Accepted",
+              "Available",
+              "Collected",
+              "Copyrighted",
+              "Created",
+              "Issued",
+              "Submitted",
+              "Updated",
+              "Valid",
+              "Other"
+            ]
+          },
+          "dateInformation": {
+            "description": "Specific information about the date.",
+            "type": "string"
+          }
+        },
+        "additionalProperties": false,
+        "required": ["dateType"]
+      }
+    },
+    "language": {
+      "description": "Primary language of the resource.",
+      "$ref": "#/definitions/language"
+    },
+    "resourceType": {
+      "description": "The type of a resource. You may enter an additional free text description. The format is open, but the preferred format is a single term of some detail so that a pair can be formed with the sub-property.",
+      "type": "object",
+      "properties": {
+        "resourceType": {
+          "type": "string"
+        },
+        "resourceTypeGeneral": {
+          "description": "The general type of a resource.",
+          "enum": [
+            "Audiovisual",
+            "Collection",
+            "DataPaper",
+            "Dataset",
+            "Event",
+            "Image",
+            "InteractiveResource",
+            "Model",
+            "PhysicalObject",
+            "Service",
+            "Software",
+            "Sound",
+            "Text",
+            "Workflow",
+            "Other"
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": ["resourceTypeGeneral"]
+    },
+    "alternateIdentifiers": {
+      "description": "An identifier or identifiers other than the primary Identifier applied to the resource being registered. This may be any alphanumeric string which is unique within its domain of issue. May be used for local identifiers. AlternateIdentifier should be used for another identifier of the same instance (same location, same file).",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "alternateIdentifier": {
+            "type": "string"
+          },
+          "alternateIdentifierType": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "alternateIdentifier",
+          "alternateIdentifierType"
+        ]
+      }
+    },
+    "relatedIdentifiers": {
+      "description": "Identifiers of related resources. Use this property to indicate subsets of properties, as appropriate.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "relatedIdentifier": {
+            "type": "string"
+          },
+          "relatedIdentifierType": {
+            "enum": [
+              "ARK",
+              "arXiv",
+              "bibcode",
+              "DOI",
+              "EAN13",
+              "EISSN",
+              "Handle",
+              "IGSN",
+              "ISBN",
+              "ISSN",
+              "ISTC",
+              "LISSN",
+              "LSID",
+              "PMID",
+              "PURL",
+              "UPC",
+              "URL",
+              "URN"
+            ]
+          },
+          "relationType": {
+            "enum": [
+              "IsCitedBy",
+              "Cites",
+              "IsSupplementTo",
+              "IsSupplementedBy",
+              "IsContinuedBy",
+              "Continues",
+              "IsDescribedBy",
+              "Describes",
+              "HasMetadata",
+              "IsMetadataFor",
+              "HasVersion",
+              "IsVersionOf",
+              "IsNewVersionOf",
+              "IsPreviousVersionOf",
+              "IsPartOf",
+              "HasPart",
+              "IsReferencedBy",
+              "References",
+              "IsDocumentedBy",
+              "Documents",
+              "IsCompiledBy",
+              "Compiles",
+              "IsVariantFormOf",
+              "IsOriginalFormOf",
+              "IsIdenticalTo",
+              "Reviews",
+              "IsReviewedBy",
+              "IsDerivedFrom",
+              "IsSourceOf",
+              "IsRequiredBy",
+              "Requires"
+            ]
+          },
+          "resourceTypeGeneral": {
+            "description": "The general type of a resource.",
+            "enum": [
+              "Audiovisual",
+              "Collection",
+              "DataPaper",
+              "Dataset",
+              "Event",
+              "Image",
+              "InteractiveResource",
+              "Model",
+              "PhysicalObject",
+              "Service",
+              "Software",
+              "Sound",
+              "Text",
+              "Workflow",
+              "Other"
+            ]
+          },
+          "relatedMetadataScheme": {
+            "type": "string"
+          },
+          "schemeURI": {
+            "$ref": "#/definitions/uri"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "relatedIdentifier",
+          "relationType",
+          "relatedIdentifierType"
+        ]
+      }
+    },
+    "sizes": {
+      "description": "Unstructures size information about the resource.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "formats": {
+      "description": "Technical format of the resource. Use file extension or MIME type where possible.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "version": {
+      "description": "Version number of the resource. If the primary resource has changed the version number increases. Register a new identifier for a major version change. Individual stewards need to determine which are major vs. minor versions. May be used in conjunction with properties 11 and 12 (AlternateIdentifier and RelatedIdentifier) to indicate various information updates. May be used in conjunction with property 17 (Description) to indicate the nature and file/record range of version.",
+      "type": "string"
+    },
+    "rightsList": {
+      "description": "Any rights information for this resource. Provide a rights management statement for the resource or reference a service providing such information. Include embargo information if applicable. Use the complete title of a license and include version information if applicable.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "rightsURI": {
+            "$ref": "#/definitions/uri"
+          },
+          "rights": {
+            "type": "string"
+          },
+          "lang": {
+            "$ref": "#/definitions/language"
+          }
+        },
+        "additionalProperties": false,
+        "minProperties": 1
+      }
+    },
+    "descriptions": {
+      "description": "All additional information that does not fit in any of the other categories. May be used for technical information. It is a best practice to supply a description.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string",
+            "minLength": 1
+          },
+          "descriptionType": {
+            "type": "string",
+            "description": "The type of the description.",
+            "enum": [
+              "Abstract",
+              "Methods",
+              "SeriesInformation",
+              "TableOfContents",
+              "TechnicalInfo",
+              "Other"
+            ]
+          },
+          "lang": {
+            "$ref": "#/definitions/language"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "description",
+          "descriptionType"
+        ]
+      }
+    },
+    "fundingReferences": {
+      "description": "Information about financial support (funding) for the resource being registered.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "funderName": {
+            "description": "Name of the funding provider.",
+            "type": "string"
+            },
+          "funderIdentifier": {
+            "description": "Uniquely identifies a funding entity, according to various types.",
+            "type": "object",
+            "properties": {
+              "funderIdentifier": {
+                "type": "string"
+              },
+              "funderIdentifierType": {
+                "type": "string",
+                "enum": [
+                  "ISNI",
+                  "GRID",
+                  "Crossref Funder ID",
+                  "Other"
+                ]
+              }
+            },
+            "additionalProperties": false,
+            "required": [
+              "funderIdentifier",
+              "funderIdentifierType"
+            ]
+          },
+          "awardNumber": {
+            "description": "The code assigned by the funder to a sponsored award (grant).",
+            "type": "object",
+            "properties": {
+              "awardNumber": {
+                "type": "string"
+              },
+              "awardURI": {
+                "$ref": "#/definitions/uri"
+              }
+            },
+            "additionalProperties": false,
+            "required": ["awardNumber"]
+          },
+          "awardTitle": {
+            "description": "The human readable title of the award (grant).",
+            "type": "string"
+          }
+        },
+        "additionalProperties": false,
+        "required": ["funderName"]
+      }
+    },
+    "geoLocations": {
+      "description": "Spatial region or named place where the data was gathered or about which the data is focused.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "geoLocationPoint": {
+            "description": "A point location in space.",
+            "type": "object",
+            "properties": {
+              "pointLongitude": {
+                "description": "Longitudinal dimension of point.",
+                "type": "number"
+              },
+              "pointLatitude": {
+                "description": "Latitudinal dimension of point.",
+                "type": "number"
+              }
+            },
+            "additionalProperties": false,
+            "required": [
+              "pointLongitude",
+              "pointLatitude"
+            ]
+          },
+          "geoLocationBox": {
+            "description": "The spatial limits of a box.",
+            "type": "object",
+            "properties": {
+              "westBoundLongitude": {
+                "description": "Western longitudinal dimension of box.",
+                "type": "number"
+              },
+              "eastBoundLongitude": {
+                "description": "Eastern longitudinal dimension of box.",
+                "type": "number"
+              },
+              "southBoundLatitude": {
+                "description": "Southern latitudinal dimension of box.",
+                "type": "number"
+              },
+              "northBoundLatitude": {
+                "description": "Northern latitudinal dimension of box.",
+                "type": "number"
+              }
+            },
+            "additionalProperties": false,
+            "required": [
+              "westBoundLongitude",
+              "eastBoundLongitude",
+              "southBoundLatitude",
+              "northBoundLatitude"
+            ]
+          },
+          "geoLocationPlace": {
+            "description": "Spatial region or named place where the data was gathered or about which the data is focused.",
+            "type": "string"
+          },
+          "geoLocationPolygon": {
+            "description": "WARNING: This field has been superseded by 'geoLocationPolygons'.",
+            "type": "object",
+            "properties": {
+              "polygonPoints": {
+                "description": "A point location in a polygon. WARNING: Last point will be automatically added.",
+                "type": "array",
+                "minItems": 4,
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "pointLongitude": {
+                      "description": "Longitudinal dimension of point.",
+                      "type": "number"
+                    },
+                    "pointLatitude": {
+                      "description": "Latitudinal dimension of point.",
+                      "type": "number"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "pointLongitude",
+                    "pointLatitude"
+                  ]
+                }
+              }
+            }
+          },
+          "geoLocationPolygons": {
+            "description": "A drawn polygon area, defined by a set of points and lines connecting the points in a closed chain.",
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "polygonPoints": {
+                  "description": "A point location in a polygon.",
+                  "type": "array",
+                  "minItems": 4,
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "pointLongitude": {
+                        "description": "Longitudinal dimension of point.",
+                        "type": "number"
+                      },
+                      "pointLatitude": {
+                        "description": "Latitudinal dimension of point.",
+                        "type": "number"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                      "pointLongitude",
+                      "pointLatitude"
+                    ]
+                  }
+                },
+                "inPolygonPoint": {
+                  "description": "For any bound area that is larger than half the earth, define a (random) point inside.",
+                  "type": "object",
+                  "properties": {
+                    "pointLongitude": {
+                      "description": "Longitudinal dimension of point.",
+                      "type": "number"
+                    },
+                    "pointLatitude": {
+                      "description": "Latitudinal dimension of point.",
+                      "type": "number"
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false,
+              "required": ["polygonPoints"]
+            }
+          }
+        }
+      }
+    }
+  },
+  "required": [
+    "identifier",
+    "creators",
+    "titles",
+    "publisher",
+    "publicationYear",
+    "resourceType"
+  ]
+}

--- a/src/metax_api/services/__init__.py
+++ b/src/metax_api/services/__init__.py
@@ -9,6 +9,7 @@ from .api_error_service import ApiErrorService
 from .catalog_record_service import CatalogRecordService
 from .common_service import CommonService
 from .data_catalog_service import DataCatalogService
+from .datacite_service import DataciteService
 from .file_service import FileService
 from .reference_data_mixin import ReferenceDataMixin
 from .schema_service import SchemaService

--- a/src/metax_api/services/catalog_record_service.py
+++ b/src/metax_api/services/catalog_record_service.py
@@ -4,7 +4,6 @@
 #
 # :author: CSC - IT Center for Science Ltd., Espoo Finland <servicedesk@csc.fi>
 # :license: MIT
-
 import logging
 import urllib.parse
 from collections import defaultdict
@@ -20,6 +19,7 @@ from metax_api.exceptions import Http400, Http403, Http503
 from metax_api.models import CatalogRecord, Directory, File
 from metax_api.utils import RabbitMQ
 from .common_service import CommonService
+from .datacite_service import DataciteService
 from .file_service import FileService
 from .reference_data_mixin import ReferenceDataMixin
 
@@ -230,12 +230,19 @@ class CatalogRecordService(CommonService, ReferenceDataMixin):
         cr.pop('__actions')
         return data
 
-    @staticmethod
-    def transform_datasets_to_format(catalog_records, target_format, include_xml_declaration=True):
+    @classmethod
+    def transform_datasets_to_format(cls, catalog_records, target_format, include_xml_declaration=True):
         """
         params:
         catalog_records: a list of catalog record dicts, or a single dict
         """
+
+        if target_format == 'datacite':
+            xml = DataciteService.to_datacite_xml(catalog_records)
+            if not include_xml_declaration:
+                # the +1 is linebreak character
+                return xml[len("<?xml version='1.0' encoding='utf-8'?>") + 1:]
+            return xml
 
         def item_func(parent_name):
             """

--- a/src/metax_api/services/datacite_service.py
+++ b/src/metax_api/services/datacite_service.py
@@ -1,0 +1,286 @@
+# This file is part of the Metax API service
+#
+# Copyright 2017-2018 Ministry of Education and Culture, Finland
+#
+# :author: CSC - IT Center for Science Ltd., Espoo Finland <servicedesk@csc.fi>
+# :license: MIT
+import logging
+import re
+from os.path import dirname, join
+
+import jsonschema
+from datacite import schema41 as datacite_schema41
+
+from metax_api.exceptions import Http400
+from .common_service import CommonService
+
+
+_logger = logging.getLogger(__name__)
+
+
+class DataciteService(CommonService):
+
+    """
+    Methods related to various aspects of Datacite metadata handling.
+
+    In the future will probably house DOI related operations too.
+    """
+
+    @classmethod
+    def to_datacite_xml(cls, catalog_record):
+        """
+        Convert dataset from metax dataset datamodel to datacite json datamodel, validate datacite json,
+        and convert to and return datacite xml as string.
+
+        Currently only supports datacite version 4.1.
+        """
+        if isinstance(catalog_record, list):
+            raise Http400({ 'detail': ['datacite conversion can only be done to individual datasets, not lists.']})
+
+        rd = catalog_record['research_dataset']
+
+        if 'language' in rd:
+            # used when trying to get most relevant name from langString when only one value is allowed.
+            # note: language contains a three-letter language. we need a two-letter language, in order to
+            # access the langString translations. this may not work as intended for some languages
+            main_lang = rd['language'][0]['identifier'].split('http://lexvo.org/id/iso639-3/')[1][:2]
+        else:
+            main_lang = 'fi'
+
+        try:
+            publisher = cls._main_lang_or_default(rd['publisher']['name'], main_lang)
+        except:
+            raise Http400({
+                'detail': [
+                    'Unable to create datacite: Requested dataset is missing a datacite-required field: publisher'
+                ]
+            })
+
+        """
+        here contains required fields only, as specified by datacite:
+        identifier
+        creators
+        titles
+        publisher
+        publicationYear
+        resourceType
+        """
+        datacite_json = {
+            'identifier': {
+                # dummy-value until we start utilizing real DOI identifiers
+                'identifier': '10.0/0',
+                'identifierType': 'DOI',
+            },
+            'publicationYear': rd['modified'][0:4],
+            'creators': cls._creators(rd['creator'], main_lang=main_lang),
+            'titles': [
+                { 'lang': lang, 'title': title } for lang, title in rd['title'].items()
+            ],
+            'publisher': publisher,
+            'resourceType': {
+                'resourceTypeGeneral': cls._resourceTypeGeneral(rd)
+            }
+        }
+
+        # add optional fields
+
+        datacite_json['alternateIdentifiers'] = [{
+            'alternateIdentifier': rd['preferred_identifier'],
+            'alternateIdentifierType': 'URN'
+        }]
+
+        if 'issued' in rd or 'modified' in rd:
+            datacite_json['dates'] = []
+            if 'issued' in rd:
+                datacite_json['dates'].append({ 'dateType': 'Issued', 'date': rd['issued']})
+            if 'modified' in rd:
+                datacite_json['dates'].append({ 'dateType': 'Updated', 'date': rd['modified']})
+
+        if 'keyword' in rd or 'field_of_science' in rd or 'theme' in rd:
+            datacite_json['subjects'] = []
+            for kw in rd.get('keyword', []):
+                datacite_json['subjects'].append({ 'subject': kw })
+            for fos in rd.get('field_of_science', []):
+                datacite_json['subjects'].extend(cls._subjects(fos))
+            for theme in rd.get('theme', []):
+                datacite_json['subjects'].extend(cls._subjects(theme))
+
+        if 'total_ida_byte_size' in rd:
+            datacite_json['sizes'] = [str(rd['total_ida_byte_size'])]
+
+        if 'description' in rd:
+            datacite_json['descriptions'] = [
+                { 'lang': lang, 'description': desc, 'descriptionType': 'Abstract' }
+                for lang, desc in rd['description'].items()
+            ]
+
+        if 'license' in rd['access_rights']:
+            datacite_json['rightsList'] = cls._licenses(rd['access_rights'])
+
+        if 'language' in rd:
+            datacite_json['language'] = rd['language'][0]['identifier'].split('http://lexvo.org/id/iso639-3/')[1]
+
+        if 'contributor' in rd or 'rights_holder' in rd:
+            datacite_json['contributors'] = []
+            if 'contributor' in rd:
+                datacite_json['contributors'].extend(cls._contributors(rd['contributor'], main_lang=main_lang))
+            if 'rights_holder' in rd:
+                datacite_json['contributors'].extend(cls._contributors(rd['rights_holder'],
+                    contributor_type='RightsHolder', main_lang=main_lang))
+
+        if 'spatial' in rd:
+            datacite_json['geoLocations'] = cls._spatials(rd['spatial'])
+
+        try:
+            jsonschema.validate(
+                datacite_json,
+                cls.get_json_schema(join(dirname(dirname(__file__)), 'api/rest/base/schemas'), 'datacite_4.1')
+            )
+        except:
+            _logger.exception('Failed to validate metax dataset -> datacite conversion json')
+            raise
+
+        # generate and return datacite xml
+        return datacite_schema41.tostring(datacite_json)
+
+    @staticmethod
+    def _main_lang_or_default(field, main_lang=None):
+        """
+        To help with cases where only one string string is accepted, try to use main_lang of a langString.
+
+        Param 'field' may also be a standard str field, in which case the field's value is returned.
+        """
+        if isinstance(field, dict):
+            for lang in (main_lang, 'en', 'fi', 'und'):
+                try:
+                    return field[lang]
+                except:
+                    pass
+            return field[field.keys()[0]]
+        else:
+            return field
+
+    @staticmethod
+    def _resourceTypeGeneral(rd):
+        """
+        Probably needs mapping from metax resource_type to dc resourceTypeGeneral...
+        """
+        return "Dataset"
+
+    @classmethod
+    def _creators(cls, research_agents, main_lang):
+        creators = []
+        for ra in research_agents:
+
+            cr = { 'creatorName': cls._main_lang_or_default(ra['name'], main_lang=main_lang) }
+
+            if 'identifier' in ra:
+                cr['nameIdentifiers'] = [{ 'nameIdentifier': ra['identifier'], 'nameIdentifierScheme': 'URI' }]
+
+            if 'member_of' in ra:
+                cr['affiliations'] = cls._person_affiliations(ra, main_lang)
+
+            creators.append(cr)
+
+        return creators
+
+    @classmethod
+    def _contributors(cls, research_agents, contributor_type=None, main_lang=None):
+        contributors = []
+        for ra in research_agents:
+            cr = { 'contributorName': cls._main_lang_or_default(ra['name'], main_lang=main_lang) }
+
+            if contributor_type:
+                cr['contributorType'] = contributor_type
+            elif 'contributor_role' in ra:
+                cr['contributorType'] = cls._dc_contributor_type(ra['contributor_role']['identifier'])
+
+            if 'identifier' in ra:
+                cr['nameIdentifiers'] = [{ 'nameIdentifier': ra['identifier'], 'nameIdentifierScheme': 'URI' }]
+
+            if 'member_of' in ra:
+                cr['affiliations'] = cls._person_affiliations(ra, main_lang)
+
+            contributors.append(cr)
+
+        return contributors
+
+    @staticmethod
+    def _person_affiliations(person, main_lang):
+        affs = []
+        try:
+            # try to use main_lang of the affiliation firstly. if it fails for whatever reason,
+            # stuff the affiliation information in all its translations. the datacite spec is
+            # not specific at all regarding this, it does not even care about the lang of the
+            # the given value.
+            affs.append(person['member_of']['name'][main_lang])
+        except KeyError:
+            for lang, name_translation in person['member_of']['name'].items():
+                affs.append(name_translation)
+        return affs
+
+    @staticmethod
+    def _dc_contributor_type(metax_contributor_role):
+        """
+        Probably needs to be some kind of mapping from metax types to dc types...
+        """
+        return 'Other'
+
+    @staticmethod
+    def _subjects(concept):
+        subjects = []
+        for lang in concept['pref_label'].keys():
+            item = {}
+            if lang in concept['pref_label']:
+                item['schemeURI'] = concept['in_scheme']
+                item['subject'] = concept['pref_label'][lang]
+                item['lang'] = lang
+            subjects.append(item)
+        return subjects
+
+    @staticmethod
+    def _licenses(access_rights):
+        licenses = []
+        for license in access_rights['license']:
+            for lang in license['title'].keys():
+                licenses.append({
+                    'lang': lang,
+                    'rightsURI': license['license'],
+                    'rights': license['title'][lang],
+                })
+        return licenses
+
+    @staticmethod
+    def _spatials(spatials):
+        geolocations = []
+        for spatial in spatials:
+            geo_location = {}
+
+            if 'geographic_name' in spatial:
+                geo_location['geoLocationPlace'] = spatial['geographic_name']
+
+            for wkt in spatial.get('as_wkt', []):
+                if wkt.startswith('POINT'):
+                    geo_location['geoLocationPoint'] = {
+                        'pointLongitude': float(re.search('POINT\((.*) ', wkt, re.IGNORECASE).group(1)),
+                        'pointLatitude': float(re.search(' (.*)\)', wkt, re.IGNORECASE).group(1)),
+                    }
+                    # only one point can be placed
+                    break
+
+                elif wkt.startswith('POLYGON'):
+                    geo_location['geoLocationPolygon'] = { 'polygonPoints': [] }
+                    for point in wkt.split('POLYGON')[1][2:-2].split(','):
+                        longitude, latitude = point.strip().split(' ')
+                        polygon_point = {
+                            'pointLongitude': int(longitude),
+                            'pointLatitude': int(latitude),
+                        }
+                        geo_location['geoLocationPolygon']['polygonPoints'].append(polygon_point)
+
+                else:
+                    # not applicable
+                    pass
+            geolocations.append(geo_location)
+
+        return geolocations

--- a/src/metax_api/tests/api/oaipmh/minimal_api.py
+++ b/src/metax_api/tests/api/oaipmh/minimal_api.py
@@ -165,8 +165,6 @@ class OAIPMHReadTests(APITestCase, TestClassUtils):
         super(OAIPMHReadTests, cls).setUpClass()
 
     def setUp(self):
-        catalog_record_from_test_data = self._get_object_from_test_data('catalogrecord', requested_index=0)
-
         cr = CatalogRecord.objects.get(pk=1)
         cr.data_catalog.catalog_json['identifier'] = "urn:nbn:fi:att:data-catalog-att"
         cr.data_catalog.force_save()
@@ -175,8 +173,10 @@ class OAIPMHReadTests(APITestCase, TestClassUtils):
         cr.data_catalog.catalog_json['identifier'] = "urn:nbn:fi:att:data-catalog-ida"
         cr.data_catalog.force_save()
 
-        self.identifier = catalog_record_from_test_data['identifier']
-        self.preferred_identifier = catalog_record_from_test_data['research_dataset']['preferred_identifier']
+        # some cr that has publisher set...
+        cr = CatalogRecord.objects.filter(research_dataset__publisher__isnull=False).first()
+        self.identifier = cr.identifier
+        self.preferred_identifier = cr.preferred_identifier
         self._use_http_authorization()
 
     def _get_new_test_cr_data(self, cr_index=0, dc_index=0, c_index=0):
@@ -424,8 +424,7 @@ class OAIPMHReadTests(APITestCase, TestClassUtils):
                 self.assertEqual(sensitive_field_value not in str(content), True,
                     'field %s should have been stripped' % sensitive_field_value)
 
-        # setup some records to have sensitive fields
-        for cr in CatalogRecord.objects.filter(pk__in=(1, 2, 3)):
+        for cr in CatalogRecord.objects.filter(identifier=self.identifier):
             cr.research_dataset['curator'][0].update({
                 'email': sensitive_field_values[0],
                 'phone': sensitive_field_values[1],

--- a/src/metax_api/tests/api/rest/base/views/datasets/read.py
+++ b/src/metax_api/tests/api/rest/base/views/datasets/read.py
@@ -432,9 +432,10 @@ class CatalogRecordApiReadXMLTransformationTests(CatalogRecordApiReadCommon):
         self._check_dataset_xml_format_response(response, '<researchdataset')
 
     def test_read_dataset_xml_format_datacite(self):
-        response = self.client.get('/rest/datasets/1?dataset_format=datacite')
-        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
-        self._check_dataset_xml_format_response(response, '<resource')
+        for id in CatalogRecord.objects.filter(research_dataset__publisher__isnull=False).values_list('id', flat=True):
+            response = self.client.get('/rest/datasets/%d?dataset_format=datacite' % id)
+            self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
+            self._check_dataset_xml_format_response(response, '<resource')
 
     def test_read_dataset_xml_format_error_unknown_format(self):
         response = self.client.get('/rest/datasets/1?dataset_format=doesnotexist')


### PR DESCRIPTION
…tasets to datacite xml using 'datacite' library

Previous implemenetation of datacite conversion relied on xml transformation, which used our custom 'metax dataset xml' as a starting point, and contained no xml schema validation at the end of it. The end result currently is quite far from the schema, and the xslt is very difficult to get right.

As an alternative solution, use python 'datacite' library, which sports a datacite json-schema, and offers conversion from that json to xml representation. The json-way is easier to validate (there is a all-in-one json schema available), and easier to modify (just python code to create datacite json from metax dataset, instead of screwing around with xslt files). Just to be sure, the produced xml was manually tested to validate agains the datacite xml.

The 'datacite' library conveniently also includes wrappers for DOI-related api's.