### PR TITLE
CSCMETAX-483: [FIX] Add to json schemas: "format": "date" for "date" …

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,5 +26,6 @@ responses==0.9.0  # Apache 2.0-license
 Sphinx==1.7.8  # custom license
 sphinx-autobuild==0.7.1 # MIT-license
 sphinx-rtd-theme==0.4.1 # MIT-license
+strict-rfc3339==0.7 # GPLv3
 simplejson==3.16.0  # MIT-license
 urllib3==1.23

--- a/src/metax_api/api/rest/base/schemas/att_dataset_schema.json
+++ b/src/metax_api/api/rest/base/schemas/att_dataset_schema.json
@@ -977,7 +977,8 @@
                     "title":"Release date",
                     "description":"Date of formal issuance (e.g., publication) of the resource.",
                     "@type":"http://www.w3.org/2001/XMLSchema#date",
-                    "type":"string"
+                    "type":"string",
+                    "format": "date"
                 },
                 "title":{
                     "@id":"http://purl.org/dc/terms/title",
@@ -1247,7 +1248,8 @@
                     "title":"Date Available",
                     "description":"Date (often a range) that the resource became or will become available.",
                     "@type":"http://www.w3.org/2001/XMLSchema#date",
-                    "type":"string"
+                    "type":"string",
+                    "format": "date"
                 },
                 "access_type":{
                     "@id":"http://purl.org/dc/terms/type",

--- a/src/metax_api/api/rest/base/schemas/contract_schema.json
+++ b/src/metax_api/api/rest/base/schemas/contract_schema.json
@@ -237,14 +237,16 @@
                     "@type":"http://www.w3.org/2001/XMLSchema#date",
                     "minItems":1,
                     "maxItems":1,
-                    "type":"string"
+                    "type":"string",
+                    "format": "date"
                 },
                 "end_date":{
                     "title":"End date",
                     "@id":"http://iow.csc.fi/ns/jhs#paattymispaivamaara",
                     "@type":"http://www.w3.org/2001/XMLSchema#date",
                     "maxItems":1,
-                    "type":"string"
+                    "type":"string",
+                    "format": "date"
                 }
             },
             "required":[

--- a/src/metax_api/api/rest/base/schemas/datacatalog_schema.json
+++ b/src/metax_api/api/rest/base/schemas/datacatalog_schema.json
@@ -45,15 +45,17 @@
                     "@id":"http://purl.org/dc/terms/modified",
                     "title":"Date Modified",
                     "description":"Date on which the Catalogue was last modified",
-                    "@type":"http://www.w3.org/2001/XMLSchema#date",
-                    "type":"string"
+                    "@type":"http://www.w3.org/2001/XMLSchema#dateTime",
+                    "type":"string",
+                    "format": "date-time"
                 },
                 "issued":{
                     "@id":"http://purl.org/dc/terms/issued",
                     "title":"Date Issued",
                     "description":"Date of formal issuance (e.g., publication, release date) of the catalogue.",
                     "@type":"http://www.w3.org/2001/XMLSchema#date",
-                    "type":"string"
+                    "type":"string",
+                    "format": "date"
                 },
                 "language":{
                     "@id":"http://purl.org/dc/terms/language",
@@ -374,10 +376,8 @@
                     "title":"Date Available",
                     "description":"Date (often a range) that the resource became or will become available.",
                     "@type":"http://www.w3.org/2001/XMLSchema#date",
-                    "type":"array",
-                    "items":{
-                        "type":"string"
-                    }
+                    "type":"string",
+                    "format": "date"
                 },
                 "access_type":{
                     "@id":"http://purl.org/dc/terms/type",

--- a/src/metax_api/api/rest/base/schemas/harvester_dataset_schema.json
+++ b/src/metax_api/api/rest/base/schemas/harvester_dataset_schema.json
@@ -1161,7 +1161,8 @@
                     "title":"Release date",
                     "description":"Date of formal issuance (e.g., publication) of the resource.",
                     "@type":"http://www.w3.org/2001/XMLSchema#date",
-                    "type":"string"
+                    "type":"string",
+                    "format": "date"
                 },
                 "title":{
                     "@id":"http://purl.org/dc/terms/title",
@@ -1458,7 +1459,8 @@
                     "title":"Date Available",
                     "description":"Date (often a range) that the resource became or will become available.",
                     "@type":"http://www.w3.org/2001/XMLSchema#date",
-                    "type":"string"
+                    "type":"string",
+                    "format": "date"
                 },
                 "access_type":{
                     "@id":"http://purl.org/dc/terms/type",

--- a/src/metax_api/api/rest/base/schemas/ida_dataset_schema.json
+++ b/src/metax_api/api/rest/base/schemas/ida_dataset_schema.json
@@ -1000,7 +1000,8 @@
                     "title":"Release date",
                     "description":"Date of formal issuance (e.g., publication) of the resource.",
                     "@type":"http://www.w3.org/2001/XMLSchema#date",
-                    "type":"string"
+                    "type":"string",
+                    "format": "date"
                 },
                 "title":{
                     "@id":"http://purl.org/dc/terms/title",
@@ -1281,7 +1282,8 @@
                     "title":"Date Available",
                     "description":"Date (often a range) that the resource became or will become available.",
                     "@type":"http://www.w3.org/2001/XMLSchema#date",
-                    "type":"string"
+                    "type":"string",
+                    "format": "date"
                 },
                 "access_type":{
                     "@id":"http://purl.org/dc/terms/type",

--- a/src/metax_api/api/rest/base/serializers/serializer_utils.py
+++ b/src/metax_api/api/rest/base/serializers/serializer_utils.py
@@ -5,12 +5,13 @@
 # :author: CSC - IT Center for Science Ltd., Espoo Finland <servicedesk@csc.fi>
 # :license: MIT
 
-from jsonschema import validate as json_validate
+from jsonschema import validate as json_validate, FormatChecker
 from jsonschema.exceptions import ValidationError as JsonValidationError
 from rest_framework.serializers import ValidationError
 
+
 def validate_json(value, schema):
     try:
-        json_validate(value, schema)
+        json_validate(value, schema, format_checker=FormatChecker())
     except JsonValidationError as e:
         raise ValidationError('%s. Json path: %s. Schema: %s' % (e.message, [p for p in e.path], e.schema))

--- a/src/metax_api/tests/api/rest/base/views/contracts/contracts.py
+++ b/src/metax_api/tests/api/rest/base/views/contracts/contracts.py
@@ -174,7 +174,7 @@ class ContractApiWriteTestV1(APITestCase, TestClassUtils):
                     "name": "Name of Service"
                 }],
                 "validity": {
-                    "start_date": "2014-01-17T08:19:58Z"
+                    "start_date": "2014-01-17"
                 }
             }
         }
