### PR TITLE
CSCMETAX-61: [FIX] When deleting datasets, only publish 'delete' to r…

### DIFF
--- a/src/metax_api/models/common.py
+++ b/src/metax_api/models/common.py
@@ -82,7 +82,7 @@ class Common(models.Model):
         Mark record as removed, never delete from db.
         """
         self.removed = True
-        self.save()
+        super().save(update_fields=['removed'])
 
     def modified_since(self, timestamp):
         """


### PR DESCRIPTION
…abbitmq

Before the recent refactoring of publishing to rabbitmq, when deleting a dataset,
only 'delete' was published. Now, after the refactoring, it was discovered that
when deleting a dataset, what happens is that actually the CR.save() method is
executed as well, by the superclass. Previously, it did not cause a rabbitmq
publish due to it being done in a different place. This is now fixed by having
the superclass (model Common) only save the value of field 'removed', and calling
its superclass (not CR.save(), and not common.save())