### PR TITLE
CSCMETAX-436: RPC api + get example minimal dataset

### DIFF
--- a/docs/source/datasets.rst
+++ b/docs/source/datasets.rst
@@ -431,6 +431,32 @@ When services interact with Metax, services have the additional responsibility o
 
 
 
+Retrieve minimal valid dataset template
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The API ``GET /rpc/datasets/get_minimal_dataset_template`` returns a valid minimal dataset, that can be used as-is to create a dataset into Metax.
+
+
+.. code-block:: python
+
+    import requests
+
+    response = requests.get('https://metax-test.csc.fi/rpc/datasets/get_minimal_dataset_template?type=endusers')
+    assert response.status_code == 200, response.content
+
+    # dataset_data can now be used in a POST request to create a new dataset!
+    dataset_data = response.json()
+
+    headers = { 'Authorization': 'Bearer abc.def.ghi' }
+    response = requests.post('https://metax-test.csc.fi/rest/datasets', json=dataset_data, headers=headers)
+    assert response.status_code == 201, response.content
+    print(response.json())
+
+
+.. important:: The other code examples below contain the full dataset in written form to give you an idea what the dataset contents really look like. While these textual examples can sometimes get outdated, the dataset template from the API is always kept up-to-date, and would serve as a good starting point for your own dataset.
+
+
+
 Creating datasets
 ^^^^^^^^^^^^^^^^^^
 

--- a/docs/source/quick_start.rst
+++ b/docs/source/quick_start.rst
@@ -23,56 +23,16 @@ No chit-chat get a dataset published into Metax and see it in the Fairdata servi
 
     import requests
 
-    dataset_data = {
-        "data_catalog": "urn:nbn:fi:att:data-catalog-att",
-        "research_dataset": {
-            "title": {
-                "en": "Test Dataset Title"
-            },
-            "description": {
-                "en": "A descriptive description describing the contents of this dataset. Must be descriptive."
-            },
-            "creator": [
-                {
-                    "name": "Teppo Testaaja",
-                    "@type": "Person",
-                    "member_of": {
-                        "name": {
-                            "fi": "Mysteeriorganisaatio"
-                        },
-                        "@type": "Organization"
-                    }
-                }
-            ],
-            "curator": [
-                {
-                    "name": {
-                        "und": "School Services, BIZ"
-                    },
-                    "@type": "Organization",
-                    "identifier": "http://purl.org/att/es/organization_data/organization/organization_10076-E700"
-                }
-            ],
-            "language":[{
-                "title": { "en": "en" },
-                "identifier": "http://lexvo.org/id/iso639-3/aar"
-            }],
-            "access_rights": {
-                "access_type": {
-                    "identifier": "http://purl.org/att/es/reference_data/access_type/access_type_open_access"
-                },
-                "restriction_grounds": {
-                    "identifier": "http://purl.org/att/es/reference_data/restriction_grounds/restriction_grounds_1"
-                }
-            }
-        }
-    }
-
     token = 'paste your token here'
 
+    response = requests.get('https://metax-test.csc.fi/rpc/datasets/get_minimal_dataset_template?type=endusers')
+    assert response.status_code == 200, response.content
+
+    dataset_data = response.json()
     headers = { 'Authorization': 'Bearer %s' % token }
     response = requests.post('https://metax-test.csc.fi/rest/datasets', json=dataset_data, headers=headers)
     assert response.status_code == 201, response.content
+
     print('I have created a dataset, and its identifier is: %s' % response.json()['identifier'])
 
 
@@ -81,4 +41,4 @@ No chit-chat get a dataset published into Metax and see it in the Fairdata servi
 4) Execute the script.
 5) You should now have a published dataset, and you should be able to find it in the Fairdata service Etsin by using the identifier printed by the script in the following url: ``https://etsin-test.fairdata.fi/dataset/<identifier>``
 
