### PR TITLE
CSCMETAX-477: [ADD] Legacy data catalog to initialdata catalogs. Add …

### DIFF
--- a/src/metax_api/api/oaipmh/base/metax_oai_server.py
+++ b/src/metax_api/api/oaipmh/base/metax_oai_server.py
@@ -90,7 +90,7 @@ class MetaxOAIServer(ResumptionOAIPMH):
 
         if data_catalog == 'urn:nbn:fi:att:data-catalog-harvest-syke':
             identifiers = self._handle_syke_urnresolver_metadata(record)
-        else:
+        elif record.data_catalog.catalog_json['identifier'] not in settings.LEGACY_CATALOGS:
             identifiers.append(settings.OAI['ETSIN_URL_TEMPLATE'] % record.identifier)
 
             if not record.catalog_is_harvested():

--- a/src/metax_api/initialdata/datacatalogs.json
+++ b/src/metax_api/initialdata/datacatalogs.json
@@ -127,4 +127,69 @@
         "dataset_versioning": false,
         "research_dataset_schema": "att"
     }
+},
+{
+    "catalog_json": {
+        "title": {
+            "en": "Metadata Catalog for Legacy Research Datasets",
+            "fi": "Aiemmin julkaistujen tutkimusaineistojen kuvailutietokatalogi"
+        },
+        "language": [
+            {
+                "title": {
+                    "en": "Finnish language",
+                    "fi": "Suomen kieli",
+                    "sv": "finska",
+                    "und": "Suomen kieli"
+                },
+                "identifier": "http://lexvo.org/id/iso639-3/fin"
+            },
+            {
+                "title": {
+                    "en": "English language",
+                    "fi": "Englannin kieli",
+                    "sv": "engelska",
+                    "und": "Englannin kieli"
+                },
+                "identifier": "http://lexvo.org/id/iso639-3/eng"
+            }
+        ],
+        "harvested": false,
+        "publisher": {
+            "name": {
+                "en": "Ministry of Education and Culture, Finland",
+                "fi": "Opetus- ja kulttuuriministeriö"
+            }
+        },
+        "identifier": "urn:nbn:fi:att:data-catalog-legacy",
+        "access_rights": {
+            "license": [
+                {
+                    "title": {
+                        "fi": "Creative Commons Yleismaailmallinen (CC0 1.0) Public Domain -lausuma",
+                        "en": "Creative Commons CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",
+                        "und": "Creative Commons Yleismaailmallinen (CC0 1.0) Public Domain -lausuma"
+                    },
+                    "license": "https://creativecommons.org/publicdomain/zero/1.0/",
+                    "identifier": "http://uri.suomi.fi/codelist/fairdata/license/code/CC0-1.0"
+                }
+            ],
+            "access_type": [
+                {
+                    "identifier": "http://uri.suomi.fi/codelist/fairdata/access_type/code/open",
+                    "pref_label": {
+                        "en": "Open",
+                        "fi": "Avoin",
+                        "und": "Avoin"
+                    }
+                }
+            ],
+            "description": {
+                "en": "Contains metadata about legacy research datasets that are published elsewhere. Published datasets may not have all of the required metadata to qualify as Fairdata-dataset",
+                "fi": "Sisältää kuvailutietoja muualla julkaistuista tutkimusaineistoista. Kaikki tutkimusaineistot eivät välttämättä täytä Fairdata-kuvailuvaatimuksia"
+            }
+        },
+        "dataset_versioning": false,
+        "research_dataset_schema": "att"
+    }
 }]

--- a/src/metax_api/models/catalog_record.py
+++ b/src/metax_api/models/catalog_record.py
@@ -750,7 +750,11 @@ class CatalogRecord(Common):
         if get_identifier_type(self.research_dataset['preferred_identifier']) == IdentifierType.DOI:
             self.add_post_request_callable(DataciteDOIUpdate(self, 'delete'))
         self.add_post_request_callable(RabbitMQPublishRecord(self, 'delete'))
-        super(CatalogRecord, self).delete(*args, **kwargs)
+        if self.catalog_is_legacy():
+            # delete permanently instead of only marking as 'removed'
+            super(Common, self).delete()
+        else:
+            super().delete(*args, **kwargs)
 
     @property
     def preferred_identifier(self):