@@ -202,7 +202,7 @@ class ContractApiWriteTestV1(APITestCase, TestClassUtils):
                     "name": "Name of Service"
                 }],
                 "validity": {
-                    "start_date": "2014-01-17T08:19:58Z"
+                    "start_date": "2014-01-17"
                 }
             }
         }

--- a/src/metax_api/tests/testdata/catalog_record_test_data_template_full_att.json
+++ b/src/metax_api/tests/testdata/catalog_record_test_data_template_full_att.json
@@ -11,7 +11,7 @@
     "version_notes": [
       "This version contains changes to x and y."
     ],
-    "issued": "2014-01-17T08:19:58Z",
+    "issued": "2014-01-17",
     "title": {
       "en": "Wonderful Title"
     },
@@ -66,7 +66,7 @@
       "description": {
         "en": "Free account of the rights"
       },
-      "available": "2014-01-15T08:19:58Z",
+      "available": "2014-01-15",
       "access_type": {
         "identifier": "http://purl.org/att/es/reference_data/access_type/access_type_open_access",
         "pref_label": {

--- a/src/metax_api/tests/testdata/catalog_record_test_data_template_full_ida.json
+++ b/src/metax_api/tests/testdata/catalog_record_test_data_template_full_ida.json
@@ -11,7 +11,7 @@
     "version_notes": [
       "This version contains changes to x and y."
     ],
-    "issued": "2014-01-17T08:19:58Z",
+    "issued": "2014-01-17",
     "title": {
       "en": "Wonderful Title"
     },
@@ -66,7 +66,7 @@
       "description": {
         "en": "Free account of the rights"
       },
-      "available": "2014-01-15T08:19:58Z",
+      "available": "2014-01-15",
       "access_type": {
         "identifier": "http://purl.org/att/es/reference_data/access_type/access_type_open_access",
         "pref_label": {

--- a/src/metax_api/tests/testdata/contract_test_data_template.json
+++ b/src/metax_api/tests/testdata/contract_test_data_template.json
@@ -17,7 +17,7 @@
         "created": "2018-04-05T08:19:58Z",
         "modified": "2018-04-05T08:19:58Z",
         "validity": {
-            "start_date": "2018-07-01T00:00:00Z"
+            "start_date": "2018-07-01"
         },
         "identifier": "urn:uuid:99ddffff-2f73-46b0-92d1-614409d83001",
         "description": "Muuttolintujen laskentatulosten säilytys",
@@ -62,7 +62,7 @@
       }
     ],
     "validity": {
-      "start_date": "2014-01-17T08:19:58Z"
+      "start_date": "2014-01-17"
     }
   },
   "service_created": "metax"

--- a/src/metax_api/tests/testdata/data_catalog_test_data_template.json
+++ b/src/metax_api/tests/testdata/data_catalog_test_data_template.json
@@ -3,7 +3,7 @@
   "catalog_record_group_create": "default-record-create-group",
   "catalog_json": {
     "modified": "2014-01-17T08:19:58Z",
-    "issued": "2014-02-27T08:19:58Z",
+    "issued": "2014-02-27",
     "title": {
       "fi": "Testidatakatalogin nimi",
       "en": "Test data catalog name"

--- a/src/metax_api/tests/testdata/test_data.json
+++ b/src/metax_api/tests/testdata/test_data.json
@@ -4611,7 +4611,7 @@
                     }
                 ],
                 "identifier": "urn:nbn:fi:att:2955e904-e3dd-4d7e-99f1-3fed446f96d1",
-                "issued": "2014-02-27T08:19:58Z",
+                "issued": "2014-02-27",
                 "language": [
                     {
                         "identifier": "http://lexvo.org/id/iso639-3/fin"
@@ -4726,7 +4726,7 @@
                     }
                 ],
                 "identifier": "urn:nbn:fi:att:2955e904-e3dd-4d7e-99f1-3fed446f96d2",
-                "issued": "2014-02-27T08:19:58Z",
+                "issued": "2014-02-27",
                 "language": [
                     {
                         "identifier": "http://lexvo.org/id/iso639-3/fin"
@@ -4841,7 +4841,7 @@
                     }
                 ],
                 "identifier": "urn:nbn:fi:att:2955e904-e3dd-4d7e-99f1-3fed446f96d3",
-                "issued": "2014-02-27T08:19:58Z",
+                "issued": "2014-02-27",
                 "language": [
                     {
                         "identifier": "http://lexvo.org/id/iso639-3/fin"
@@ -4956,7 +4956,7 @@
                     }
                 ],
                 "identifier": "urn:nbn:fi:att:2955e904-e3dd-4d7e-99f1-3fed446f96d4",
-                "issued": "2014-02-27T08:19:58Z",
+                "issued": "2014-02-27",
                 "language": [
                     {
                         "identifier": "http://lexvo.org/id/iso639-3/fin"
@@ -5071,7 +5071,7 @@
                     }
                 ],
                 "identifier": "urn:nbn:fi:att:2955e904-e3dd-4d7e-99f1-3fed446f96d5",
-                "issued": "2014-02-27T08:19:58Z",
+                "issued": "2014-02-27",
                 "language": [
                     {
                         "identifier": "http://lexvo.org/id/iso639-3/fin"
@@ -5186,7 +5186,7 @@
                     }
                 ],
                 "identifier": "urn:nbn:fi:att:2955e904-e3dd-4d7e-99f1-3fed446f96d6",
-                "issued": "2014-02-27T08:19:58Z",
+                "issued": "2014-02-27",
                 "language": [
                     {
                         "identifier": "http://lexvo.org/id/iso639-3/fin"
@@ -5301,7 +5301,7 @@
                     }
                 ],
                 "identifier": "urn:nbn:fi:att:2955e904-e3dd-4d7e-99f1-3fed446f96d7",
-                "issued": "2014-02-27T08:19:58Z",
+                "issued": "2014-02-27",
                 "language": [
                     {
                         "identifier": "http://lexvo.org/id/iso639-3/fin"
@@ -5416,7 +5416,7 @@
                     }
                 ],
                 "identifier": "urn:nbn:fi:att:2955e904-e3dd-4d7e-99f1-3fed446f96d8",
-                "issued": "2014-02-27T08:19:58Z",
+                "issued": "2014-02-27",
                 "language": [
                     {
                         "identifier": "http://lexvo.org/id/iso639-3/fin"
@@ -5489,7 +5489,7 @@
                 ],
                 "title": "Helsingin yliopiston biotieteiden laitoksen muuttolintujen laskentatulosten s\u00e4ilytyssopimus",
                 "validity": {
-                    "start_date": "2018-07-01T00:00:00Z"
+                    "start_date": "2018-07-01"
                 }
             },
             "date_created": "2018-04-05T08:19:58+03:00",
@@ -5526,7 +5526,7 @@
                 ],
                 "title": "Title of Contract 2",
                 "validity": {
-                    "start_date": "2014-01-17T08:19:58Z"
+                    "start_date": "2014-01-17"
                 }
             },
             "date_created": "2017-05-15T10:07:22Z",