-For more involved examples, see the examples sections in topics :doc:`datasets` and :doc:`files`, or start browsing the various sections of the documentation to get to know what's what.
+In reality you will probably want to create a dataset with a little bit more interesting data in it, but using the example dataset from API ``/rpc/datasets/get_minimal_dataset_template`` is a good starting point for your modifications. For more involved examples, see the examples sections in topics :doc:`datasets` and :doc:`files`, or start browsing the various sections of the documentation to get to know what's what.

--- a/src/metax_api/api/rest/base/views/common_view.py
+++ b/src/metax_api/api/rest/base/views/common_view.py
@@ -33,6 +33,7 @@ class CommonViewSet(ModelViewSet):
     which include fields like modified and created timestamps, uuid, active flags etc.
     """
 
+    api_type = 'rest'
     authentication_classes = ()
     permission_classes = (EndUserPermissions, ServicePermissions)
 

--- a/src/metax_api/api/rest/base/views/directory_view.py
+++ b/src/metax_api/api/rest/base/views/directory_view.py
@@ -48,6 +48,9 @@ class DirectoryViewSet(CommonViewSet):
     def create(self, request, *args, **kwargs):
         raise Http501()
 
+    def destroy(self, request, *args, **kwargs):
+        raise Http501()
+
     def _get_directory_contents(self, request, identifier=None):
         """
         A wrapper to call FS to collect and validate parameters from the request,

--- a/src/metax_api/api/rest/base/views/schema_view.py
+++ b/src/metax_api/api/rest/base/views/schema_view.py
@@ -15,6 +15,7 @@ class SchemaViewSet(viewsets.ReadOnlyModelViewSet):
 
     authentication_classes = ()
     permission_classes = (ServicePermissions,)
+    api_type = 'rest'
 
     def list(self, request, *args, **kwargs):
         return SchemaService.get_all_schemas()

--- a/src/metax_api/api/rpc/base/__init__.py
+++ b/src/metax_api/api/rpc/base/__init__.py
@@ -1,0 +1,6 @@
+# This file is part of the Metax API service
+#
+# Copyright 2017-2018 Ministry of Education and Culture, Finland
+#
+# :author: CSC - IT Center for Science Ltd., Espoo Finland <servicedesk@csc.fi>
+# :license: MIT

--- a/src/metax_api/api/rpc/base/common_rpc.py
+++ b/src/metax_api/api/rpc/base/common_rpc.py
@@ -1,0 +1,62 @@
+# This file is part of the Metax API service
+#
+# Copyright 2017-2018 Ministry of Education and Culture, Finland
+#
+# :author: CSC - IT Center for Science Ltd., Espoo Finland <servicedesk@csc.fi>
+# :license: MIT
+
+from rest_framework.serializers import ModelSerializer
+
+from metax_api.api.rest.base.views import CommonViewSet
+from metax_api.exceptions import Http501
+from metax_api.permissions import EndUserPermissions, ServicePermissions
+
+
+class CommonRPC(CommonViewSet):
+
+    """
+    A base object for other RPC classes. Inherits CommonViewSet in order to use some of the
+    common tricks, such as saving errors to /apierrors, request modifications, permission objects...
+    """
+
+    api_type = 'rpc'
+
+    # serves no purpose, but satisfies the ViewSet basic requirements
+    serializer_class = ModelSerializer
+
+    permission_classes = (EndUserPermissions, ServicePermissions)
+
+    def get_api_name(self):
+        """
+        Return api name, example: DatasetRPC -> datasets.
+        Some views where the below formula does not produce a sensible result
+        will inherit this and return a customized result.
+        """
+        return '%ss' % self.__class__.__name__.split('RPC')[0].lower()
+
+    def create(self, request, *args, **kwargs):
+        raise Http501()
+
+    def retrieve(self, request, *args, **kwargs):
+        raise Http501()
+
+    def list(self, request, *args, **kwargs):
+        raise Http501()
+
+    def update(self, request, *args, **kwargs):
+        raise Http501()
+
+    def delete(self, request, *args, **kwargs):
+        raise Http501()
+
+    def update_bulk(self, request, *args, **kwargs):
+        raise Http501()
+
+    def partial_update(self, request, *args, **kwargs):
+        raise Http501()
+
+    def partial_update_bulk(self, request, *args, **kwargs):
+        raise Http501()
+
+    def destroy(self, request, *args, **kwargs):
+        raise Http501()

