### PR TITLE
CSCMETAX-452: [ADD] Schema changes: Add contributor type and contribu…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,11 +8,11 @@ hiredis==0.2.0 # Used by redis (redis-py) for parser
 djangorestframework==3.8.2  # BSD-license
 django-rainbowtests==0.6.0 # colored test output
 flake8==3.5.0 # MIT-license
-gevent==1.3.5 # gunicorn dep
+gevent==1.3.6 # gunicorn dep
 gunicorn==19.9.0 # MIT-license
 ipdb==0.11 # dev tool
 jsonschema==2.6.0
-lxml==4.2.3
+lxml==4.2.4
 pika==0.12.0
 psycopg2-binary==2.7.5  # LGPL with exceptions or ZPL
 pyoai==2.5.0

--- a/src/metax_api/api/rest/base/schemas/att_dataset_schema.json
+++ b/src/metax_api/api/rest/base/schemas/att_dataset_schema.json
@@ -2,7 +2,7 @@
 {
     "@id":"http://uri.suomi.fi/datamodel/ns/mrd#",
     "title":"Metax Research Datasets",
-    "modified":"Mon, 11 Jun 2018 10:12:12 GMT",
+    "modified":"Fri, 17 Aug 2018 11:50:11 GMT",
     "$schema":"http://json-schema.org/draft-04/schema#",
     "type":"object",
     "allOf":[
@@ -78,7 +78,7 @@
                 },
                 "was_associated_with":{
                     "@id":"http://www.w3.org/ns/prov#wasAssociatedWith",
-                    "title":"wasAssociatedWith",
+                    "title":"Was associated with",
                     "description":"An activity association is an assignment of responsibility to an agent for an activity, indicating that the agent had a role in the activity.",
                     "@type":"@id",
                     "type":"array",
@@ -447,7 +447,7 @@
             "title":"Entity relation",
             "type":"object",
             "@id":"http://www.w3.org/ns/prov#EntityInfluence",
-            "description":"Description of a the dataset influence upon any other kind of entity.",
+            "description":"Description of a the dataset influence upon any other kind of entity. In Metax RelationType is used from reference data: https://wiki.eduuni.fi/pages/viewpage.action?spaceKey=CSCMETAX&title=Reference+Data",
             "properties":{
                 "entity":{
                     "@id":"http://www.w3.org/ns/prov#entity",
@@ -608,6 +608,17 @@
                     "@type":"@id",
                     "type":"object",
                     "$ref":"#/definitions/Organization"
+                },
+                "contributor_type":{
+                    "@id":"http://uri.suomi.fi/datamodel/ns/mrd#contributorType",
+                    "title":"Contributor type",
+                    "description":"Contributor type of the Organization. Based on the subset of the DataCite reference data.",
+                    "@type":"@id",
+                    "type":"array",
+                    "items":{
+                        "type":"object",
+                        "$ref":"#/definitions/Concept"
+                    }
                 }
             },
             "required":[
@@ -701,12 +712,26 @@
                     "$ref":"#/definitions/Organization"
                 },
                 "contributor_role":{
-                    "@id":"http://purl.org/dc/terms/type",
+                    "@id":"http://uri.suomi.fi/datamodel/ns/mrd#contributorRole",
                     "title":"Contributor role",
-                    "description":"Contributor role from reference data",
+                    "description":"Contribution role from CASRAI. This relates person with the contribution domain.",
                     "@type":"@id",
-                    "type":"object",
-                    "$ref":"#/definitions/Concept"
+                    "type":"array",
+                    "items":{
+                        "type":"object",
+                        "$ref":"#/definitions/Concept"
+                    }
+                },
+                "contributor_type":{
+                    "@id":"http://uri.suomi.fi/datamodel/ns/mrd#contributorType",
+                    "title":"Contributor type",
+                    "description":"Contributor type of the Agent. Reference data from DataCite.",
+                    "@type":"@id",
+                    "type":"array",
+                    "items":{
+                        "type":"object",
+                        "$ref":"#/definitions/Concept"
+                    }
                 }
             },
             "required":[
@@ -831,7 +856,7 @@
         },
         "ResearchAgent":{
             "title":"Agent",
-			"type":"object",
+            "type":"object",
             "@id":"http://xmlns.com/foaf/0.1/Agent",
 			"oneOf":[
                 {"$ref": "#/definitions/Person"},
@@ -892,6 +917,28 @@
                     "@type":"@id",
                     "type":"object",
                     "$ref":"#/definitions/Document"
+                },
+                "contributor_role":{
+                    "@id":"http://uri.suomi.fi/datamodel/ns/mrd#contributorRole",
+                    "title":"Contributor role",
+                    "description":"Contribution role from CASRAI. This relates person with the contribution domain.",
+                    "@type":"@id",
+                    "type":"array",
+                    "items":{
+                        "type":"object",
+                        "$ref":"#/definitions/Concept"
+                    }
+                },
+                "contributor_type":{
+                    "@id":"http://uri.suomi.fi/datamodel/ns/mrd#contributorType",
+                    "title":"Contributor type",
+                    "description":"Contributor type of the Agent. Reference data from DataCite.",
+                    "@type":"@id",
+                    "type":"array",
+                    "items":{
+                        "type":"object",
+                        "$ref":"#/definitions/Concept"
+                    }
                 }
             },
             "required":[

--- a/src/metax_api/api/rest/base/schemas/harvester_dataset_schema.json
+++ b/src/metax_api/api/rest/base/schemas/harvester_dataset_schema.json
@@ -2,7 +2,7 @@
 {
     "@id":"http://uri.suomi.fi/datamodel/ns/mrd#",
     "title":"Metax Research Datasets",
-    "modified":"Mon, 11 Jun 2018 10:12:12 GMT",
+    "modified":"Fri, 17 Aug 2018 11:50:11 GMT",
     "$schema":"http://json-schema.org/draft-04/schema#",
     "type":"object",
     "allOf":[
@@ -78,7 +78,7 @@
                 },
                 "was_associated_with":{
                     "@id":"http://www.w3.org/ns/prov#wasAssociatedWith",
-                    "title":"wasAssociatedWith",
+                    "title":"Was associated with",
                     "description":"An activity association is an assignment of responsibility to an agent for an activity, indicating that the agent had a role in the activity.",
                     "@type":"@id",
                     "type":"array",
@@ -502,7 +502,7 @@
             "title":"Entity relation",
             "type":"object",
             "@id":"http://www.w3.org/ns/prov#EntityInfluence",
-            "description":"Description of a the dataset influence upon any other kind of entity.",
+            "description":"Description of a the dataset influence upon any other kind of entity. In Metax RelationType is used from reference data: https://wiki.eduuni.fi/pages/viewpage.action?spaceKey=CSCMETAX&title=Reference+Data",
             "properties":{
                 "entity":{
                     "@id":"http://www.w3.org/ns/prov#entity",
@@ -726,6 +726,17 @@
                     "@type":"@id",
                     "type":"object",
                     "$ref":"#/definitions/Organization"
+                },
+                "contributor_type":{
+                    "@id":"http://uri.suomi.fi/datamodel/ns/mrd#contributorType",
+                    "title":"Contributor type",
+                    "description":"Contributor type of the Organization. Based on the subset of the DataCite reference data.",
+                    "@type":"@id",
+                    "type":"array",
+                    "items":{
+                        "type":"object",
+                        "$ref":"#/definitions/Concept"
+                    }
                 }
             },
             "required":[
@@ -819,12 +830,26 @@
                     "$ref":"#/definitions/Organization"
                 },
                 "contributor_role":{
-                    "@id":"http://purl.org/dc/terms/type",
+                    "@id":"http://uri.suomi.fi/datamodel/ns/mrd#contributorRole",
                     "title":"Contributor role",
-                    "description":"Contributor role from reference data",
+                    "description":"Contribution role from CASRAI. This relates person with the contribution domain.",
                     "@type":"@id",
-                    "type":"object",
-                    "$ref":"#/definitions/Concept"
+                    "type":"array",
+                    "items":{
+                        "type":"object",
+                        "$ref":"#/definitions/Concept"
+                    }
+                },
+                "contributor_type":{
+                    "@id":"http://uri.suomi.fi/datamodel/ns/mrd#contributorType",
+                    "title":"Contributor type",
+                    "description":"Contributor type of the Agent. Reference data from DataCite.",
+                    "@type":"@id",
+                    "type":"array",
+                    "items":{
+                        "type":"object",
+                        "$ref":"#/definitions/Concept"
+                    }
                 }
             },
             "required":[
@@ -1009,6 +1034,28 @@
                     "@type":"@id",
                     "type":"object",
                     "$ref":"#/definitions/Document"
+                },
+                "contributor_role":{
+                    "@id":"http://uri.suomi.fi/datamodel/ns/mrd#contributorRole",
+                    "title":"Contributor role",
+                    "description":"Contribution role from CASRAI. This relates person with the contribution domain.",
+                    "@type":"@id",
+                    "type":"array",
+                    "items":{
+                        "type":"object",
+                        "$ref":"#/definitions/Concept"
+                    }
+                },
+                "contributor_type":{
+                    "@id":"http://uri.suomi.fi/datamodel/ns/mrd#contributorType",
+                    "title":"Contributor type",
+                    "description":"Contributor type of the Agent. Reference data from DataCite.",
+                    "@type":"@id",
+                    "type":"array",
+                    "items":{
+                        "type":"object",
+                        "$ref":"#/definitions/Concept"
+                    }
                 }
             },
             "required":[

--- a/src/metax_api/api/rest/base/schemas/ida_dataset_schema.json
+++ b/src/metax_api/api/rest/base/schemas/ida_dataset_schema.json
@@ -2,7 +2,7 @@
 {
     "@id":"http://uri.suomi.fi/datamodel/ns/mrd#",
     "title":"Metax Research Datasets",
-    "modified":"Mon, 11 Jun 2018 10:12:12 GMT",
+    "modified":"Fri, 17 Aug 2018 11:50:11 GMT",
     "$schema":"http://json-schema.org/draft-04/schema#",
     "type":"object",
     "allOf":[
@@ -78,7 +78,7 @@
                 },
                 "was_associated_with":{
                     "@id":"http://www.w3.org/ns/prov#wasAssociatedWith",
-                    "title":"wasAssociatedWith",
+                    "title":"Was associated with",
                     "description":"An activity association is an assignment of responsibility to an agent for an activity, indicating that the agent had a role in the activity.",
                     "@type":"@id",
                     "type":"array",
@@ -432,7 +432,7 @@
             "title":"Entity relation",
             "type":"object",
             "@id":"http://www.w3.org/ns/prov#EntityInfluence",
-            "description":"Description of a the dataset influence upon any other kind of entity.",
+            "description":"Description of a the dataset influence upon any other kind of entity. In Metax RelationType is used from reference data: https://wiki.eduuni.fi/pages/viewpage.action?spaceKey=CSCMETAX&title=Reference+Data",
             "properties":{
                 "entity":{
                     "@id":"http://www.w3.org/ns/prov#entity",
@@ -656,6 +656,17 @@
                     "@type":"@id",
                     "type":"object",
                     "$ref":"#/definitions/Organization"
+                },
+                "contributor_type":{
+                    "@id":"http://uri.suomi.fi/datamodel/ns/mrd#contributorType",
+                    "title":"Contributor type",
+                    "description":"Contributor type of the Organization. Based on the subset of the DataCite reference data.",
+                    "@type":"@id",
+                    "type":"array",
+                    "items":{
+                        "type":"object",
+                        "$ref":"#/definitions/Concept"
+                    }
                 }
             },
             "required":[
@@ -749,12 +760,26 @@
                     "$ref":"#/definitions/Organization"
                 },
                 "contributor_role":{
-                    "@id":"http://purl.org/dc/terms/type",
+                    "@id":"http://uri.suomi.fi/datamodel/ns/mrd#contributorRole",
                     "title":"Contributor role",
-                    "description":"Contributor role from reference data",
+                    "description":"Contribution role from CASRAI. This relates person with the contribution domain.",
                     "@type":"@id",
-                    "type":"object",
-                    "$ref":"#/definitions/Concept"
+                    "type":"array",
+                    "items":{
+                        "type":"object",
+                        "$ref":"#/definitions/Concept"
+                    }
+                },
+                "contributor_type":{
+                    "@id":"http://uri.suomi.fi/datamodel/ns/mrd#contributorType",
+                    "title":"Contributor type",
+                    "description":"Contributor type of the Agent. Reference data from DataCite.",
+                    "@type":"@id",
+                    "type":"array",
+                    "items":{
+                        "type":"object",
+                        "$ref":"#/definitions/Concept"
+                    }
                 }
             },
             "required":[
@@ -940,6 +965,28 @@
                     "@type":"@id",
                     "type":"object",
                     "$ref":"#/definitions/Document"
+                },
+                "contributor_role":{
+                    "@id":"http://uri.suomi.fi/datamodel/ns/mrd#contributorRole",
+                    "title":"Contributor role",
+                    "description":"Contribution role from CASRAI. This relates person with the contribution domain.",
+                    "@type":"@id",
+                    "type":"array",
+                    "items":{
+                        "type":"object",
+                        "$ref":"#/definitions/Concept"
+                    }
+                },
+                "contributor_type":{
+                    "@id":"http://uri.suomi.fi/datamodel/ns/mrd#contributorType",
+                    "title":"Contributor type",
+                    "description":"Contributor type of the Agent. Reference data from DataCite.",
+                    "@type":"@id",
+                    "type":"array",
+                    "items":{
+                        "type":"object",
+                        "$ref":"#/definitions/Concept"
+                    }
                 }
             },
             "required":[

--- a/src/metax_api/services/catalog_record_service.py
+++ b/src/metax_api/services/catalog_record_service.py
@@ -438,11 +438,13 @@ class CatalogRecordService(CommonService, ReferenceDataMixin):
         for project in research_dataset.get('is_output_of', []):
             for org_obj in project.get('source_organization', []):
                 cls.process_org_obj_against_ref_data(orgdata, org_obj,
-                                                     'research_dataset.is_output_of.source_organization')
+                                                     'research_dataset.is_output_of.source_organization',
+                                                     refdata=refdata, errors=errors)
 
             for org_obj in project.get('has_funding_agency', []):
                 cls.process_org_obj_against_ref_data(orgdata, org_obj,
-                                                     'research_dataset.is_output_of.has_funding_agency')
+                                                     'research_dataset.is_output_of.has_funding_agency',
+                                                     refdata=refdata, errors=errors)
 
             if project.get('funder_type', False):
                 ref_entry = cls.check_ref_data(refdata['funder_type'], project['funder_type']['identifier'],
@@ -459,7 +461,8 @@ class CatalogRecordService(CommonService, ReferenceDataMixin):
 
             if other_identifier.get('provider', False):
                 cls.process_org_obj_against_ref_data(orgdata, other_identifier['provider'],
-                                                     'research_dataset.other_identifier.provider')
+                                                     'research_dataset.other_identifier.provider', refdata=refdata,
+                                                     errors=errors)
 
         for spatial in research_dataset.get('spatial', []):
             as_wkt = spatial.get('as_wkt', [])

--- a/src/metax_api/services/data_catalog_service.py
+++ b/src/metax_api/services/data_catalog_service.py
@@ -74,11 +74,13 @@ class DataCatalogService(ReferenceDataMixin):
             if 'has_rights_related_agent' in access_rights:
                 for agent in access_rights.get('has_rights_related_agent', []):
                     cls.process_org_obj_against_ref_data(orgdata['organization'], agent,
-                                                         'data_catalog_json.access_rights.has_rights_related_agent')
+                                                         'data_catalog_json.access_rights.has_rights_related_agent',
+                                                         errors=errors)
 
         publisher = data_catalog.get('publisher', None)
         if publisher:
-            cls.process_org_obj_against_ref_data(orgdata['organization'], publisher, 'data_catalog_json.publisher')
+            cls.process_org_obj_against_ref_data(orgdata['organization'], publisher, 'data_catalog_json.publisher',
+                                                 errors=errors)
 
         if errors:
             raise ValidationError(errors)

--- a/src/metax_api/services/datacite_service.py
+++ b/src/metax_api/services/datacite_service.py
@@ -204,11 +204,11 @@ class DataciteService(CommonService):
                 cr_base['affiliations'] = cls._person_affiliations(ra, main_lang)
 
             for ct in ra.get('contributor_type', []):
-                ct_id = ct['identifier']
-                ct = ct_id[ct_id.rfind('/'):]
-                ct = ct[len('contributor_type_') + 1:]
+                # for example, extracts from initial value:
+                # http://purl.org/att/es/reference_data/contributor_type/contributor_type_Distributor
+                # and produces value: Distributor
                 cr = dict(cr_base)
-                cr['contributorType'] = ct
+                cr['contributorType'] = ct['identifier'].split('/contributor_type_')[-1]
                 contributors.append(cr)
 
         return contributors

--- a/src/metax_api/tests/api/rest/base/views/datasets/write.py
+++ b/src/metax_api/tests/api/rest/base/views/datasets/write.py
@@ -896,7 +896,8 @@ class CatalogRecordApiWriteReferenceDataTests(CatalogRecordApiWriteCommon):
         rd_ida['files'][0]['file_type']['identifier'] = 'nonexisting'
         rd_ida['files'][0]['use_category']['identifier'] = 'nonexisting'
         rd_ida['infrastructure'][0]['identifier'] = 'nonexisting'
-        rd_ida['creator'][0]['contributor_role']['identifier'] = 'nonexisting'
+        rd_ida['creator'][0]['contributor_role'][0]['identifier'] = 'nonexisting'
+        rd_ida['curator'][0]['contributor_type'][0]['identifier'] = 'nonexisting'
         rd_ida['is_output_of'][0]['funder_type']['identifier'] = 'nonexisting'
         rd_ida['directories'][0]['use_category']['identifier'] = 'nonexisting'
         rd_ida['relation'][0]['relation_type']['identifier'] = 'nonexisting'
@@ -907,7 +908,7 @@ class CatalogRecordApiWriteReferenceDataTests(CatalogRecordApiWriteCommon):
         response = self.client.post('/rest/datasets', self.cr_full_ida_test_data, format="json")
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual('research_dataset' in response.data.keys(), True)
-        self.assertEqual(len(response.data['research_dataset']), 18)
+        self.assertEqual(len(response.data['research_dataset']), 19)
 
         rd_att = self.cr_full_att_test_data['research_dataset']
         rd_att['remote_resources'][0]['checksum']['algorithm'] = 'nonexisting'
@@ -986,6 +987,7 @@ class CatalogRecordApiWriteReferenceDataTests(CatalogRecordApiWriteCommon):
             'use_category',
             'research_infra',
             'contributor_role',
+            'contributor_type',
             'funder_type',
             'relation_type',
             'lifecycle_event',
@@ -1030,7 +1032,8 @@ class CatalogRecordApiWriteReferenceDataTests(CatalogRecordApiWriteCommon):
         rd_ida['files'][0]['use_category'] = {'identifier': refs['use_category']['code']}
         rd_ida['directories'][0]['use_category'] = {'identifier': refs['use_category']['code']}
         rd_ida['infrastructure'][0] = {'identifier': refs['research_infra']['code']}
-        rd_ida['creator'][0]['contributor_role'] = {'identifier': refs['contributor_role']['code']}
+        rd_ida['creator'][0]['contributor_role'][0] = {'identifier': refs['contributor_role']['code']}
+        rd_ida['curator'][0]['contributor_type'][0] = {'identifier': refs['contributor_type']['code']}
         rd_ida['is_output_of'][0]['funder_type'] = {'identifier': refs['funder_type']['code']}
         rd_ida['relation'][0]['relation_type'] = {'identifier': refs['relation_type']['code']}
         rd_ida['relation'][0]['entity']['type'] = {'identifier': refs['resource_type']['code']}
@@ -1117,7 +1120,8 @@ class CatalogRecordApiWriteReferenceDataTests(CatalogRecordApiWriteCommon):
         self.assertEqual(refs['organization']['uri'], new_rd['publisher']['is_part_of']['identifier'])
         self.assertEqual(refs['organization']['uri'], new_rd['rights_holder'][0]['is_part_of']['identifier'])
         self.assertEqual(refs['research_infra']['uri'], new_rd['infrastructure'][0]['identifier'])
-        self.assertEqual(refs['contributor_role']['uri'], new_rd['creator'][0]['contributor_role']['identifier'])
+        self.assertEqual(refs['contributor_role']['uri'], new_rd['creator'][0]['contributor_role'][0]['identifier'])
+        self.assertEqual(refs['contributor_type']['uri'], new_rd['curator'][0]['contributor_type'][0]['identifier'])
         self.assertEqual(refs['funder_type']['uri'], new_rd['is_output_of'][0]['funder_type']['identifier'])
         self.assertEqual(refs['relation_type']['uri'], new_rd['relation'][0]['relation_type']['identifier'])
         self.assertEqual(refs['resource_type']['uri'], new_rd['relation'][0]['entity']['type']['identifier'])
@@ -1141,6 +1145,7 @@ class CatalogRecordApiWriteReferenceDataTests(CatalogRecordApiWriteCommon):
         self.assertEqual(refs['use_category']['scheme'], new_rd['directories'][0]['use_category']['in_scheme'])
         self.assertEqual(refs['research_infra']['scheme'], new_rd['infrastructure'][0]['in_scheme'])
         self.assertEqual(refs['contributor_role']['scheme'], new_rd['creator'][0]['contributor_role']['in_scheme'])
+        self.assertEqual(refs['contributor_type']['scheme'], new_rd['curator'][0]['contributor_type']['in_scheme'])
         self.assertEqual(refs['funder_type']['scheme'], new_rd['is_output_of'][0]['funder_type']['in_scheme'])
         self.assertEqual(refs['relation_type']['scheme'], new_rd['relation'][0]['relation_type']['in_scheme'])
         self.assertEqual(refs['resource_type']['scheme'], new_rd['relation'][0]['entity']['type']['in_scheme'])
@@ -1165,7 +1170,9 @@ class CatalogRecordApiWriteReferenceDataTests(CatalogRecordApiWriteCommon):
 
         self.assertEqual(refs['research_infra']['label'], new_rd['infrastructure'][0].get('pref_label', None))
         self.assertEqual(refs['contributor_role']['label'],
-                         new_rd['creator'][0]['contributor_role'].get('pref_label', None))
+                         new_rd['creator'][0]['contributor_role'][0].get('pref_label', None))
+        self.assertEqual(refs['contributor_type']['label'],
+                         new_rd['curator'][0]['contributor_type'][0].get('pref_label', None))
         self.assertEqual(refs['funder_type']['label'], new_rd['is_output_of'][0]['funder_type'].get('pref_label', None))
         self.assertEqual(refs['relation_type']['label'], new_rd['relation'][0]['relation_type'].get('pref_label', None))
         self.assertEqual(refs['resource_type']['label'],

--- a/src/metax_api/tests/testdata/catalog_record_test_data_template.json
+++ b/src/metax_api/tests/testdata/catalog_record_test_data_template.json
@@ -29,7 +29,10 @@
           "name": {
             "fi": "Mysteeriorganisaatio"
           }
-        }
+        },
+        "contributor_role": [{
+          "identifier": "http://purl.org/att/es/reference_data/contributor_role/contributor_role_visualization"
+        }]
       }
     ],
     "curator": [
@@ -39,7 +42,10 @@
         "name": {
           "en": "Org in ref data",
           "fi": "Organisaatio"
-        }
+        },
+        "contributor_type": [{
+          "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_ResearchGroup"
+        }]
       }
     ],
     "language": [

--- a/src/metax_api/tests/testdata/catalog_record_test_data_template_full_att.json
+++ b/src/metax_api/tests/testdata/catalog_record_test_data_template_full_att.json
@@ -116,14 +116,17 @@
           "email": "info@csc.fi",
           "telephone": [
             "+358501231235"
-          ]
+          ],
+          "contributor_type": [{
+            "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_ContactPerson"
+          }]
         },
         "type": {
           "identifier": "doi",
           "pref_label": {
             "en": "pref label"
           },
-          "definition": {
+          "definition":{
             "en": "A statement or formal explanation of the meaning of a concept."
           },
           "in_scheme": "http://uri.of.filetype.concept/scheme"
@@ -142,7 +145,10 @@
           "email": "info@csc.fi",
           "telephone": [
             "+358501231235"
-          ]
+          ],
+          "contributor_type": [{
+            "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_DataCollector"
+          }]
         },
         "type": {
           "identifier": "http://purl.org/att/es/reference_data/identifier_type/identifier_type_urn",
@@ -239,7 +245,10 @@
             "email": "info@csc.fi",
             "telephone": [
               "+358501231235"
-            ]
+            ],
+            "contributor_type": [{
+              "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_DataCurator"
+            }]
           }
         ],
         "variable": [
@@ -322,7 +331,10 @@
           "en": "Parent Mysterious Organization",
           "fi": "Organisaatio"
         }
