### PR TITLE
CSCMETAX-61: [FIX] Prevent adding filesystem root dir ('/') to a data…

### DIFF
--- a/src/metax_api/models/catalog_record.py
+++ b/src/metax_api/models/catalog_record.py
@@ -1122,6 +1122,11 @@ class CatalogRecord(Common):
         dirs_by_project = defaultdict(list)
 
         for dr in dirs:
+            if dr['directory_path'] == '/':
+                raise ValidationError({ 'detail': [
+                    'Adding the filesystem root directory ("/") to a dataset is not allowed. Identifier of the '
+                    'offending directory: %s' % dr['directory_path']
+                ]})
             dirs_by_project[dr['project_identifier']].append(dr['directory_path'])
 
         top_level_dirs_by_project = defaultdict(list)

--- a/src/metax_api/models/directory.py
+++ b/src/metax_api/models/directory.py
@@ -88,7 +88,7 @@ class Directory(Common):
             % (
                 self.project_identifier,
                 self.byte_size,
-                self.byte_size / 1024 / 1024.0,
+                self.byte_size / 1024 / 1024 / 1024,
                 self.file_count
             )
         )


### PR DESCRIPTION
…set (even though in reality it is not the filesystem root, but the path looks like it). Freezing the root is also not possible in IDA, minimum path is /something.

Also fix bug in logging which tried to print bytes as giga bytes: one division was missing.