--- a/src/metax_api/api/rpc/base/dataset_rpc.py
+++ b/src/metax_api/api/rpc/base/dataset_rpc.py
@@ -1,0 +1,36 @@
+# This file is part of the Metax API service
+#
+# Copyright 2017-2018 Ministry of Education and Culture, Finland
+#
+# :author: CSC - IT Center for Science Ltd., Espoo Finland <servicedesk@csc.fi>
+# :license: MIT
+
+from json import load
+
+from django.conf import settings as django_settings
+from rest_framework.decorators import list_route
+from rest_framework.response import Response
+
+from metax_api.exceptions import Http400
+from .common_rpc import CommonRPC
+
+
+class DatasetRPC(CommonRPC):
+
+    @list_route(methods=['get'], url_path="get_minimal_dataset_template")
+    def get_minimal_dataset_template(self, request):
+        if request.query_params.get('type', None) not in ['service', 'enduser']:
+            raise Http400({
+                'detail': ['query param \'type\' missing or wrong. please specify ?type= as one of: service, enduser']
+            })
+
+        with open('metax_api/exampledata/dataset_minimal.json', 'rb') as f:
+            example_ds = load(f)
+
+        example_ds['data_catalog'] = django_settings.END_USER_ALLOWED_DATA_CATALOGS[0]
+
+        if request.query_params['type'] == 'enduser':
+            example_ds.pop('metadata_provider_org', None)
+            example_ds.pop('metadata_provider_user', None)
+
+        return Response(example_ds)