-      }
+      },
+      "contributor_type": [{
+        "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_DataManager"
+      }]
     }],
     "creator": [
       {
@@ -336,9 +348,9 @@
             "fi": "Organisaatio"
           }
         },
-        "contributor_role": {
-          "identifier": "data_curation"
-        }
+        "contributor_role": [{
+          "identifier": "http://purl.org/att/es/reference_data/contributor_role/contributor_role_conceptualization"
+        }]
       }
     ],
     "curator": [
@@ -356,7 +368,10 @@
             "en": "Parent Mysterious Organization",
             "fi": "Organisaatio"
           }
-        }
+        },
+        "contributor_type": [{
+          "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_Distributor"
+        }]
       }
     ],
     "publisher": {
@@ -395,7 +410,10 @@
             "fi": "Julkaisijan yläorganisaation kotisivu"
           }
         }
-      }
+      },
+      "contributor_type": [{
+        "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_Distributor"
+      }]
     },
     "contributor": [
       {
@@ -418,9 +436,9 @@
             "+358501231235"
           ]
         },
-        "contributor_role": {
+        "contributor_role": [{
           "identifier": "http://purl.org/att/es/reference_data/contributor_role/contributor_role_funding_acquisition"
-        }
+        }]
       },
       {
         "@type": "Person",
@@ -442,9 +460,9 @@
             "+23423423"
           ]
         },
