### PR TITLE
CSCMETAX-472 & CSCMETAX-474: Change remote_resource.checksum.algorith…

### DIFF
--- a/src/metax_api/api/rest/base/schemas/att_dataset_schema.json
+++ b/src/metax_api/api/rest/base/schemas/att_dataset_schema.json
@@ -271,6 +271,15 @@
                     "@id":"http://spdx.org/rdf/terms#algorithm",
                     "title":"Algorithm",
                     "description":"Used checksum algortihm",
+                    "enum":[
+                        "MD5",
+                        "SHA-1",
+                        "SHA-224",
+                        "SHA-256",
+                        "SHA-384",
+                        "SHA-512",
+                        "OTHER"
+                    ],
                     "@type":"http://www.w3.org/2001/XMLSchema#string",
                     "type":"string"
                 },

--- a/src/metax_api/api/rest/base/schemas/harvester_dataset_schema.json
+++ b/src/metax_api/api/rest/base/schemas/harvester_dataset_schema.json
@@ -271,6 +271,15 @@
                     "@id":"http://spdx.org/rdf/terms#algorithm",
                     "title":"Algorithm",
                     "description":"Used checksum algortihm",
+                    "enum":[
+                        "MD5",
+                        "SHA-1",
+                        "SHA-224",
+                        "SHA-256",
+                        "SHA-384",
+                        "SHA-512",
+                        "OTHER"
+                    ],
                     "@type":"http://www.w3.org/2001/XMLSchema#string",
                     "type":"string"
                 },
@@ -370,14 +379,6 @@
                     "@type":"@id",
                     "type":"object",
                     "$ref":"#/definitions/Concept"