--- a/src/metax_api/api/rpc/base/router.py
+++ b/src/metax_api/api/rpc/base/router.py
@@ -20,18 +20,25 @@ Including another URLconf
     1. Import the include() function: from django.conf.urls import url, include
     2. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
 """
-from django.conf.urls import url, include
 
-from metax_api.api.oaipmh.base.view import oaipmh_view as oaipmh
-from metax_api.api.rest.base.router import api_urlpatterns as rest_api_v1
-from metax_api.api.rpc.base.router import api_urlpatterns as rpc_api_v1
-from metax_api.views.router import view_urlpatterns
+from rest_framework.routers import DefaultRouter
 
-urlpatterns = [
-    url('', include(view_urlpatterns)),
-    url(r'^oai/', oaipmh, name='oai'),
-    url(r'^rest/', include(rest_api_v1)),
-    url(r'^rest/v1/', include(rest_api_v1)),
-    url(r'^rpc/', include(rpc_api_v1)),
-    url(r'^rpc/v1/', include(rpc_api_v1)),
-]
+from .views import (
+    DatasetRPC,
+)
+
+
+class CustomRouter(DefaultRouter):
+
+    def get_default_base_name(self, viewset):
+        """
+        When a viewset has no queryset set, or base_name is not passed to a router as the
+        3rd parameter, automatically determine base name.
+        """
+        return viewset.__class__.__name__.split('RPC')[0]
+
+
+router = CustomRouter(trailing_slash=False)
+router.register(r'datasets/?', DatasetRPC)
+
+api_urlpatterns = router.urls

--- a/src/metax_api/api/rpc/base/views/__init__.py
+++ b/src/metax_api/api/rpc/base/views/__init__.py
@@ -1,0 +1,8 @@
+# This file is part of the Metax API service
+#
+# Copyright 2017-2018 Ministry of Education and Culture, Finland
+#
+# :author: CSC - IT Center for Science Ltd., Espoo Finland <servicedesk@csc.fi>
+# :license: MIT
+
+from .dataset_rpc import DatasetRPC

--- a/src/metax_api/api/rpc/base/views/common_rpc.py
+++ b/src/metax_api/api/rpc/base/views/common_rpc.py
@@ -1,0 +1,66 @@
+# This file is part of the Metax API service
+#
+# Copyright 2017-2018 Ministry of Education and Culture, Finland
+#
+# :author: CSC - IT Center for Science Ltd., Espoo Finland <servicedesk@csc.fi>
+# :license: MIT
+
+import logging
+
+from rest_framework.serializers import ModelSerializer
+
+from metax_api.api.rest.base.views import CommonViewSet
+from metax_api.exceptions import Http501
+from metax_api.permissions import EndUserPermissions, ServicePermissions
+
+_logger = logging.getLogger(__name__)
+
+
+class CommonRPC(CommonViewSet):
+
+    """
+    A base object for other RPC classes. Inherits CommonViewSet in order to use some of the
+    common tricks, such as saving errors to /apierrors, request modifications, permission objects...
+    """
+
+    api_type = 'rpc'
+
+    # serves no purpose, but satisfies the ViewSet basic requirements
+    serializer_class = ModelSerializer
+
+    permission_classes = (EndUserPermissions, ServicePermissions)
+
+    def get_api_name(self):
+        """
+        Return api name, example: DatasetRPC -> datasets.
+        Some views where the below formula does not produce a sensible result
+        will inherit this and return a customized result.
+        """
+        return '%ss' % self.__class__.__name__.split('RPC')[0].lower()
+
+    def create(self, request, *args, **kwargs):
+        raise Http501()
+
+    def retrieve(self, request, *args, **kwargs):
+        raise Http501()
+
+    def list(self, request, *args, **kwargs):
+        raise Http501()
+
+    def update(self, request, *args, **kwargs):
+        raise Http501()
+
+    def delete(self, request, *args, **kwargs):
+        raise Http501()
+
+    def update_bulk(self, request, *args, **kwargs):
+        raise Http501()
+
+    def partial_update(self, request, *args, **kwargs):
+        raise Http501()
+
+    def partial_update_bulk(self, request, *args, **kwargs):
+        raise Http501()
+
+    def destroy(self, request, *args, **kwargs):
+        raise Http501()

--- a/src/metax_api/api/rpc/base/views/dataset_rpc.py
+++ b/src/metax_api/api/rpc/base/views/dataset_rpc.py
@@ -1,0 +1,36 @@
+# This file is part of the Metax API service
+#
+# Copyright 2017-2018 Ministry of Education and Culture, Finland
+#
+# :author: CSC - IT Center for Science Ltd., Espoo Finland <servicedesk@csc.fi>
+# :license: MIT
+
+from json import load
+
+from django.conf import settings as django_settings
+from rest_framework.decorators import list_route
+from rest_framework.response import Response
+
+from metax_api.exceptions import Http400
+from .common_rpc import CommonRPC
+
+
+class DatasetRPC(CommonRPC):
+
+    @list_route(methods=['get'], url_path="get_minimal_dataset_template")
+    def get_minimal_dataset_template(self, request):
+        if request.query_params.get('type', None) not in ['service', 'enduser']:
+            raise Http400({
+                'detail': ['query param \'type\' missing or wrong. please specify ?type= as one of: service, enduser']
+            })
+
+        with open('metax_api/exampledata/dataset_minimal.json', 'rb') as f:
+            example_ds = load(f)
+
+        example_ds['data_catalog'] = django_settings.END_USER_ALLOWED_DATA_CATALOGS[0]
+
+        if request.query_params['type'] == 'enduser':
+            example_ds.pop('metadata_provider_org', None)
+            example_ds.pop('metadata_provider_user', None)
+
+        return Response(example_ds)

--- a/src/metax_api/exampledata/dataset_minimal.json
+++ b/src/metax_api/exampledata/dataset_minimal.json
@@ -1,0 +1,44 @@
+{
+    "data_catalog": "urn:nbn:fi:att:data-catalog-att",
+    "research_dataset": {
+        "title": {
+            "en": "Test Dataset Title"
+        },
+        "description": {
+            "en": "A descriptive description describing the contents of this dataset. Must be descriptive."
+        },
+        "creator": [
+            {
+                "name": "Teppo Testaaja",
+                "@type": "Person",
+                "member_of": {
+                    "name": {
+                        "fi": "Testiorganisaatio"
+                    },
+                    "@type": "Organization"
+                }
+            }
+        ],
+        "curator": [
+            {
+                "name": {
+                    "fi": "Testiorganisaatio"
+                },
+                "@type": "Organization"
+            }
+        ],
+        "language":[{
+            "identifier": "http://lexvo.org/id/iso639-3/aar"
+        }],
+        "access_rights": {
+            "access_type": {
+                "identifier": "http://purl.org/att/es/reference_data/access_type/access_type_open_access"
+            },
+            "restriction_grounds": {
+                "identifier": "http://purl.org/att/es/reference_data/restriction_grounds/restriction_grounds_1"
+            }
+        }
+    },
+    "metadata_provider_org": "some_org_id",
+    "metadata_provider_user": "some_user_id"
+}

--- a/src/metax_api/settings.py
+++ b/src/metax_api/settings.py
@@ -70,14 +70,45 @@ if executing_in_test_case or executing_in_travis:
     ]
 
     API_ACCESS = {
-        "apierrors":    { "read":  ["testuser", "metax"], "write": ["testuser", "metax"] },
-        "contracts":    { "read":  ["testuser", "metax"], "write": ["testuser", "metax"] },
-        "datacatalogs": { "read":  ["all"], "write": ["testuser", "metax"] },
-        "datasets":     { "read":  ["all"], "write": ["testuser", "metax", "api_auth_user", "endusers"] },
-        "directories":  { "read":  ["testuser", "metax", "endusers"], "write": ["testuser", "metax"] },
-        "files":        { "read":  ["testuser", "metax", "api_auth_user", "endusers"], "write": ["testuser", "metax"] },
-        "filestorages": { "read":  ["testuser", "metax"], "write": ["testuser", "metax"] },
-        "schemas":      { "read":  ["all"], "write": ["testuser", "metax"] }
+        "rest": {
+            "apierrors":    {
+                "read": ["testuser", "metax"],
+                "write": ["testuser", "metax"]
+            },
+            "contracts":    {
+                "read": ["testuser", "metax"],
+                "write": ["testuser", "metax"]
+            },
+            "datacatalogs": {
+                "read": ["all"],
+                "write": ["testuser", "metax"]
+            },
+            "datasets":     {
+                "read": ["all"],
+                "write": ["testuser", "metax", "api_auth_user", "endusers"]
+            },
+            "directories":  {
+                "read": ["testuser", "metax", "endusers"],
+                "write": ["testuser", "metax"]
+            },
+            "files":        {
+                "read": ["testuser", "metax", "api_auth_user", "endusers"],
+                "write": ["testuser", "metax"]
+            },
+            "filestorages": {
+                "read": ["testuser", "metax"],
+                "write": ["testuser", "metax"]
+            },
+            "schemas":      {
+                "read": ["all"],
+                "write": ["testuser", "metax"]
+            }
+        },
+        "rpc": {
+            "datasets": {
+                "get_minimal_dataset_template": { "use": ["all"] }
+            }
+        }
     }
 elif METAX_ENV == 'test':
     # in test-env, modify API_ACCESS to give read and write perms to all (public). note that

--- a/src/metax_api/tests/api/rpc/base/views/__init__.py
+++ b/src/metax_api/tests/api/rpc/base/views/__init__.py
@@ -1,0 +1,8 @@
+# This file is part of the Metax API service
+#
+# Copyright 2017-2018 Ministry of Education and Culture, Finland
+#
+# :author: CSC - IT Center for Science Ltd., Espoo Finland <servicedesk@csc.fi>
+# :license: MIT
+
+from .dataset_rpc import *

--- a/src/metax_api/tests/api/rpc/base/views/dataset_rpc.py
+++ b/src/metax_api/tests/api/rpc/base/views/dataset_rpc.py
@@ -1,0 +1,61 @@
+# This file is part of the Metax API service
+#
+# Copyright 2017-2018 Ministry of Education and Culture, Finland
+#
+# :author: CSC - IT Center for Science Ltd., Espoo Finland <servicedesk@csc.fi>
+# :license: MIT
+
+from django.core.management import call_command
+from rest_framework import status
+from rest_framework.test import APITestCase
+import responses
+
+from metax_api.tests.utils import TestClassUtils, get_test_oidc_token, test_data_file_path
+
+
+class DatasetRPCTests(APITestCase, TestClassUtils):
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        Loaded only once for test cases inside this class.
+        """
+        super().setUpClass()
+        call_command('loaddata', test_data_file_path, verbosity=0)
+
+    def setUp(self):
+        super().setUp()
+        self.create_end_user_data_catalogs()
+
+    @responses.activate
+    def test_get_minimal_dataset_template(self):
+        """
+        Retrieve and use a minimal dataset template example from the api.
+        """
+
+        # query param type is missing, should return error and description what to do.
+        response = self.client.get('/rpc/datasets/get_minimal_dataset_template')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        # test preventing typos
+        response = self.client.get('/rpc/datasets/get_minimal_dataset_template?type=wrong')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        # test minimal dataset for service use
+        response = self.client.get('/rpc/datasets/get_minimal_dataset_template?type=service')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue('metadata_provider_org' in response.data)
+        self.assertTrue('metadata_provider_user' in response.data)
+        self._use_http_authorization(username='testuser')
+        response = self.client.post('/rest/datasets', response.data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        # test minimal dataset for end user use
+        response = self.client.get('/rpc/datasets/get_minimal_dataset_template?type=enduser')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue('metadata_provider_org' not in response.data)
+        self.assertTrue('metadata_provider_user' not in response.data)
+        self._use_http_authorization(method='bearer', token=get_test_oidc_token())
+        self._mock_token_validation_succeeds()
+        response = self.client.post('/rest/datasets', response.data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -12,7 +12,7 @@ produces:
 paths:
 
 # File Storage API
-  /filestorages:
+  /rest/filestorages:
     get:
       summary: List File Storages
       responses:
@@ -33,7 +33,7 @@ paths:
           description: Unauthorized
       tags:
         - File Storage API
-  /filestorages/{PID}:
+  /rest/filestorages/{PID}:
     get:
       summary: Get File Storage metadata
       parameters:
@@ -102,7 +102,7 @@ paths:
         - File Storage API
 
 # File API
-  /files:
+  /rest/files:
     get:
       summary: get list of files
       parameters:
@@ -208,7 +208,7 @@ paths:
           description: None of the provided identifiers were found.
       tags:
         - File API
-  /files/{PID}:
+  /rest/files/{PID}:
     get:
       summary: get file metadata
       parameters:
@@ -289,7 +289,7 @@ paths:
           description: object not found
       tags:
         - File API
-  /files/{PID}/XML:
+  /rest/files/{PID}/XML:
     get:
       summary: get XML metadata from file
       produces:
@@ -391,7 +391,7 @@ paths:
           description: file or namespace does not exist
       tags:
         - File API
-  /files/datasets:
+  /rest/files/datasets:
     post:
       summary: get datasets where files belong to
       description: |
@@ -414,7 +414,7 @@ paths:
           description: files given in the list not found
       tags:
         - File API
-  /files/restore:
+  /rest/files/restore:
     post:
       summary: restore removed files back to "not removed" state.
       description: |
@@ -435,10 +435,10 @@ paths:
           description: request ended in an error, response contains details.
       tags:
         - File API
-  /directories/{PID}:
+  /rest/directories/{PID}:
     get:
       summary: get details of a directory
-      description: Does not contain the directory's files and sub-directories. For that, use /directories/{PID}/files
+      description: Does not contain the directory's files and sub-directories. For that, use /rest/directories/{PID}/files
       parameters:
         - name: PID
           in: path
@@ -454,7 +454,7 @@ paths:
           description: not found
       tags:
         - File API
-  /directories/{PID}/files:
+  /rest/directories/{PID}/files:
     get:
       summary: get list of files and directories contained by a directory
       parameters:
@@ -486,8 +486,8 @@ paths:
           in: query
           description: |
             includes the 'parent directory' of the contents being fetched in the results also. example&#58;
-            GET /directories/3/files?include_parent=true also includes data about directory id: 3 in the results.
-            otherwise, one would query for its data separately by GET /directories/3.
+            GET /rest/directories/3/files?include_parent=true also includes data about directory id: 3 in the results.
+            otherwise, one would query for its data separately by GET /rest/directories/3.
           required: false
           type: boolean
         - name: cr_identifier
@@ -514,11 +514,11 @@ paths:
           description: directory not found
       tags:
         - File API
-  /directories/files:
+  /rest/directories/files:
     get:
       summary: get list of files and directories contained by a directory, queried by dir path and project
       description: |
-        functions the same as /directories/pid, except queried by dir path and project identifier, instead of directly by directory identifier.
+        functions the same as /rest/directories/pid, except queried by dir path and project identifier, instead of directly by directory identifier.
       parameters:
         - name: path
           in: path
@@ -553,8 +553,8 @@ paths:
           in: query
           description: |
             includes the 'parent directory' of the contents being fetched in the results also. example&#58;
-            GET /directories/3/files?include_parent=true also includes data about directory id: 3 in the results.
-            otherwise, one would query for its data separately by GET /directories/3.
+            GET /rest/directories/3/files?include_parent=true also includes data about directory id: 3 in the results.
+            otherwise, one would query for its data separately by GET /rest/directories/3.
           required: false
           type: boolean
         - name: preferred_identifier
@@ -571,7 +571,7 @@ paths:
           description: directory not found
       tags:
         - File API
-  /directories/root:
+  /rest/directories/root:
     get:
       summary: return root directory for a project, and its files and directories
       description: Useful when starting to browse files for a project, when individual root-level directory identifier is not yet known.
@@ -596,7 +596,7 @@ paths:
 
 
 # Data Catalog API
-  /datacatalogs:
+  /rest/datacatalogs:
     get:
       summary: "list of data catalogs"
       responses:
@@ -624,7 +624,7 @@ paths:
           description: Unauthorized. Reserved for admins only
       tags:
         - Data Catalog API
-  /datacatalogs/{PID}:
+  /rest/datacatalogs/{PID}:
     get:
       summary: get data catalog metadata
       parameters:
@@ -701,7 +701,7 @@ paths:
 
 
 # Dataset API
-  /datasets:
+  /rest/datasets:
     # some of the parameters and returned fields are for TPAS usage only
     get:
       summary: "list datasets"
@@ -840,7 +840,7 @@ paths:
           description: All updates failed. A list of errors is returned.
       tags:
         - Dataset API
-  /datasets/identifiers:
+  /rest/datasets/identifiers:
     get:
       summary: "list all dataset identifiers"
       parameters:
@@ -874,7 +874,7 @@ paths:
           description: successful operation, returns a list of all dataset metadata version identifiers.
       tags:
         - Dataset API
-  /datasets/unique_preferred_identifiers:
+  /rest/datasets/unique_preferred_identifiers:
     get:
       summary: "list all unique dataset preferred identifiers"
       parameters:
@@ -908,7 +908,7 @@ paths:
           description: successful operation, returns a list of all unique dataset preferred identifiers.
       tags:
         - Dataset API
-  /datasets/{PID}:
+  /rest/datasets/{PID}:
     get:
       summary: get dataset metadata
       parameters:
@@ -1012,7 +1012,7 @@ paths:
           description: parameters contained errors, response includes details
       tags:
         - Dataset API
-  /datasets/{PID}/files:
+  /rest/datasets/{PID}/files:
     get:
       summary: get list of files in a dataset
       parameters:
@@ -1036,7 +1036,7 @@ paths:
           description: successful operation, return list of full files metadata
       tags:
         - Dataset API
-  /datasets/{PID}/metadata_versions:
+  /rest/datasets/{PID}/metadata_versions:
     get:
       summary: "list old research_dataset entries of a record"
       parameters:
@@ -1052,7 +1052,7 @@ paths:
             $ref: '#/definitions/StringList'
       tags:
         - Dataset API
-  /datasets/{PID}/metadata_versions/{MVI}:
+  /rest/datasets/{PID}/metadata_versions/{MVI}:
     get:
       summary: "get contents of a specific old research_dataset of a record."
       parameters:
@@ -1075,7 +1075,7 @@ paths:
         - Dataset API
 
 # Contract API
-  /contracts:
+  /rest/contracts:
     get:
       summary: "list contracts"
       parameters:
@@ -1110,7 +1110,7 @@ paths:
           description: parameters contained errors, response includes details
       tags:
         - Contract API
-  /contracts/{PID}:
+  /rest/contracts/{PID}:
     get:
       summary: get contract metadata
       parameters:
@@ -1159,7 +1159,7 @@ paths:
 
 
 # ApiErrors API
-  /apierrors:
+  /rest/apierrors:
     get:
       summary: "list errors produced during api requests"
       responses:
@@ -1167,7 +1167,7 @@ paths:
           description: returns a list of error entries. may return an empty list.
       tags:
         - ApiErrors API
-  /apierrors/{identifier}:
+  /rest/apierrors/{identifier}:
     get:
       summary: get details of a single error entry
       parameters:
@@ -1198,7 +1198,7 @@ paths:
           description: not found
       tags:
         - ApiErrors API
-  /apierrors/flush:
+  /rest/apierrors/flush:
     post:
       summary: "delete all error entries"
       responses:
@@ -1209,7 +1209,7 @@ paths:
 
 
 # Schema API
-  /schemas:
+  /rest/schemas:
     get:
       summary: "list schemas"
       responses:
@@ -1217,7 +1217,7 @@ paths:
           description: successful operation, return list of schema names
       tags:
         - Schema API
-  /schemas/{name}:
+  /rest/schemas/{name}:
     get:
       summary: get schema content
       parameters:
@@ -1233,6 +1233,26 @@ paths:
           description: not found
       tags:
         - Schema API
+
+
+# RPC APIs
+  /rpc/datasets/get_minimal_dataset_template:
+    get:
+      summary: Get minimal dataset template.
+      description:  Get minimal dataset template that can be used to create datasets. Service and End Users have different kind of templates. The returned template can be used as-is when creating a dataset into Metax.
+      parameters:
+      - name: type
+          in: query
+          description: Type of dataset template to retrieve. Accepted values&#58; service, enduser.
+          required: true
+          type: string
+      responses:
+        '200':
+          description: successful operation, return dataset template as json.
+          schema:
+            $ref: '#/definitions/CatalogRecord'
+      tags:
+        - Dataset RPC
 
             
 definitions:


### PR DESCRIPTION
Added base for RPC apis, and the first RPC api /rpc/datasets/get_minimal_dataset_template.
Needs updated metax-ops for altered API_PERMISSIONS object in app_config. Permissions for RPC can be set per RPC method.