-        "contributor_role": {
-          "identifier": "project_administration"
-        }
+        "contributor_type": [{
+          "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_ProjectLeader"
+        }]
       }
     ],
     "is_output_of": [
@@ -465,7 +483,10 @@
             "email": "rahoitus@rahaorg.fi",
             "telephone": [
               "+358501232233"
-            ]
+            ],
+            "contributor_type": [{
+              "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_Editor"
+            }]
           }
         ],
         "source_organization": [
@@ -479,7 +500,10 @@
             "email": "info@csc.fi",
             "telephone": [
               "+358501231235"
-            ]
+            ],
+            "contributor_type": [{
+              "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_HostingInstitution"
+            }]
           }
         ],
         "funder_type": {

--- a/src/metax_api/tests/testdata/catalog_record_test_data_template_full_ida.json
+++ b/src/metax_api/tests/testdata/catalog_record_test_data_template_full_ida.json
@@ -116,7 +116,10 @@
           "email": "info@csc.fi",
           "telephone": [
             "+358501231235"
-          ]
+          ],
+          "contributor_type": [{
+            "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_ContactPerson"
+          }]
         },
         "type": {
           "identifier": "doi",
@@ -142,7 +145,10 @@
           "email": "info@csc.fi",
           "telephone": [
             "+358501231235"
-          ]
+          ],
+          "contributor_type": [{
+            "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_DataCollector"
+          }]
         },
         "type": {
           "identifier": "http://purl.org/att/es/reference_data/identifier_type/identifier_type_urn",
@@ -249,7 +255,10 @@
             "email": "info@csc.fi",
             "telephone": [
               "+358501231235"
-            ]
+            ],
+            "contributor_type": [{
+              "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_DataCurator"
+            }]
           }
         ],
         "variable": [
@@ -332,7 +341,10 @@
           "en": "Parent Mysterious Organization",
           "fi": "Organisaatio"
         }
