### PR TITLE
Cscmetax 498 509

### DIFF
--- a/src/metax_api/models/catalog_record.py
+++ b/src/metax_api/models/catalog_record.py
@@ -747,7 +747,7 @@ class CatalogRecord(Common):
     def delete(self, *args, **kwargs):
         if self.has_alternate_records():
             self._remove_from_alternate_record_set()
-        if get_identifier_type(self.research_dataset['preferred_identifier']) == IdentifierType.DOI:
+        if get_identifier_type(self.preferred_identifier) == IdentifierType.DOI:
             self.add_post_request_callable(DataciteDOIUpdate(self, 'delete'))
         self.add_post_request_callable(RabbitMQPublishRecord(self, 'delete'))
         if self.catalog_is_legacy():
@@ -799,8 +799,7 @@ class CatalogRecord(Common):
         pref_id_type = self._get_preferred_identifier_type_from_request()
         if self.catalog_is_harvested():
             # in harvested catalogs, the harvester is allowed to set the preferred_identifier.
-            # do not overwrite. note: if the value was left empty, an error would have been
-            # raised in the serializer validation.
+            # do not overwrite.
             pass
         elif self.catalog_is_legacy():
             if 'preferred_identifier' not in self.research_dataset:
@@ -855,7 +854,7 @@ class CatalogRecord(Common):
         if other_record:
             self._create_or_update_alternate_record_set(other_record)
 
-        if get_identifier_type(self.research_dataset['preferred_identifier']) == IdentifierType.DOI:
+        if get_identifier_type(self.preferred_identifier) == IdentifierType.DOI:
             self.add_post_request_callable(DataciteDOIUpdate(self, 'create'))
 
         if self._dataset_is_access_restricted():
@@ -985,7 +984,7 @@ class CatalogRecord(Common):
                 self._handle_preferred_identifier_changed()
 
     def _post_update_operations(self):
-        if get_identifier_type(self.research_dataset['preferred_identifier']) == IdentifierType.DOI and \
+        if get_identifier_type(self.preferred_identifier) == IdentifierType.DOI and \
                 self.update_datacite:
             self.add_post_request_callable(DataciteDOIUpdate(self, 'update'))
 

--- a/src/metax_api/services/catalog_record_service.py
+++ b/src/metax_api/services/catalog_record_service.py
@@ -95,6 +95,10 @@ class CatalogRecordService(CommonService, ReferenceDataMixin):
         if request.query_params.get('pas_filter', False):
             cls.set_pas_filter(queryset_search_params, request)
 
+        if request.query_params.get('data_catalog', False):
+            queryset_search_params['data_catalog__catalog_json__identifier__iregex'] = \
+                request.query_params['data_catalog']
+
         return queryset_search_params
 
     @staticmethod

--- a/src/metax_api/tests/api/rest/base/views/datasets/read.py
+++ b/src/metax_api/tests/api/rest/base/views/datasets/read.py
@@ -558,6 +558,26 @@ class CatalogRecordApiReadQueryParamsTests(CatalogRecordApiReadCommon):
         response = self.client.get('/rest/datasets?contract_org_identifier=1234')
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
+    def test_read_catalog_record_search_by_data_catalog_id(self):
+        from metax_api.models.data_catalog import DataCatalog
+
+        # Create a new data catalog
+        dc = self._get_object_from_test_data('datacatalog', requested_index=0)
+        dc_id = 'original_dc_identifier'
+        dc['catalog_json']['identifier'] = dc_id
+        self.client.post('/rest/datacatalogs', dc, format="json")
+
+        # Set the new data catalog for a catalog record and store the catalog record
+        cr = CatalogRecord.objects.get(pk=1)
+        cr.data_catalog = DataCatalog.objects.get(catalog_json__identifier=dc_id)
+        cr.force_save()
+
+        # Verify
+        response = self.client.get('/rest/datasets?data_catalog={0}'.format(dc_id))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data['results']), 1)
+        self.assertEqual(response.data['results'][0]['data_catalog']['identifier'], dc_id)
+
 
 class CatalogRecordApiReadXMLTransformationTests(CatalogRecordApiReadCommon):
     """

--- a/src/metax_api/utils/utils.py
+++ b/src/metax_api/utils/utils.py
@@ -102,12 +102,12 @@ def extract_doi_from_doi_identifier(doi_identifier):
 
 
 def get_identifier_type(identifier):
-    if identifier.startswith('doi:'):
-        return IdentifierType.DOI
-    elif identifier.startswith('urn:'):
-        return IdentifierType.URN
-    else:
-        return None
+    if identifier:
+        if identifier.startswith('doi:'):
+            return IdentifierType.DOI
+        elif identifier.startswith('urn:'):
+            return IdentifierType.URN
+    return None
 
 
 def remove_keys_recursively(obj, fields_to_remove):

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -795,6 +795,10 @@ paths:
           in: query
           description: identifier of the editor used to modify the record, i.e. qvain.
           type: string
+        - name: data_catalog
+          in: query
+          description: Filter by data catalog identifier
+          type: string
         - name: offset
           in: query
           description: offset for paging


### PR DESCRIPTION
* Fixed: Metax API crashes when creating a dataset into a harvester catalog while omitting pid
* Filter datasets by data catalog