--- a/src/metax_api/models/catalog_record.py
+++ b/src/metax_api/models/catalog_record.py
@@ -881,7 +881,7 @@ class CatalogRecord(Common):
                 self._initial_data['research_dataset']['metadata_version_identifier']
 
         if self.field_changed('research_dataset.preferred_identifier'):
-            if not self.catalog_is_harvested():
+            if not (self.catalog_is_harvested() or self.catalog_is_legacy()):
                 raise Http400("Cannot change preferred_identifier in datasets in non-harvested catalogs")
 
         if self.field_changed('research_dataset.total_ida_byte_size'):

--- a/src/metax_api/models/catalog_record.py
+++ b/src/metax_api/models/catalog_record.py
@@ -41,6 +41,9 @@ ACCESS_TYPES = {
 }
 
 
+LEGACY_CATALOGS = settings.LEGACY_CATALOGS
+
+
 class DiscardRecord(Exception):
     pass
 
@@ -769,6 +772,9 @@ class CatalogRecord(Common):
     def catalog_is_harvested(self):
         return self.data_catalog.catalog_json.get('harvested', False) is True
 
+    def catalog_is_legacy(self):
+        return self.data_catalog.catalog_json['identifier'] in LEGACY_CATALOGS
+
     def has_alternate_records(self):
         return bool(self.alternate_record_set)
 
@@ -792,6 +798,21 @@ class CatalogRecord(Common):
             # do not overwrite. note: if the value was left empty, an error would have been
             # raised in the serializer validation.
             pass
+        elif self.catalog_is_legacy():
+            if 'preferred_identifier' not in self.research_dataset:
+                raise ValidationError({
+                    'detail': [
+                        'Selected catalog %s is a legacy catalog. Preferred identifiers are not '
+                        'automatically generated for datasets stored in legacy catalogs, nor is '
+                        'their uniqueness enforced. Please provide a value for dataset field '
+                        'preferred_identifier.'
+                        % self.data_catalog.catalog_json['identifier']
+                    ]
+                })
+            _logger.info(
+                'Catalog %s is a legacy catalog - not generating pid'
+                % self.data_catalog.catalog_json['identifier']
+            )
         else:
             if pref_id_type == IdentifierType.URN:
                 self.research_dataset['preferred_identifier'] = generate_uuid_identifier(urn_prefix=True)

--- a/src/metax_api/settings.py
+++ b/src/metax_api/settings.py
@@ -134,12 +134,22 @@ if executing_in_test_case or executing_in_travis:
     END_USER_ALLOWED_DATA_CATALOGS = [
         "urn:nbn:fi:att:data-catalog-ida",
         "urn:nbn:fi:att:data-catalog-att",
+        "urn:nbn:fi:att:data-catalog-legacy",
+    ]
+    LEGACY_CATALOGS = [
+        "urn:nbn:fi:att:data-catalog-legacy",
     ]
 else:
     # allow end users to create catalogrecords only to the following data catalogs
     END_USER_ALLOWED_DATA_CATALOGS = [
         app_config_dict['IDA_DATACATALOG_IDENTIFIER'],
         app_config_dict['ATT_DATACATALOG_IDENTIFIER'],
+        app_config_dict['LEGACY_DATACATALOG_IDENTIFIER'],
+    ]
+
+    # catalogs where uniqueness of dataset pids is not enforced.
+    LEGACY_CATALOGS = [
+        app_config_dict['LEGACY_DATACATALOG_IDENTIFIER'],
     ]
 
 # endpoint in localhost where bearer tokens should be sent for validation

--- a/src/metax_api/tests/api/oaipmh/minimal_api.py
+++ b/src/metax_api/tests/api/oaipmh/minimal_api.py
@@ -321,6 +321,19 @@ class OAIPMHReadTests(APITestCase, TestClassUtils):
                                         self.preferred_identifier)
         self.assertTrue(len(identifiers) == 1, response.content)
 
