### PR TITLE
CSCMETAX-437: [FIX] RequestLogging: If no useragent is set, print (no…

### DIFF
--- a/src/metax_api/middleware/request_logging.py
+++ b/src/metax_api/middleware/request_logging.py
@@ -32,7 +32,7 @@ class RequestLogging():
                     request.environ['REQUEST_METHOD'],
                     request.get_full_path(),
                     request.environ['SERVER_PROTOCOL'],
-                    request.environ['HTTP_USER_AGENT']
+                    request.environ.get('HTTP_USER_AGENT', '(no useragent)')
                 )
             )
         except:


### PR DESCRIPTION
… useragent) instead of crashing and burning