### PR TITLE
CSCMETAX-490: [ADD] IDA and ATT schemas: Make org name non-mandatory.…

### DIFF
--- a/src/metax_api/api/rest/base/schemas/att_dataset_schema.json
+++ b/src/metax_api/api/rest/base/schemas/att_dataset_schema.json
@@ -639,8 +639,7 @@
                 }
             },
             "required":[
-                "@type",
-                "name"
+                "@type"
             ],
             "additionalProperties": false
         },

--- a/src/metax_api/api/rest/base/schemas/ida_dataset_schema.json
+++ b/src/metax_api/api/rest/base/schemas/ida_dataset_schema.json
@@ -662,8 +662,7 @@
                 }
             },
             "required":[
-                "@type",
-                "name"
+                "@type"
             ],
             "additionalProperties": false
         },

--- a/src/metax_api/tests/api/rest/base/views/common/auth.py
+++ b/src/metax_api/tests/api/rest/base/views/common/auth.py
@@ -33,7 +33,7 @@ class ApiServiceAccessAuthorization(CatalogRecordApiWriteCommon):
         cr['contract'] = 1
 
         response = self.client.put('/rest/datasets/1', cr, format='json')
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
 
     def test_write_access_error(self):
         """


### PR DESCRIPTION
… Do mandatory-checking in backend code

To not force end users to provide temporary data that is going to get overwritten anyway, when using identifiers from reference data.