### PR TITLE
Cscmetax 506 docs building fails

### DIFF
--- a/.travis-deploy.sh
+++ b/.travis-deploy.sh
@@ -13,11 +13,11 @@ cd metax-ops/ansible/
 if [[ "$TRAVIS_BRANCH" == "test" && "$TRAVIS_PULL_REQUEST" == "false" ]]; then
     echo "Deploying to test.."
     ansible-galaxy -r requirements.yml install --roles-path=roles
-    ansible-playbook -vv -i inventories/test/hosts site_deploy.yml --extra-vars "ssh_user=metax-deploy-user"
+    ansible-playbook -vv -i inventories/test/hosts site_deploy.yml --extra-vars "ssh_user=metax-deploy-user server_domain_name=metax-test.csc.fi"
 elif [[ "$TRAVIS_BRANCH" == "stable" && "$TRAVIS_PULL_REQUEST" == "false" ]]; then
     echo "Deploying to stable.."
     ansible-galaxy -r requirements.yml install --roles-path=roles
-    ansible-playbook -vv -i inventories/stable/hosts site_deploy.yml --extra-vars "ssh_user=metax-deploy-user"
+    ansible-playbook -vv -i inventories/stable/hosts site_deploy.yml --extra-vars "ssh_user=metax-deploy-user server_domain_name=metax-stable.csc.fi"
 fi
 
 # Make sure the last command to run before this part is the ansible-playbook command


### PR DESCRIPTION
* This PR needs to be first accepted: https://github.com/CSCfi/metax-ops/pull/6 . NOTE: Do not accept before https://github.com/CSCfi/metax-api/pull/390 is accepted since otherwise that PR would fail in Travis (would try to build the docs)
* Assuming metax test and stable domain names aren't a big secret
* Other way to do this would be to move all server_domain_name ansible variables to publiclly available inventory files
* Third way would be to set server_domain_name values as env variable and use that in the target env.