+    def test_legacy_catalog_datasets_are_not_urnresolved(self):
+        cr = CatalogRecord.objects.get(identifier=self.identifier)
+        cr.data_catalog.catalog_json['identifier'] = settings.LEGACY_CATALOGS[0]
+        cr.data_catalog.force_save()
+
+        response = self.client.get(
+            '/oai/?verb=GetRecord&identifier=%s&metadataPrefix=oai_dc_urnresolver' % self.identifier)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        identifiers = self._get_results(response.content,
+                                        '//o:record/o:metadata/oai_dc:dc/dc:identifier[text()="%s"]' %
+                                        self.preferred_identifier)
+        self.assertTrue(len(identifiers) == 0, response.content)
+
     def test_list_records_from_datasets_set(self):
         ms = settings.OAI['BATCH_SIZE']
         allRecords = CatalogRecord.objects.filter(

--- a/src/metax_api/tests/api/rest/base/views/apierrors/read.py
+++ b/src/metax_api/tests/api/rest/base/views/apierrors/read.py
@@ -111,9 +111,9 @@ class ApiErrorReadBasicTests(APITestCase, TestClassUtils):
         cr_1.pop('data_catalog') # causes an error
 
         response = self.client.post('/rest/datasets', cr_1, format='json')
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.data)
         response = self.client.post('/rest/datasets', cr_1, format='json')
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.data)
 
         # ensure something was produced...
         response = self.client.get('/rest/apierrors')

--- a/src/metax_api/tests/api/rest/base/views/datasets/read.py
+++ b/src/metax_api/tests/api/rest/base/views/datasets/read.py
@@ -88,6 +88,10 @@ class CatalogRecordApiReadBasicTests(CatalogRecordApiReadCommon):
         cr = self._get_object_from_test_data('catalogrecord', requested_index=9)
         pid = cr['research_dataset']['preferred_identifier']
 
+        # verify there are more than one record with same pid!
+        count = CatalogRecord.objects.filter(research_dataset__preferred_identifier=pid).count()
+        self.assertEqual(count > 1, True, 'makes no sense to test with a pid that exists only once')
+
         # the retrieved record should be the one that is in catalog 1
         response = self.client.get('/rest/datasets?preferred_identifier=%s' %
             urllib.parse.quote(pid))

--- a/src/metax_api/tests/api/rest/base/views/datasets/write.py
+++ b/src/metax_api/tests/api/rest/base/views/datasets/write.py
@@ -2395,7 +2395,7 @@ class CatalogRecordApiWriteLegacyDataCatalogs(CatalogRecordApiWriteCommon):
         modify = response.data
         real_pid = CatalogRecord.objects.get(pk=1).preferred_identifier
         modify['research_dataset']['preferred_identifier'] = real_pid
-        response = self.client.put('/rest/datasets/%s' % modify['id'], self.cr_test_data, format="json")
+        response = self.client.put('/rest/datasets/%s' % modify['id'], modify, format="json")
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
 
     def test_delete_legacy_catalog_dataset(self):

--- a/src/metax_api/tests/api/rest/base/views/datasets/write.py
+++ b/src/metax_api/tests/api/rest/base/views/datasets/write.py
@@ -23,6 +23,7 @@ from metax_api.tests.utils import get_test_oidc_token
 
 VALIDATE_TOKEN_URL = django_settings.VALIDATE_TOKEN_URL
 END_USER_ALLOWED_DATA_CATALOGS = django_settings.END_USER_ALLOWED_DATA_CATALOGS
+LEGACY_CATALOGS = django_settings.LEGACY_CATALOGS
 
 
 class CatalogRecordApiWriteCommon(APITestCase, TestClassUtils):
@@ -2335,6 +2336,68 @@ class CatalogRecordApiWriteRemoteResources(CatalogRecordApiWriteCommon):
                          total_remote_resources_byte_size)
 
 