-      }
+      },
+      "contributor_type": [{
+        "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_DataManager"
+      }]
     }],
     "creator": [
       {
@@ -346,9 +358,9 @@
             "fi": "Organisaatio"
           }
         },
-        "contributor_role": {
-          "identifier": "data_curation"
-        }
+        "contributor_role": [{
+          "identifier": "http://purl.org/att/es/reference_data/contributor_role/contributor_role_conceptualization"
+        }]
       }
     ],
     "curator": [
@@ -366,7 +378,15 @@
             "en": "Parent Mysterious Organization",
             "fi": "Organisaatio"
           }
-        }
+        },
+        "contributor_type": [
+          {
+          "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_Distributor"
+          },
+          {
+          "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_Sponsor"
+          }
+        ]
       }
     ],
     "publisher": {
@@ -405,7 +425,10 @@
             "fi": "Julkaisijan yläorganisaation kotisivu"
           }
         }
-      }
+      },
+      "contributor_type": [{
+        "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_Distributor"
+      }]
     },
     "contributor": [
       {
@@ -428,9 +451,9 @@
             "+358501231235"
           ]
         },
-        "contributor_role": {
+        "contributor_role": [{
           "identifier": "http://purl.org/att/es/reference_data/contributor_role/contributor_role_funding_acquisition"
-        }
+        }]
       },
       {
         "@type": "Person",
@@ -452,9 +475,9 @@
             "+23423423"
           ]
         },