@@ -5563,7 +5563,7 @@
                 ],
                 "title": "Title of Contract 3",
                 "validity": {
-                    "start_date": "2014-01-17T08:19:58Z"
+                    "start_date": "2014-01-17"
                 }
             },
             "date_created": "2017-05-15T10:07:22Z",
@@ -5600,7 +5600,7 @@
                 ],
                 "title": "Title of Contract 4",
                 "validity": {
-                    "start_date": "2014-01-17T08:19:58Z"
+                    "start_date": "2014-01-17"
                 }
             },
             "date_created": "2017-05-15T10:07:22Z",
@@ -5637,7 +5637,7 @@
                 ],
                 "title": "Title of Contract 5",
                 "validity": {
-                    "start_date": "2014-01-17T08:19:58Z"
+                    "start_date": "2014-01-17"
                 }
             },
             "date_created": "2017-05-15T10:07:22Z",
@@ -6861,7 +6861,7 @@
                             "en": "A name given to the document"
                         }
                     },
-                    "available": "2014-01-15T08:19:58Z",
+                    "available": "2014-01-15",
                     "description": {
                         "en": "Free account of the rights"
                     },
@@ -7101,7 +7101,7 @@
                         ]
                     }
                 ],
-                "issued": "2014-01-17T08:19:58Z",
+                "issued": "2014-01-17",
                 "keyword": [
                     "keyword",
                     "keyword2",
@@ -7583,7 +7583,7 @@
                             "en": "A name given to the document"
                         }
                     },