+class CatalogRecordApiWriteLegacyDataCatalogs(CatalogRecordApiWriteCommon):
+
+    """
+    Tests related to legacy data catalogs.
+    """
+
+    def setUp(self):
+        """
+        Create a test-datacatalog that plays the role of a legacy catalog.
+        """
+        super().setUp()
+        dc = DataCatalog.objects.filter(catalog_json__research_dataset_schema='att').first()
+        dc.catalog_json['identifier'] = LEGACY_CATALOGS[0]
+        dc.force_save()
+        del self.cr_test_data['research_dataset']['files']
+        del self.cr_test_data['research_dataset']['total_ida_byte_size']
+
+    def test_legacy_catalog_pids_are_not_unique(self):
+        # values provided as pid values in legacy catalogs are not required to be unique
+        # within the catalog.
+        self.cr_test_data['data_catalog'] = LEGACY_CATALOGS[0]
+        self.cr_test_data['research_dataset']['preferred_identifier'] = 'a'
+        same_pid_ids = []
+        for i in range(3):
+            response = self.client.post('/rest/datasets', self.cr_test_data, format="json")
+            self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.data)
+            self.assertEqual(response.data['research_dataset']['preferred_identifier'], 'a')
+            same_pid_ids.append(response.data['id'])
+
+        # pid can even be same as an existing dataset's pid in an ATT catalog
+        real_pid = CatalogRecord.objects.get(pk=1).preferred_identifier
+        self.cr_test_data['research_dataset']['preferred_identifier'] = real_pid
+        response = self.client.post('/rest/datasets', self.cr_test_data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.data)
+        self.assertEqual(response.data['research_dataset']['preferred_identifier'], real_pid)
+
+    def test_legacy_catalog_pid_must_be_provided(self):
+        # pid cant be empty string
+        self.cr_test_data['data_catalog'] = LEGACY_CATALOGS[0]
+        self.cr_test_data['research_dataset']['preferred_identifier'] = ''
+        response = self.client.post('/rest/datasets', self.cr_test_data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.data)
+
+        # pid cant be omitted
+        del self.cr_test_data['research_dataset']['preferred_identifier']
+        response = self.client.post('/rest/datasets', self.cr_test_data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.data)
+
+    def test_legacy_catalog_pids_update(self):
+        # test setup
+        self.cr_test_data['data_catalog'] = LEGACY_CATALOGS[0]
+        self.cr_test_data['research_dataset']['preferred_identifier'] = 'a'
+        response = self.client.post('/rest/datasets', self.cr_test_data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.data)
+
+        # update record. in updates uniqueness also should not be checked
+        modify = response.data
+        real_pid = CatalogRecord.objects.get(pk=1).preferred_identifier
+        modify['research_dataset']['preferred_identifier'] = real_pid
+        response = self.client.put('/rest/datasets/%s' % modify['id'], self.cr_test_data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
+
 class CatalogRecordApiWriteOwnerFields(CatalogRecordApiWriteCommon):
 
     """
@@ -2483,6 +2546,8 @@ class CatalogRecordApiEndUserAccess(CatalogRecordApiWriteCommon):
 
         # should work
         for identifier in END_USER_ALLOWED_DATA_CATALOGS:
+            if identifier in LEGACY_CATALOGS:
+                self.cr_test_data['research_dataset']['preferred_identifier'] = 'a'
             self.cr_test_data['data_catalog'] = identifier
             response = self.client.post('/rest/datasets', self.cr_test_data, format="json")
             self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.data)

--- a/src/metax_api/tests/api/rest/base/views/datasets/write.py
+++ b/src/metax_api/tests/api/rest/base/views/datasets/write.py
@@ -2398,6 +2398,26 @@ class CatalogRecordApiWriteLegacyDataCatalogs(CatalogRecordApiWriteCommon):
         response = self.client.put('/rest/datasets/%s' % modify['id'], self.cr_test_data, format="json")
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
 
+    def test_delete_legacy_catalog_dataset(self):
+        """
+        Datasets in legacy catalogs should be deleted permanently, instead of only marking them
+        as 'removed'.
+        """
+
+        # test setup
+        self.cr_test_data['data_catalog'] = LEGACY_CATALOGS[0]
+        self.cr_test_data['research_dataset']['preferred_identifier'] = 'a'
+        response = self.client.post('/rest/datasets', self.cr_test_data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.data)
+        cr_id = response.data['id']
+
+        # delete record
+        response = self.client.delete('/rest/datasets/%s' % cr_id, format="json")
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT, response.data)
+        results_count = CatalogRecord.objects_unfiltered.filter(pk=cr_id).count()
+        self.assertEqual(results_count, 0, 'record should have been deleted permantly')
+
+
 class CatalogRecordApiWriteOwnerFields(CatalogRecordApiWriteCommon):
 
     """


### PR DESCRIPTION
…array LEGACY_CATALOGS to settings.py, which holds identifiers of catalogs where pid uniqueness or other validation is not checked, except that a SOME value has to be provided.