-        "contributor_role": {
-          "identifier": "project_administration"
-        }
+        "contributor_type": [{
+          "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_ProjectLeader"
+        }]
       }
     ],
     "is_output_of": [
@@ -475,7 +498,10 @@
             "email": "rahoitus@rahaorg.fi",
             "telephone": [
               "+358501232233"
-            ]
+            ],
+            "contributor_type": [{
+              "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_Editor"
+            }]
           }
         ],
         "source_organization": [
@@ -489,7 +515,10 @@
             "email": "info@csc.fi",
             "telephone": [
               "+358501231235"
-            ]
+            ],
+            "contributor_type": [{
+              "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_HostingInstitution"
+            }]
           }
         ],
         "funder_type": {

--- a/src/metax_api/tests/testdata/test_data.json
+++ b/src/metax_api/tests/testdata/test_data.json
@@ -5753,6 +5753,11 @@
                 "creator": [
                     {
                         "@type": "Person",
+                        "contributor_role": [
+                            {
+                                "identifier": "http://purl.org/att/es/reference_data/contributor_role/contributor_role_visualization"
+                            }
+                        ],
                         "member_of": {
                             "@type": "Organization",
                             "name": {
@@ -5858,6 +5863,11 @@
                 "creator": [
                     {
                         "@type": "Person",
+                        "contributor_role": [
+                            {
+                                "identifier": "http://purl.org/att/es/reference_data/contributor_role/contributor_role_visualization"
+                            }
+                        ],
                         "member_of": {
                             "@type": "Organization",
                             "name": {
@@ -5963,6 +5973,11 @@
                 "creator": [
                     {
                         "@type": "Person",
+                        "contributor_role": [
+                            {
+                                "identifier": "http://purl.org/att/es/reference_data/contributor_role/contributor_role_visualization"
+                            }
+                        ],
                         "member_of": {
                             "@type": "Organization",
                             "name": {
@@ -6068,6 +6083,11 @@
                 "creator": [
                     {
                         "@type": "Person",
+                        "contributor_role": [
+                            {
+                                "identifier": "http://purl.org/att/es/reference_data/contributor_role/contributor_role_visualization"
+                            }
+                        ],
                         "member_of": {
                             "@type": "Organization",
                             "name": {
@@ -6173,6 +6193,11 @@
                 "creator": [
                     {
                         "@type": "Person",
+                        "contributor_role": [
+                            {
+                                "identifier": "http://purl.org/att/es/reference_data/contributor_role/contributor_role_visualization"
+                            }
+                        ],
                         "member_of": {
                             "@type": "Organization",
                             "name": {
@@ -6278,6 +6303,11 @@
                 "creator": [
                     {
                         "@type": "Person",
+                        "contributor_role": [
+                            {
+                                "identifier": "http://purl.org/att/es/reference_data/contributor_role/contributor_role_visualization"
+                            }
+                        ],
                         "member_of": {
                             "@type": "Organization",
                             "name": {
@@ -6383,6 +6413,11 @@
                 "creator": [
                     {
                         "@type": "Person",
+                        "contributor_role": [
+                            {
+                                "identifier": "http://purl.org/att/es/reference_data/contributor_role/contributor_role_visualization"
+                            }
+                        ],
                         "member_of": {
                             "@type": "Organization",
                             "name": {
@@ -6488,6 +6523,11 @@
                 "creator": [
                     {
                         "@type": "Person",
+                        "contributor_role": [
+                            {
+                                "identifier": "http://purl.org/att/es/reference_data/contributor_role/contributor_role_visualization"
+                            }
+                        ],
                         "member_of": {
                             "@type": "Organization",
                             "name": {
@@ -6590,6 +6630,11 @@
                 "creator": [
                     {
                         "@type": "Person",
+                        "contributor_role": [
+                            {
+                                "identifier": "http://purl.org/att/es/reference_data/contributor_role/contributor_role_visualization"
+                            }
+                        ],
                         "member_of": {
                             "@type": "Organization",
                             "name": {
@@ -6690,6 +6735,11 @@
                 "creator": [
                     {
                         "@type": "Person",
+                        "contributor_role": [
+                            {
+                                "identifier": "http://purl.org/att/es/reference_data/contributor_role/contributor_role_visualization"
+                            }
+                        ],
                         "member_of": {
                             "@type": "Organization",
                             "name": {
@@ -6835,9 +6885,11 @@
                 "contributor": [
                     {
                         "@type": "Person",
-                        "contributor_role": {
-                            "identifier": "http://purl.org/att/es/reference_data/contributor_role/contributor_role_funding_acquisition"
-                        },
+                        "contributor_role": [
+                            {
+                                "identifier": "http://purl.org/att/es/reference_data/contributor_role/contributor_role_funding_acquisition"
+                            }
+                        ],
                         "email": "kalle.kontribuuttaaja@csc.fi",
                         "identifier": "contributorid",
                         "member_of": {
@@ -6859,9 +6911,11 @@
                     },
                     {
                         "@type": "Person",
-                        "contributor_role": {
-                            "identifier": "project_administration"
-                        },
+                        "contributor_type": [
+                            {
+                                "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_ProjectLeader"
+                            }
+                        ],
                         "email": "franzibald.kontribuuttaaja@csc.fi",
                         "identifier": "contributorid2",
                         "member_of": {
@@ -6885,9 +6939,11 @@
                 "creator": [
                     {
                         "@type": "Person",
-                        "contributor_role": {
-                            "identifier": "data_curation"
-                        },
+                        "contributor_role": [
+                            {
+                                "identifier": "http://purl.org/att/es/reference_data/contributor_role/contributor_role_conceptualization"
+                            }
+                        ],
                         "member_of": {
                             "@type": "Organization",
                             "identifier": "10076",
@@ -6902,6 +6958,14 @@
                 "curator": [
                     {
                         "@type": "Organization",
+                        "contributor_type": [
+                            {
+                                "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_Distributor"
+                            },
+                            {
+                                "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_Sponsor"
+                            }
+                        ],
                         "identifier": "id:of:curator:default",
                         "is_part_of": {
                             "@type": "Organization",
@@ -6996,6 +7060,11 @@
                         "has_funding_agency": [
                             {
                                 "@type": "Organization",
+                                "contributor_type": [
+                                    {
+                                        "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_Editor"
+                                    }
+                                ],
                                 "email": "rahoitus@rahaorg.fi",
                                 "identifier": "fundingagencyidentifier",
                                 "name": {
@@ -7014,6 +7083,11 @@
                         "source_organization": [
                             {
                                 "@type": "Organization",
+                                "contributor_type": [
+                                    {
+                                        "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_HostingInstitution"
+                                    }
+                                ],
                                 "email": "info@csc.fi",
                                 "identifier": "http://purl.org/att/es/organization_data/organization/organization_01901",
                                 "name": {
@@ -7046,6 +7120,11 @@
                         "notation": "doi:10.12345",
                         "provider": {
                             "@type": "Organization",
+                            "contributor_type": [
+                                {
+                                    "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_ContactPerson"
+                                }
+                            ],
                             "email": "info@csc.fi",
                             "identifier": "http://purl.org/att/es/organization_data/organization/organization_01901",
                             "name": {
@@ -7072,6 +7151,11 @@
                         "notation": "urn:nbn:fi-12345",
                         "provider": {
                             "@type": "Organization",
+                            "contributor_type": [
+                                {
+                                    "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_DataCollector"
+                                }
+                            ],
                             "email": "info@csc.fi",
                             "identifier": "http://purl.org/att/es/organization_data/organization/organization_01901",
                             "name": {
@@ -7180,6 +7264,11 @@
                         "was_associated_with": [
                             {
                                 "@type": "Organization",
+                                "contributor_type": [
+                                    {
+                                        "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_DataCurator"
+                                    }
+                                ],
                                 "email": "info@csc.fi",
                                 "identifier": "http://purl.org/att/es/organization_data/organization/organization_01901",
                                 "name": {
@@ -7221,6 +7310,11 @@
                 ],
                 "publisher": {
                     "@type": "Organization",
+                    "contributor_type": [
+                        {
+                            "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_Distributor"
+                        }
+                    ],
                     "email": "info@csc.fi",
                     "homepage": {
                         "identifier": "http://www.publisher.fi/",
@@ -7334,6 +7428,11 @@
                 "rights_holder": [
                     {
                         "@type": "Organization",
+                        "contributor_type": [
+                            {
+                                "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_DataManager"
+                            }
+                        ],
                         "email": "info@csc.fi",
                         "identifier": "http://purl.org/att/es/organization_data/organization/organization_01901",
                         "is_part_of": {
@@ -7500,9 +7599,11 @@
                 "contributor": [
                     {
                         "@type": "Person",
-                        "contributor_role": {
-                            "identifier": "http://purl.org/att/es/reference_data/contributor_role/contributor_role_funding_acquisition"
-                        },
+                        "contributor_role": [
+                            {
+                                "identifier": "http://purl.org/att/es/reference_data/contributor_role/contributor_role_funding_acquisition"
+                            }
+                        ],
                         "email": "kalle.kontribuuttaaja@csc.fi",
                         "identifier": "contributorid",
                         "member_of": {
@@ -7524,9 +7625,11 @@
                     },
                     {
                         "@type": "Person",
-                        "contributor_role": {
-                            "identifier": "project_administration"
-                        },
+                        "contributor_type": [
+                            {
+                                "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_ProjectLeader"
+                            }
+                        ],
                         "email": "franzibald.kontribuuttaaja@csc.fi",
                         "identifier": "contributorid2",
                         "member_of": {
@@ -7550,9 +7653,11 @@
                 "creator": [
                     {
                         "@type": "Person",
-                        "contributor_role": {
-                            "identifier": "data_curation"
-                        },
+                        "contributor_role": [
+                            {
+                                "identifier": "http://purl.org/att/es/reference_data/contributor_role/contributor_role_conceptualization"
+                            }
+                        ],
                         "member_of": {
                             "@type": "Organization",
                             "identifier": "10076",
@@ -7567,6 +7672,14 @@
                 "curator": [
                     {
                         "@type": "Organization",
+                        "contributor_type": [
+                            {
+                                "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_Distributor"
+                            },
+                            {
+                                "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_Sponsor"
+                            }
+                        ],
                         "identifier": "id:of:curator:default",
                         "is_part_of": {
                             "@type": "Organization",
@@ -7661,6 +7774,11 @@
                         "has_funding_agency": [
                             {
                                 "@type": "Organization",
+                                "contributor_type": [
+                                    {
+                                        "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_Editor"
+                                    }
+                                ],
                                 "email": "rahoitus@rahaorg.fi",
                                 "identifier": "fundingagencyidentifier",
                                 "name": {
@@ -7679,6 +7797,11 @@
                         "source_organization": [
                             {
                                 "@type": "Organization",
+                                "contributor_type": [
+                                    {
+                                        "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_HostingInstitution"
+                                    }
+                                ],
                                 "email": "info@csc.fi",
                                 "identifier": "http://purl.org/att/es/organization_data/organization/organization_01901",
                                 "name": {
@@ -7711,6 +7834,11 @@
                         "notation": "doi:10.12345",
                         "provider": {
                             "@type": "Organization",
+                            "contributor_type": [
+                                {
+                                    "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_ContactPerson"
+                                }
+                            ],
                             "email": "info@csc.fi",
                             "identifier": "http://purl.org/att/es/organization_data/organization/organization_01901",
                             "name": {
@@ -7737,6 +7865,11 @@
                         "notation": "urn:nbn:fi-12345",
                         "provider": {
                             "@type": "Organization",
+                            "contributor_type": [
+                                {
+                                    "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_DataCollector"
+                                }
+                            ],
                             "email": "info@csc.fi",
                             "identifier": "http://purl.org/att/es/organization_data/organization/organization_01901",
                             "name": {
@@ -7845,6 +7978,11 @@
                         "was_associated_with": [
                             {
                                 "@type": "Organization",
+                                "contributor_type": [
+                                    {
+                                        "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_DataCurator"
+                                    }
+                                ],
                                 "email": "info@csc.fi",
                                 "identifier": "http://purl.org/att/es/organization_data/organization/organization_01901",
                                 "name": {
@@ -7886,6 +8024,11 @@
                 ],
                 "publisher": {
                     "@type": "Organization",
+                    "contributor_type": [
+                        {
+                            "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_Distributor"
+                        }
+                    ],
                     "email": "info@csc.fi",
                     "homepage": {
                         "identifier": "http://www.publisher.fi/",
@@ -7999,6 +8142,11 @@
                 "rights_holder": [
                     {
                         "@type": "Organization",
+                        "contributor_type": [
+                            {
+                                "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_DataManager"
+                            }
+                        ],
                         "email": "info@csc.fi",
                         "identifier": "http://purl.org/att/es/organization_data/organization/organization_01901",
                         "is_part_of": {
@@ -8233,9 +8381,11 @@
                 "contributor": [
                     {
                         "@type": "Person",
-                        "contributor_role": {
-                            "identifier": "http://purl.org/att/es/reference_data/contributor_role/contributor_role_funding_acquisition"
-                        },
+                        "contributor_role": [
+                            {
+                                "identifier": "http://purl.org/att/es/reference_data/contributor_role/contributor_role_funding_acquisition"
+                            }
+                        ],
                         "email": "kalle.kontribuuttaaja@csc.fi",
                         "identifier": "contributorid",
                         "member_of": {
@@ -8257,9 +8407,11 @@
                     },
                     {
                         "@type": "Person",
-                        "contributor_role": {
-                            "identifier": "project_administration"
-                        },
+                        "contributor_type": [
+                            {
+                                "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_ProjectLeader"
+                            }
+                        ],
                         "email": "franzibald.kontribuuttaaja@csc.fi",
                         "identifier": "contributorid2",
                         "member_of": {
@@ -8283,9 +8435,11 @@
                 "creator": [
                     {
                         "@type": "Person",
-                        "contributor_role": {
-                            "identifier": "data_curation"
-                        },
+                        "contributor_role": [
+                            {
+                                "identifier": "http://purl.org/att/es/reference_data/contributor_role/contributor_role_conceptualization"
+                            }
+                        ],
                         "member_of": {
                             "@type": "Organization",
                             "identifier": "10076",
@@ -8300,6 +8454,14 @@
                 "curator": [
                     {
                         "@type": "Organization",
+                        "contributor_type": [
+                            {
+                                "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_Distributor"
+                            },
+                            {
+                                "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_Sponsor"
+                            }
+                        ],
                         "identifier": "id:of:curator:default",
                         "is_part_of": {
                             "@type": "Organization",
@@ -8418,6 +8580,11 @@
                         "has_funding_agency": [
                             {
                                 "@type": "Organization",
+                                "contributor_type": [
+                                    {
+                                        "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_Editor"
+                                    }
+                                ],
                                 "email": "rahoitus@rahaorg.fi",
                                 "identifier": "fundingagencyidentifier",
                                 "name": {
@@ -8436,6 +8603,11 @@
                         "source_organization": [
                             {
                                 "@type": "Organization",
+                                "contributor_type": [
+                                    {
+                                        "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_HostingInstitution"
+                                    }
+                                ],
                                 "email": "info@csc.fi",
                                 "identifier": "http://purl.org/att/es/organization_data/organization/organization_01901",
                                 "name": {
@@ -8468,6 +8640,11 @@
                         "notation": "doi:10.12345",
                         "provider": {
                             "@type": "Organization",
+                            "contributor_type": [
+                                {
+                                    "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_ContactPerson"
+                                }
+                            ],
                             "email": "info@csc.fi",
                             "identifier": "http://purl.org/att/es/organization_data/organization/organization_01901",
                             "name": {
@@ -8494,6 +8671,11 @@
                         "notation": "urn:nbn:fi-12345",
                         "provider": {
                             "@type": "Organization",
+                            "contributor_type": [
+                                {
+                                    "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_DataCollector"
+                                }
+                            ],
                             "email": "info@csc.fi",
                             "identifier": "http://purl.org/att/es/organization_data/organization/organization_01901",
                             "name": {
@@ -8602,6 +8784,11 @@
                         "was_associated_with": [
                             {
                                 "@type": "Organization",
+                                "contributor_type": [
+                                    {
+                                        "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_DataCurator"
+                                    }
+                                ],
                                 "email": "info@csc.fi",
                                 "identifier": "http://purl.org/att/es/organization_data/organization/organization_01901",
                                 "name": {
@@ -8643,6 +8830,11 @@
                 ],
                 "publisher": {
                     "@type": "Organization",
+                    "contributor_type": [
+                        {
+                            "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_Distributor"
+                        }
+                    ],
                     "email": "info@csc.fi",
                     "homepage": {
                         "identifier": "http://www.publisher.fi/",
@@ -8756,6 +8948,11 @@
                 "rights_holder": [
                     {
                         "@type": "Organization",
+                        "contributor_type": [
+                            {
+                                "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_DataManager"
+                            }
+                        ],
                         "email": "info@csc.fi",
                         "identifier": "http://purl.org/att/es/organization_data/organization/organization_01901",
                         "is_part_of": {
@@ -8865,6 +9062,11 @@
                 "creator": [
                     {
                         "@type": "Person",
+                        "contributor_role": [
+                            {
+                                "identifier": "http://purl.org/att/es/reference_data/contributor_role/contributor_role_visualization"
+                            }
+                        ],
                         "member_of": {
                             "@type": "Organization",
                             "name": {
@@ -8877,6 +9079,11 @@
                 "curator": [
                     {
                         "@type": "Organization",
+                        "contributor_type": [
+                            {
+                                "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_ResearchGroup"
+                            }
+                        ],
                         "identifier": "10076-E700",
                         "name": {
                             "en": "Org in ref data",
@@ -8960,6 +9167,11 @@
                 "creator": [
                     {
                         "@type": "Person",
+                        "contributor_role": [
+                            {
+                                "identifier": "http://purl.org/att/es/reference_data/contributor_role/contributor_role_visualization"
+                            }
+                        ],
                         "member_of": {
                             "@type": "Organization",
                             "name": {
@@ -8972,6 +9184,11 @@
                 "curator": [
                     {
                         "@type": "Organization",
+                        "contributor_type": [
+                            {
+                                "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_ResearchGroup"
+                            }
+                        ],
                         "identifier": "10076-E700",
                         "name": {
                             "en": "Org in ref data",
@@ -9055,6 +9272,11 @@
                 "creator": [
                     {
                         "@type": "Person",
+                        "contributor_role": [
+                            {
+                                "identifier": "http://purl.org/att/es/reference_data/contributor_role/contributor_role_visualization"
+                            }
+                        ],
                         "member_of": {
                             "@type": "Organization",
                             "name": {
@@ -9067,6 +9289,11 @@
                 "curator": [
                     {
                         "@type": "Organization",
+                        "contributor_type": [
+                            {
+                                "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_ResearchGroup"
+                            }
+                        ],
                         "identifier": "10076-E700",
                         "name": {
                             "en": "Org in ref data",
@@ -9150,6 +9377,11 @@
                 "creator": [
                     {
                         "@type": "Person",
+                        "contributor_role": [
+                            {
+                                "identifier": "http://purl.org/att/es/reference_data/contributor_role/contributor_role_visualization"
+                            }
+                        ],
                         "member_of": {
                             "@type": "Organization",
                             "name": {
@@ -9162,6 +9394,11 @@
                 "curator": [
                     {
                         "@type": "Organization",
+                        "contributor_type": [
+                            {
+                                "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_ResearchGroup"
+                            }
+                        ],
                         "identifier": "10076-E700",
                         "name": {
                             "en": "Org in ref data",
@@ -9245,6 +9482,11 @@
                 "creator": [
                     {
                         "@type": "Person",
+                        "contributor_role": [
+                            {
+                                "identifier": "http://purl.org/att/es/reference_data/contributor_role/contributor_role_visualization"
+                            }
+                        ],
                         "member_of": {
                             "@type": "Organization",
                             "name": {
@@ -9257,6 +9499,11 @@
                 "curator": [
                     {
                         "@type": "Organization",
+                        "contributor_type": [
+                            {
+                                "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_ResearchGroup"
+                            }
+                        ],
                         "identifier": "10076-E700",
                         "name": {
                             "en": "Org in ref data",
@@ -9340,6 +9587,11 @@
                 "creator": [
                     {
                         "@type": "Person",
+                        "contributor_role": [
+                            {
+                                "identifier": "http://purl.org/att/es/reference_data/contributor_role/contributor_role_visualization"
+                            }
+                        ],
                         "member_of": {
                             "@type": "Organization",
                             "name": {
@@ -9352,6 +9604,11 @@
                 "curator": [
                     {
                         "@type": "Organization",
+                        "contributor_type": [
+                            {
+                                "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_ResearchGroup"
+                            }
+                        ],
                         "identifier": "10076-E700",
                         "name": {
                             "en": "Org in ref data",
@@ -9435,6 +9692,11 @@
                 "creator": [
                     {
                         "@type": "Person",
+                        "contributor_role": [
+                            {
+                                "identifier": "http://purl.org/att/es/reference_data/contributor_role/contributor_role_visualization"
+                            }
+                        ],
                         "member_of": {
                             "@type": "Organization",
                             "name": {
@@ -9533,6 +9795,11 @@
                 "creator": [
                     {
                         "@type": "Person",
+                        "contributor_role": [
+                            {
+                                "identifier": "http://purl.org/att/es/reference_data/contributor_role/contributor_role_visualization"
+                            }
+                        ],
                         "member_of": {
                             "@type": "Organization",
                             "name": {
@@ -9631,6 +9898,11 @@
                 "creator": [
                     {
                         "@type": "Person",
+                        "contributor_role": [
+                            {
+                                "identifier": "http://purl.org/att/es/reference_data/contributor_role/contributor_role_visualization"
+                            }
+                        ],
                         "member_of": {
                             "@type": "Organization",
                             "name": {
@@ -9729,6 +10001,11 @@
                 "creator": [
                     {
                         "@type": "Person",
+                        "contributor_role": [
+                            {
+                                "identifier": "http://purl.org/att/es/reference_data/contributor_role/contributor_role_visualization"
+                            }
+                        ],
                         "member_of": {
                             "@type": "Organization",
                             "name": {
@@ -9859,9 +10136,11 @@
                 "contributor": [
                     {
                         "@type": "Person",
-                        "contributor_role": {
-                            "identifier": "http://purl.org/att/es/reference_data/contributor_role/contributor_role_funding_acquisition"
-                        },
+                        "contributor_role": [
+                            {
+                                "identifier": "http://purl.org/att/es/reference_data/contributor_role/contributor_role_funding_acquisition"
+                            }
+                        ],
                         "email": "kalle.kontribuuttaaja@csc.fi",
                         "identifier": "contributorid",
                         "member_of": {
@@ -9883,9 +10162,11 @@
                     },
                     {
                         "@type": "Person",
-                        "contributor_role": {
-                            "identifier": "project_administration"
-                        },
+                        "contributor_type": [
+                            {
+                                "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_ProjectLeader"
+                            }
+                        ],
                         "email": "franzibald.kontribuuttaaja@csc.fi",
                         "identifier": "contributorid2",
                         "member_of": {
@@ -9909,9 +10190,11 @@
                 "creator": [
                     {
                         "@type": "Person",
-                        "contributor_role": {
-                            "identifier": "data_curation"
-                        },
+                        "contributor_role": [
+                            {
+                                "identifier": "http://purl.org/att/es/reference_data/contributor_role/contributor_role_conceptualization"
+                            }
+                        ],
                         "member_of": {
                             "@type": "Organization",
                             "identifier": "10076",
@@ -9926,6 +10209,11 @@
                 "curator": [
                     {
                         "@type": "Organization",
+                        "contributor_type": [
+                            {
+                                "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_Distributor"
+                            }
+                        ],
                         "identifier": "id:of:curator:default",
                         "is_part_of": {
                             "@type": "Organization",
@@ -9970,6 +10258,11 @@
                         "has_funding_agency": [
                             {
                                 "@type": "Organization",
+                                "contributor_type": [
+                                    {
+                                        "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_Editor"
+                                    }
+                                ],
                                 "email": "rahoitus@rahaorg.fi",
                                 "identifier": "fundingagencyidentifier",
                                 "name": {
@@ -9988,6 +10281,11 @@
                         "source_organization": [
                             {
                                 "@type": "Organization",
+                                "contributor_type": [
+                                    {
+                                        "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_HostingInstitution"
+                                    }
+                                ],
                                 "email": "info@csc.fi",
                                 "identifier": "http://purl.org/att/es/organization_data/organization/organization_01901",
                                 "name": {
@@ -10020,6 +10318,11 @@
                         "notation": "doi:10.12345",
                         "provider": {
                             "@type": "Organization",
+                            "contributor_type": [
+                                {
+                                    "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_ContactPerson"
+                                }
+                            ],
                             "email": "info@csc.fi",
                             "identifier": "http://purl.org/att/es/organization_data/organization/organization_01901",
                             "name": {
@@ -10046,6 +10349,11 @@
                         "notation": "urn:nbn:fi-12345",
                         "provider": {
                             "@type": "Organization",
+                            "contributor_type": [
+                                {
+                                    "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_DataCollector"
+                                }
+                            ],
                             "email": "info@csc.fi",
                             "identifier": "http://purl.org/att/es/organization_data/organization/organization_01901",
                             "name": {
@@ -10154,6 +10462,11 @@
                         "was_associated_with": [
                             {
                                 "@type": "Organization",
+                                "contributor_type": [
+                                    {
+                                        "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_DataCurator"
+                                    }
+                                ],
                                 "email": "info@csc.fi",
                                 "identifier": "http://purl.org/att/es/organization_data/organization/organization_01901",
                                 "name": {
@@ -10195,6 +10508,11 @@
                 ],
                 "publisher": {
                     "@type": "Organization",
+                    "contributor_type": [
+                        {
+                            "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_Distributor"
+                        }
+                    ],
                     "email": "info@csc.fi",
                     "homepage": {
                         "identifier": "http://www.publisher.fi/",
@@ -10402,6 +10720,11 @@
                 "rights_holder": [
                     {
                         "@type": "Organization",
+                        "contributor_type": [
+                            {
+                                "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_DataManager"
+                            }
+                        ],
                         "email": "info@csc.fi",
                         "identifier": "http://purl.org/att/es/organization_data/organization/organization_01901",
                         "is_part_of": {
@@ -10533,9 +10856,11 @@
                 "contributor": [
                     {
                         "@type": "Person",
-                        "contributor_role": {
-                            "identifier": "http://purl.org/att/es/reference_data/contributor_role/contributor_role_funding_acquisition"
-                        },
+                        "contributor_role": [
+                            {
+                                "identifier": "http://purl.org/att/es/reference_data/contributor_role/contributor_role_funding_acquisition"
+                            }
+                        ],
                         "email": "kalle.kontribuuttaaja@csc.fi",
                         "identifier": "contributorid",
                         "member_of": {
@@ -10557,9 +10882,11 @@
                     },
                     {
                         "@type": "Person",
-                        "contributor_role": {
-                            "identifier": "project_administration"
-                        },
+                        "contributor_type": [
+                            {
+                                "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_ProjectLeader"
+                            }
+                        ],
                         "email": "franzibald.kontribuuttaaja@csc.fi",
                         "identifier": "contributorid2",
                         "member_of": {
@@ -10583,9 +10910,11 @@
                 "creator": [
                     {
                         "@type": "Person",
-                        "contributor_role": {
-                            "identifier": "data_curation"
-                        },
+                        "contributor_role": [
+                            {
+                                "identifier": "http://purl.org/att/es/reference_data/contributor_role/contributor_role_conceptualization"
+                            }
+                        ],
                         "member_of": {
                             "@type": "Organization",
                             "identifier": "10076",
@@ -10600,6 +10929,11 @@
                 "curator": [
                     {
                         "@type": "Organization",
+                        "contributor_type": [
+                            {
+                                "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_Distributor"
+                            }
+                        ],
                         "identifier": "id:of:curator:default",
                         "is_part_of": {
                             "@type": "Organization",
@@ -10644,6 +10978,11 @@
                         "has_funding_agency": [
                             {
                                 "@type": "Organization",
+                                "contributor_type": [
+                                    {
+                                        "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_Editor"
+                                    }
+                                ],
                                 "email": "rahoitus@rahaorg.fi",
                                 "identifier": "fundingagencyidentifier",
                                 "name": {
@@ -10662,6 +11001,11 @@
                         "source_organization": [
                             {
                                 "@type": "Organization",
+                                "contributor_type": [
+                                    {
+                                        "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_HostingInstitution"
+                                    }
+                                ],
                                 "email": "info@csc.fi",
                                 "identifier": "http://purl.org/att/es/organization_data/organization/organization_01901",
                                 "name": {
@@ -10694,6 +11038,11 @@
                         "notation": "doi:10.12345",
                         "provider": {
                             "@type": "Organization",
+                            "contributor_type": [
+                                {
+                                    "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_ContactPerson"
+                                }
+                            ],
                             "email": "info@csc.fi",
                             "identifier": "http://purl.org/att/es/organization_data/organization/organization_01901",
                             "name": {
@@ -10720,6 +11069,11 @@
                         "notation": "urn:nbn:fi-12345",
                         "provider": {
                             "@type": "Organization",
+                            "contributor_type": [
+                                {
+                                    "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_DataCollector"
+                                }
+                            ],
                             "email": "info@csc.fi",
                             "identifier": "http://purl.org/att/es/organization_data/organization/organization_01901",
                             "name": {
@@ -10828,6 +11182,11 @@
                         "was_associated_with": [
                             {
                                 "@type": "Organization",
+                                "contributor_type": [
+                                    {
+                                        "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_DataCurator"
+                                    }
+                                ],
                                 "email": "info@csc.fi",
                                 "identifier": "http://purl.org/att/es/organization_data/organization/organization_01901",
                                 "name": {
@@ -10869,6 +11228,11 @@
                 ],
                 "publisher": {
                     "@type": "Organization",
+                    "contributor_type": [
+                        {
+                            "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_Distributor"
+                        }
+                    ],
                     "email": "info@csc.fi",
                     "homepage": {
                         "identifier": "http://www.publisher.fi/",
@@ -11076,6 +11440,11 @@
                 "rights_holder": [
                     {
                         "@type": "Organization",
+                        "contributor_type": [
+                            {
+                                "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_DataManager"
+                            }
+                        ],
                         "email": "info@csc.fi",
                         "identifier": "http://purl.org/att/es/organization_data/organization/organization_01901",
                         "is_part_of": {
@@ -11207,9 +11576,11 @@
                 "contributor": [
                     {
                         "@type": "Person",
-                        "contributor_role": {
-                            "identifier": "http://purl.org/att/es/reference_data/contributor_role/contributor_role_funding_acquisition"
-                        },
+                        "contributor_role": [
+                            {
+                                "identifier": "http://purl.org/att/es/reference_data/contributor_role/contributor_role_funding_acquisition"
+                            }
+                        ],
                         "email": "kalle.kontribuuttaaja@csc.fi",
                         "identifier": "contributorid",
                         "member_of": {
@@ -11231,9 +11602,11 @@
                     },
                     {
                         "@type": "Person",
-                        "contributor_role": {
-                            "identifier": "project_administration"
-                        },
+                        "contributor_type": [
+                            {
+                                "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_ProjectLeader"
+                            }
+                        ],
                         "email": "franzibald.kontribuuttaaja@csc.fi",
                         "identifier": "contributorid2",
                         "member_of": {
@@ -11257,9 +11630,11 @@
                 "creator": [
                     {
                         "@type": "Person",
-                        "contributor_role": {
-                            "identifier": "data_curation"
-                        },
+                        "contributor_role": [
+                            {
+                                "identifier": "http://purl.org/att/es/reference_data/contributor_role/contributor_role_conceptualization"
+                            }
+                        ],
                         "member_of": {
                             "@type": "Organization",
                             "identifier": "10076",
@@ -11274,6 +11649,11 @@
                 "curator": [
                     {
                         "@type": "Organization",
+                        "contributor_type": [
+                            {
+                                "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_Distributor"
+                            }
+                        ],
                         "identifier": "id:of:curator:default",
                         "is_part_of": {
                             "@type": "Organization",
@@ -11318,6 +11698,11 @@
                         "has_funding_agency": [
                             {
                                 "@type": "Organization",
+                                "contributor_type": [
+                                    {
+                                        "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_Editor"
+                                    }
+                                ],
                                 "email": "rahoitus@rahaorg.fi",
                                 "identifier": "fundingagencyidentifier",
                                 "name": {
@@ -11336,6 +11721,11 @@
                         "source_organization": [
                             {
                                 "@type": "Organization",
+                                "contributor_type": [
+                                    {
+                                        "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_HostingInstitution"
+                                    }
+                                ],
                                 "email": "info@csc.fi",
                                 "identifier": "http://purl.org/att/es/organization_data/organization/organization_01901",
                                 "name": {
@@ -11368,6 +11758,11 @@
                         "notation": "doi:10.12345",
                         "provider": {
                             "@type": "Organization",
+                            "contributor_type": [
+                                {
+                                    "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_ContactPerson"
+                                }
+                            ],
                             "email": "info@csc.fi",
                             "identifier": "http://purl.org/att/es/organization_data/organization/organization_01901",
                             "name": {
@@ -11394,6 +11789,11 @@
                         "notation": "urn:nbn:fi-12345",
                         "provider": {
                             "@type": "Organization",
+                            "contributor_type": [
+                                {
+                                    "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_DataCollector"
+                                }
+                            ],
                             "email": "info@csc.fi",
                             "identifier": "http://purl.org/att/es/organization_data/organization/organization_01901",
                             "name": {
@@ -11502,6 +11902,11 @@
                         "was_associated_with": [
                             {
                                 "@type": "Organization",
+                                "contributor_type": [
+                                    {
+                                        "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_DataCurator"
+                                    }
+                                ],
                                 "email": "info@csc.fi",
                                 "identifier": "http://purl.org/att/es/organization_data/organization/organization_01901",
                                 "name": {
@@ -11543,6 +11948,11 @@
                 ],
                 "publisher": {
                     "@type": "Organization",
+                    "contributor_type": [
+                        {
+                            "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_Distributor"
+                        }
+                    ],
                     "email": "info@csc.fi",
                     "homepage": {
                         "identifier": "http://www.publisher.fi/",
@@ -11750,6 +12160,11 @@
                 "rights_holder": [
                     {
                         "@type": "Organization",
+                        "contributor_type": [
+                            {
+                                "identifier": "http://purl.org/att/es/reference_data/contributor_type/contributor_type_DataManager"
+                            }
+                        ],
                         "email": "info@csc.fi",
                         "identifier": "http://purl.org/att/es/organization_data/organization/organization_01901",
                         "is_part_of": {
@@ -11860,6 +12275,11 @@
                 "creator": [
                     {
                         "@type": "Person",
+                        "contributor_role": [
+                            {
+                                "identifier": "http://purl.org/att/es/reference_data/contributor_role/contributor_role_visualization"
+                            }
+                        ],
                         "member_of": {
                             "@type": "Organization",
                             "name": {
@@ -11953,6 +12373,11 @@
                 "creator": [
                     {
                         "@type": "Person",
+                        "contributor_role": [
+                            {
+                                "identifier": "http://purl.org/att/es/reference_data/contributor_role/contributor_role_visualization"
+                            }
+                        ],
                         "member_of": {
                             "@type": "Organization",
                             "name": {


### PR DESCRIPTION
…tor role arrays to research agents of type Agent and Person. Add contributor type array to research agent of type Organization. Autopopulate those two new associations whenever present in the said objects in research datasets. Accomodate datacite service to properly create contributors. Add contributor type and contributor role data to test datasets and add tests for the autopopulation.