-                    "available": "2014-01-15T08:19:58Z",
+                    "available": "2014-01-15",
                     "description": {
                         "en": "Free account of the rights"
                     },
@@ -7823,7 +7823,7 @@
                         ]
                     }
                 ],
-                "issued": "2014-01-17T08:19:58Z",
+                "issued": "2014-01-17",
                 "keyword": [
                     "keyword",
                     "keyword2",
@@ -8373,7 +8373,7 @@
                             "en": "A name given to the document"
                         }
                     },
-                    "available": "2014-01-15T08:19:58Z",
+                    "available": "2014-01-15",
                     "description": {
                         "en": "Free account of the rights"
                     },
@@ -8637,7 +8637,7 @@
                         ]
                     }
                 ],
-                "issued": "2014-01-17T08:19:58Z",
+                "issued": "2014-01-17",
                 "keyword": [
                     "keyword",
                     "keyword2",
@@ -10136,7 +10136,7 @@
                             "en": "A name given to the document"
                         }
                     },
-                    "available": "2014-01-15T08:19:58Z",
+                    "available": "2014-01-15",
                     "description": {
                         "en": "Free account of the rights"
                     },
@@ -10323,7 +10323,7 @@
                         ]
                     }
                 ],
-                "issued": "2014-01-17T08:19:58Z",
+                "issued": "2014-01-17",
                 "keyword": [
                     "keyword",
                     "keyword2",
@@ -10864,7 +10864,7 @@
                             "en": "A name given to the document"
                         }
                     },
-                    "available": "2014-01-15T08:19:58Z",
+                    "available": "2014-01-15",
                     "description": {
                         "en": "Free account of the rights"
                     },
@@ -11051,7 +11051,7 @@
                         ]
                     }
                 ],
-                "issued": "2014-01-17T08:19:58Z",
+                "issued": "2014-01-17",
                 "keyword": [
                     "keyword",
                     "keyword2",
@@ -11592,7 +11592,7 @@
                             "en": "A name given to the document"
                         }
                     },
-                    "available": "2014-01-15T08:19:58Z",
+                    "available": "2014-01-15",
                     "description": {
                         "en": "Free account of the rights"
                     },
@@ -11779,7 +11779,7 @@
                         ]
                     }
                 ],
-                "issued": "2014-01-17T08:19:58Z",
+                "issued": "2014-01-17",
                 "keyword": [
                     "keyword",
                     "keyword2",


### PR DESCRIPTION
…type fields. Change in DC schema rights_statement.available from array to single obj. Add jsonschema.FormatChecker use to json schema validation, which checks format of the string-form date and datetime values. Add python lib to requirements.txt which provides the valid formats.