-                },
-                "access_url":{
-                    "@id":"http://www.w3.org/ns/dcat#accessURL",
-                    "title":"Access URL",
-                    "description":"Could be any kind of URL that gives access to a distribution of the dataset. E.g. landing page download, feed URL, SPARQL endpoint. Use when your catalog does not have information on which it is or when it is definitely not a download.",
-                    "@type":"@id",
-                    "type":"object",
-                    "$ref":"#/definitions/Document"
                 }
             },
             "required":[
@@ -564,14 +565,6 @@
                     "description":"Free-text account of the file.",
                     "@type":"http://www.w3.org/2001/XMLSchema#string",
                     "type":"string"
-                },
-                "access_url":{
-                    "@id":"http://www.w3.org/ns/dcat#accessURL",
-                    "title":"Access URL",
-                    "description":"Could be any kind of URL that gives access to a distribution of the dataset. E.g. landing page download, feed URL, SPARQL endpoint. Use when your catalog does not have information on which it is or when it is definitely not a download.",
-                    "@type":"@id",
-                    "type":"object",
-                    "$ref":"#/definitions/Document"
                 },
                 "file_type":{
                     "@id":"http://purl.org/dc/terms/type",

--- a/src/metax_api/api/rest/base/schemas/ida_dataset_schema.json
+++ b/src/metax_api/api/rest/base/schemas/ida_dataset_schema.json
@@ -343,14 +343,6 @@
                     "@type":"@id",
                     "type":"object",
                     "$ref":"#/definitions/Concept"
-                },
-                "access_url":{
-                    "@id":"http://www.w3.org/ns/dcat#accessURL",
-                    "title":"Access URL",
-                    "description":"Could be any kind of URL that gives access to a distribution of the dataset. E.g. landing page download, feed URL, SPARQL endpoint. Use when your catalog does not have information on which it is or when it is definitely not a download.",
-                    "@type":"@id",
-                    "type":"object",
-                    "$ref":"#/definitions/Document"
                 }
             },
             "required":[
@@ -494,14 +486,6 @@
                     "description":"Free-text account of the file.",
                     "@type":"http://www.w3.org/2001/XMLSchema#string",
                     "type":"string"
-                },
-                "access_url":{
-                    "@id":"http://www.w3.org/ns/dcat#accessURL",
-                    "title":"Access URL",
-                    "description":"Could be any kind of URL that gives access to a distribution of the dataset. E.g. landing page download, feed URL, SPARQL endpoint. Use when your catalog does not have information on which it is or when it is definitely not a download.",
-                    "@type":"@id",
-                    "type":"object",
-                    "$ref":"#/definitions/Document"
                 },
                 "file_type":{
                     "@id":"http://purl.org/dc/terms/type",

--- a/src/metax_api/services/catalog_record_service.py
+++ b/src/metax_api/services/catalog_record_service.py
@@ -327,13 +327,6 @@ class CatalogRecordService(CommonService, ReferenceDataMixin):
 
         for remote_resource in research_dataset.get('remote_resources', []):
 
-            # Since checksum is a plain string field, it should not be changed to a reference data uri in case
-            # it is recognized as one of the checksum_algorithm reference data items.
-            # TODO: Find out whether a non-reference data value for the checksum_algorithm should even throw an error
-            if 'checksum' in remote_resource:
-                cls.check_ref_data(refdata['checksum_algorithm'], remote_resource['checksum']['algorithm'],
-                                   'research_dataset.remote_resources.checksum.algorithm', errors)
-
             for license in remote_resource.get('license', []):
                 license_url = license.get('license', None)
 

--- a/src/metax_api/tests/api/rest/base/views/datasets/write.py
+++ b/src/metax_api/tests/api/rest/base/views/datasets/write.py
@@ -937,14 +937,13 @@ class CatalogRecordApiWriteReferenceDataTests(CatalogRecordApiWriteCommon):
         self.assertEqual(len(response.data['research_dataset']), 19)
 
         rd_att = self.cr_full_att_test_data['research_dataset']
-        rd_att['remote_resources'][0]['checksum']['algorithm'] = 'nonexisting'
         rd_att['remote_resources'][0]['license'][0]['identifier'] = 'nonexisting'
         rd_att['remote_resources'][1]['resource_type']['identifier'] = 'nonexisting'
         rd_att['remote_resources'][0]['use_category']['identifier'] = 'nonexisting'
         response = self.client.post('/rest/datasets', self.cr_full_att_test_data, format="json")
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual('research_dataset' in response.data.keys(), True)
-        self.assertEqual(len(response.data['research_dataset']), 4)
+        self.assertEqual(len(response.data['research_dataset']), 3)
 
     def test_create_catalog_record_with_dependent_reference_datas(self):
         # Unallowed combinations
@@ -1001,7 +1000,6 @@ class CatalogRecordApiWriteReferenceDataTests(CatalogRecordApiWriteCommon):
         data_types = [
             'access_type',
             'restriction_grounds',
-            'checksum_algorithm',
             'field_of_science',
             'identifier_type',
             'keyword',
@@ -1103,7 +1101,6 @@ class CatalogRecordApiWriteReferenceDataTests(CatalogRecordApiWriteCommon):
         rd_att['remote_resources'][1]['resource_type'] = {'identifier': refs['resource_type']['code']}
         rd_att['remote_resources'][0]['use_category'] = {'identifier': refs['use_category']['code']}
         rd_att['remote_resources'][0]['license'][0] = {'identifier': refs['license']['code']}
-        rd_att['remote_resources'][0]['checksum']['algorithm'] = refs['checksum_algorithm']['code']
 
         # Assert remote resources related reference datas
         response = self.client.post('/rest/datasets', self.cr_full_att_test_data, format="json")
@@ -1121,7 +1118,6 @@ class CatalogRecordApiWriteReferenceDataTests(CatalogRecordApiWriteCommon):
         self.assertEqual(refs['use_category']['label'],
                          new_rd['remote_resources'][0]['use_category'].get('pref_label', None))
         self.assertEqual(refs['license']['label'], new_rd['remote_resources'][0]['license'][0].get('title', None))
-        self.assertEquals(refs['checksum_algorithm']['code'], new_rd['remote_resources'][0]['checksum']['algorithm'])
 
     def _assert_uri_copied_to_identifier(self, refs, new_rd):
         self.assertEqual(refs['keyword']['uri'], new_rd['theme'][0]['identifier'])

--- a/src/metax_api/tests/testdata/catalog_record_test_data_template_full_att.json
+++ b/src/metax_api/tests/testdata/catalog_record_test_data_template_full_att.json
@@ -530,7 +530,7 @@
           }
         },
         "checksum": {
-          "algorithm": "http://purl.org/att/es/reference_data/checksum_algorithm/checksum_algorithm_SHA-512",
+          "algorithm": "SHA-512",
           "checksum_value": "u5y6f4y68765ngf6ry8n"
         },
         "license": [
@@ -579,7 +579,7 @@
           }
         },
         "checksum": {
-          "algorithm": "http://purl.org/att/es/reference_data/checksum_algorithm/checksum_algorithm_SHA-512",
+          "algorithm": "SHA-512",
           "checksum_value": "u5y6f4y68765ngf6ry8n"
         },
         "license": [

--- a/src/metax_api/tests/testdata/test_data.json
+++ b/src/metax_api/tests/testdata/test_data.json
@@ -10659,7 +10659,7 @@
                     {
                         "byte_size": 2048,
                         "checksum": {
-                            "algorithm": "http://purl.org/att/es/reference_data/checksum_algorithm/checksum_algorithm_SHA-512",
+                            "algorithm": "SHA-512",
                             "checksum_value": "u5y6f4y68765ngf6ry8n"
                         },
                         "description": "Free-text account of the distribution.",
@@ -10717,7 +10717,7 @@
                         },
                         "byte_size": 4096,
                         "checksum": {
-                            "algorithm": "http://purl.org/att/es/reference_data/checksum_algorithm/checksum_algorithm_SHA-512",
+                            "algorithm": "SHA-512",
                             "checksum_value": "u5y6f4y68765ngf6ry8n"
                         },
                         "description": "Free-text account of the second distribution.",
@@ -11387,7 +11387,7 @@
                     {
                         "byte_size": 2048,
                         "checksum": {
-                            "algorithm": "http://purl.org/att/es/reference_data/checksum_algorithm/checksum_algorithm_SHA-512",
+                            "algorithm": "SHA-512",
                             "checksum_value": "u5y6f4y68765ngf6ry8n"
                         },
                         "description": "Free-text account of the distribution.",
@@ -11445,7 +11445,7 @@
                         },
                         "byte_size": 4096,
                         "checksum": {
-                            "algorithm": "http://purl.org/att/es/reference_data/checksum_algorithm/checksum_algorithm_SHA-512",
+                            "algorithm": "SHA-512",
                             "checksum_value": "u5y6f4y68765ngf6ry8n"
                         },
                         "description": "Free-text account of the second distribution.",
@@ -12115,7 +12115,7 @@
                     {
                         "byte_size": 2048,
                         "checksum": {
-                            "algorithm": "http://purl.org/att/es/reference_data/checksum_algorithm/checksum_algorithm_SHA-512",
+                            "algorithm": "SHA-512",
                             "checksum_value": "u5y6f4y68765ngf6ry8n"
                         },
                         "description": "Free-text account of the distribution.",
@@ -12173,7 +12173,7 @@
                         },
                         "byte_size": 4096,
                         "checksum": {
-                            "algorithm": "http://purl.org/att/es/reference_data/checksum_algorithm/checksum_algorithm_SHA-512",
+                            "algorithm": "SHA-512",
                             "checksum_value": "u5y6f4y68765ngf6ry8n"
                         },
                         "description": "Free-text account of the second distribution.",


### PR DESCRIPTION
…m to enum in json schemas. Remove File and Directory objects' access_url association from json schemas. Remove checking checksum algorithm value from reference data, since it is no longer a reference data but an enumeration in json schema. Update test data, fix tests.