### PR TITLE
CSCMETAX-516: [REF] Separate the fetching of oai_dc_urnresolver recor…

### DIFF
--- a/src/metax_api/api/oaipmh/base/metax_oai_server.py
+++ b/src/metax_api/api/oaipmh/base/metax_oai_server.py
@@ -359,8 +359,8 @@ class MetaxOAIServer(ResumptionOAIPMH):
                  'https://schema.datacite.org/meta/kernel-4.1/metadata.xsd',
                  'https://schema.datacite.org/meta/kernel-4.1/'),
                 (OAI_DC_URNRESOLVER_MDPREFIX,
-                 'http://www.openarchives.org/OAI/2.0/oai_dc.xsd',
-                 'http://www.openarchives.org/OAI/2.0/oai_dc/')
+                 '',
+                 '')
                 ]
 
     def listSets(self, cursor=None, batch_size=None):

--- a/src/metax_api/api/oaipmh/base/view.py
+++ b/src/metax_api/api/oaipmh/base/view.py
@@ -47,13 +47,14 @@ def oai_dc_writer_with_lang(element, metadata):
         'contributor', 'date', 'type', 'format', 'identifier',
         'source', 'language', 'relation', 'coverage', 'rights'
     ]:
-
-        for value in map.get(name, []):
-
-            e = SubElement(e_dc, nsdc(name))
-            if 'lang' in value:
-                e.attrib['{http://www.w3.org/XML/1998/namespace}lang'] = value['lang']
-            e.text = value['value']
+        try:
+            for value in map.get(name, []):
+                e = SubElement(e_dc, nsdc(name))
+                if 'lang' in value:
+                    e.attrib['{http://www.w3.org/XML/1998/namespace}lang'] = value['lang']
+                e.text = value['value']
+        except:
+            pass
 
 
 def oai_datacite_writer(element, metadata):

--- a/src/metax_api/services/datacite_service.py
+++ b/src/metax_api/services/datacite_service.py
@@ -361,13 +361,17 @@ class _DataciteService(CommonService):
 
                 elif wkt.startswith('POLYGON'):
                     geo_location['geoLocationPolygon'] = { 'polygonPoints': [] }
-                    for point in wkt.split('POLYGON')[1][2:-2].split(','):
-                        longitude, latitude = point.strip().split(' ')
-                        polygon_point = {
-                            'pointLongitude': int(longitude),
-                            'pointLatitude': int(latitude),
-                        }
-                        geo_location['geoLocationPolygon']['polygonPoints'].append(polygon_point)
+                    # Split POLYGON in case it contains several polygon objects
+                    for polygon in wkt.split('POLYGON')[1][2:-2].split('),('):
+                        for point in polygon.split(','):
+                            longitude, latitude = point.strip().split(' ')
+                            polygon_point = {
+                                'pointLongitude': float(longitude),
+                                'pointLatitude': float(latitude),
+                            }
+                            geo_location['geoLocationPolygon']['polygonPoints'].append(polygon_point)
+                        # Do not support for more than one polygon within one POLYGON value, for now
+                        break
 
                 else:
                     # not applicable

--- a/src/metax_api/tests/api/oaipmh/minimal_api.py
+++ b/src/metax_api/tests/api/oaipmh/minimal_api.py
@@ -26,136 +26,6 @@ class OAIPMHReadTests(APITestCase, TestClassUtils):
                    'dct': "http://purl.org/dc/terms/",
                    'datacite': 'http://schema.datacite.org/oai/oai-1.0/'}
 
-    _datacatalog_record = {
-        "id": 2,
-        "catalog_json": {
-            "title": {
-                "en": "Test data catalog name",
-                "fi": "Testidatakatalogin nimi"
-            },
-            "issued": "2014-02-27T08:19:58Z",
-            "homepage": [
-                {
-                    "title": {
-                        "en": "Test website",
-                        "fi": "Testi-verkkopalvelu"
-                    },
-                    "identifier": "http://testing.com"
-                },
-                {
-                    "title": {
-                        "en": "Another website",
-                        "fi": "Toinen verkkopalvelu"
-                    },
-                    "identifier": "http://www.testing.fi"
-                }
-            ],
-            "language": [
-                {
-                    "title": {
-                        "en": "Finnish language",
-                        "fi": "Suomen kieli",
-                        "sv": "finska",
-                        "und": "Suomen kieli"
-                    },
-                    "identifier": "http://lexvo.org/id/iso639-3/fin"
-                },
-                {
-                    "title": {
-                        "en": "English language",
-                        "fi": "Englannin kieli",
-                        "sv": "engelska",
-                        "und": "Englannin kieli"
-                    },
-                    "identifier": "http://lexvo.org/id/iso639-3/eng"
-                }
-            ],
-            "modified": "2014-01-17T08:19:58Z",
-            "harvested": False,
-            "publisher": {
-                "name": {
-                    "en": "Data catalog publisher organization",
-                    "fi": "Datakatalogin julkaisijaorganisaatio"
-                },
-                "homepage": [
-                    {
-                        "title": {
-                            "en": "Publisher organization website",
-                            "fi": "Julkaisijaorganisaation kotisivu"
-                        },
-                        "identifier": "http://www.publisher.fi/"
-                    }
-                ],
-                "identifier": "http://isni.org/isni/0000000405129137"
-            },
-            "identifier": "urn:nbn:fi:att:2955e904-e3dd-4d7e-99f1-3fed446f96d2",
-            "access_rights": {
-                "license": [
-                    {
-                        "title": {
-                            "en": "Creative Commons Attribution 4.0 International (CC BY 4.0)",
-                            "fi": "Creative Commons Nimeä 4.0 Kansainvälinen (CC BY 4.0)",
-                            "und": "Creative Commons Nimeä 4.0 Kansainvälinen (CC BY 4.0)"
-                        },
-                        "license": "https://creativecommons.org/licenses/by/4.0/",
-                        "identifier": "http://uri.suomi.fi/codelist/fairdata/license/code/CC-BY-4.0"
-                    }
-                ],
-                "access_type": [
-                    {
-                        "identifier": "http://uri.suomi.fi/codelist/fairdata/access_type/code/open",
-                        "pref_label": {
-                            "en": "Open",
-                            "fi": "Avoin",
-                            "und": "Avoin"
-                        }
-                    }
-                ],
-                "description": {
-                    "fi": "Käyttöehtojen kuvaus"
-                },
-                "has_rights_related_agent": [
-                    {
-                        "name": {
-                            "en": "A rights related organization",
-                            "fi": "Oikeuksiin liittyvä organisaatio"
-                        },
-                        "identifier": "org_id"
-                    },
-                    {
-                        "name": {
-                            "und": "Aalto yliopisto"
-                        },
-                        "email": "wahatever@madeupdomain.com",
-                        "telephone": [
-                            "+12353495823424"
-                        ],
-                        "identifier": "http://uri.suomi.fi/codelist/fairdata/organization/code/10076"
-                    }
-                ]
-            },
-            "field_of_science": [
-                {
-                    "identifier": "http://www.yso.fi/onto/okm-tieteenala/ta1172",
-                    "pref_label": {
-                        "en": "Environmental sciences",
-                        "fi": "Ympäristötiede",
-                        "sv": "Miljövetenskap",
-                        "und": "Ympäristötiede"
-                    }
-                }
-            ],
-            "dataset_versioning": True,
-            "research_dataset_schema": "ida"
-        },
-        "catalog_record_group_edit": "default-record-edit-group",
-        "catalog_record_group_create": "default-record-create-group",
-        "date_modified": "2018-06-01T16:54:32+03:00",
-        "date_created": "2017-05-15T13:07:22+03:00",
-        "service_modified": "metax",
-        "service_created": "metax"
-    }
-
     @classmethod
     def setUpClass(cls):
         """
@@ -179,37 +49,6 @@ class OAIPMHReadTests(APITestCase, TestClassUtils):
         self.preferred_identifier = cr.preferred_identifier
         self._use_http_authorization()
 
-    def _get_new_test_cr_data(self, cr_index=0, dc_index=0, c_index=0):
-        catalog_record_from_test_data = self._get_object_from_test_data('catalogrecord', requested_index=cr_index)
-
-        catalog_record_from_test_data['research_dataset'].update({
-            "metadata_version_identifier": "urn:nbn:fi:att:ec55c1dd-668d-43ae-b51b-f6c56a5bd4d6",
-            "preferred_identifier": None,
-            "other_identifier": [
-                {
-                    "notation": "urn:nbn:fi:csc-kata:12345",
-                }
-            ],
-            "creator": [{
-                "@type": "Person",
-                "name": "Teppo Testaaja",
-                "member_of": {
-                    "@type": "Organization",
-                    "name": {"fi": "Mysterious Organization"}
-                }
-            }],
-            "curator": [{
-                "@type": "Person",
-                "name": "Default Owner",
-                "member_of": {
-                    "@type": "Organization",
-                    "name": {"fi": "Mysterious Organization"}
-                }
-            }]
-        })
-
-        return catalog_record_from_test_data
-
     def _get_results(self, data, xpath):
         root = data
         if isinstance(data, bytes):
@@ -220,9 +59,13 @@ class OAIPMHReadTests(APITestCase, TestClassUtils):
         results = self._get_results(data, xpath)
         return results[0]
 
+# VERB: Identity
+
     def test_identity(self):
         response = self.client.get('/oai/?verb=Identity')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+# VERB: ListMetadataFormats
 
     def test_list_metadata_formats(self):
         response = self.client.get('/oai/?verb=ListMetadataFormats')
@@ -239,12 +82,16 @@ class OAIPMHReadTests(APITestCase, TestClassUtils):
         metadataPrefix = self._get_results(formats, '//o:metadataPrefix[text() = "oai_dc_urnresolver"]')
         self.assertEqual(len(metadataPrefix), 1)
 
+# VERB: ListSets
+
     def test_list_sets(self):
         response = self.client.get('/oai/?verb=ListSets')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         sets = self._get_results(response.content, '//o:setSpec')
         # urnresolver set should be hidden
         self.assertEquals(len(sets), 4)
+
+# VERB: ListIdentifiers
 
     def test_list_identifiers(self):
         ms = settings.OAI['BATCH_SIZE']
@@ -254,6 +101,26 @@ class OAIPMHReadTests(APITestCase, TestClassUtils):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         headers = self._get_results(response.content, '//o:header')
         self.assertTrue(len(headers) == len(allRecords), len(headers))
+
+        response = self.client.get('/oai/?verb=ListIdentifiers&metadataPrefix=oai_datacite')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        headers = self._get_results(response.content, '//o:header')
+        self.assertTrue(len(headers) == len(allRecords), len(headers))
+
+        response = self.client.get('/oai/?verb=ListIdentifiers&metadataPrefix=oai_dc_urnresolver')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        headers = self._get_results(response.content, '//o:header')
+        self.assertTrue(len(headers) == len(allRecords), len(headers))
+
+    def test_list_identifiers_from_datacatalogs_set(self):
+        allRecords = DataCatalog.objects.all()[:settings.OAI['BATCH_SIZE']]
+
+        response = self.client.get('/oai/?verb=ListIdentifiers&metadataPrefix=oai_dc&set=datacatalogs')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        records = self._get_results(response.content, '//o:header')
+        self.assertTrue(len(records) == len(allRecords), len(records))
+
+# VERB: ListRecords
 
     def test_list_records(self):
         ms = settings.OAI['BATCH_SIZE']
@@ -265,7 +132,33 @@ class OAIPMHReadTests(APITestCase, TestClassUtils):
         records = self._get_results(response.content, '//o:record')
         self.assertTrue(len(records) == len(allRecords))
 
-    def test_metadataformat_for_urn_resolver(self):
+        response = self.client.get('/oai/?verb=ListRecords&metadataPrefix=oai_datacite')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        records = self._get_results(response.content, '//o:record')
+        self.assertTrue(len(records) == len(allRecords))
+
+        response = self.client.get('/oai/?verb=ListRecords&metadataPrefix=oai_dc_urnresolver')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        records = self._get_results(response.content, '//o:record')
+        self.assertTrue(len(records) == len(allRecords))
+
+    def test_list_records_urnresolver_from_datacatalogs_set(self):
+        response = self.client.get('/oai/?verb=ListRecords&metadataPrefix=oai_dc_urnresolver&set=datacatalogs')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        errors = self._get_results(response.content, '//o:error[@code="badArgument"]')
+        self.assertTrue(len(errors) == 1, response.content)
+
+        response = self.client.get('/oai/?verb=ListRecords&metadataPrefix=oai_dc_urnresolver&set=ida_datasets')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        errors = self._get_results(response.content, '//o:error[@code="badArgument"]')
+        self.assertTrue(len(errors) == 1, response.content)
+
+        response = self.client.get('/oai/?verb=ListRecords&metadataPrefix=oai_dc&set=invalid')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        errors = self._get_results(response.content, '//o:error[@code="badArgument"]')
+        self.assertTrue(len(errors) == 1, response.content)
+
+    def test_list_records_urnresolver_for_datasets_set(self):
         response = self.client.get('/oai/?verb=ListRecords&metadataPrefix=oai_dc_urnresolver&set=datasets')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         headers = self._get_results(response.content, '//o:header')
@@ -277,69 +170,20 @@ class OAIPMHReadTests(APITestCase, TestClassUtils):
             url_element = self._get_single_result(record_metadata, 'dc:identifier[starts-with(text(), "http")]')
             self.assertTrue(url_element is not None)
 
-    def test_get_record(self):
-        response = self.client.get(
-            '/oai/?verb=GetRecord&identifier=%s&metadataPrefix=oai_dc' % self.identifier)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        identifiers = self._get_results(response.content,
-            '//o:record/o:header/o:identifier[text()="%s"]' % self.identifier)
-        self.assertTrue(len(identifiers) == 1, response.content)
-
-    def test_get_record_non_existing(self):
-        response = self.client.get('/oai/?verb=GetRecord&identifier=urn:non:existing&metadataPrefix=oai_dc')
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        errors = self._get_results(response.content, '//o:error[@code="idDoesNotExist"]')
-        self.assertTrue(len(errors) == 1, response.content)
-
-    def test_get_using_invalid_metadata_prefix(self):
-        response = self.client.get('/oai/?verb=ListRecords&metadataPrefix=oai_notavailable')
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        errors = self._get_results(response.content, '//o:error[@code="cannotDisseminateFormat"]')
-        self.assertTrue(len(errors) == 1, response.content)
-
-        response = self.client.get(
-            '/oai/?verb=GetRecord&identifier=%s&metadataPrefix=oai_notavailable' % self.identifier)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        errors = self._get_results(response.content, '//o:error[@code="cannotDisseminateFormat"]')
-        self.assertTrue(len(errors) == 1, response.content)
-
-    def test_get_datacite_record(self):
-        response = self.client.get(
-            '/oai/?verb=GetRecord&identifier=%s&metadataPrefix=oai_datacite' % self.identifier)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        identifiers = self._get_results(response.content,
-                                        '//o:record/o:metadata/datacite:oai_datacite/' +
-                                        'datacite:schemaVersion[text()="%s"]' % '4.1')
-        self.assertTrue(len(identifiers) == 1, response.content)
-
-    def test_get_urnresolver_dataset_record(self):
-        response = self.client.get(
-            '/oai/?verb=GetRecord&identifier=%s&metadataPrefix=oai_dc_urnresolver' % self.identifier)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        identifiers = self._get_results(response.content,
-                                        '//o:record/o:metadata/oai_dc:dc/dc:identifier[text()="%s"]' %
-                                        self.preferred_identifier)
-        self.assertTrue(len(identifiers) == 1, response.content)
-
-    def test_legacy_catalog_datasets_are_not_urnresolved(self):
-        cr = CatalogRecord.objects.get(identifier=self.identifier)
-        cr.data_catalog.catalog_json['identifier'] = settings.LEGACY_CATALOGS[0]
-        cr.data_catalog.force_save()
-
-        response = self.client.get(
-            '/oai/?verb=GetRecord&identifier=%s&metadataPrefix=oai_dc_urnresolver&set=datasets' % self.identifier)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        identifiers = self._get_results(response.content,
-                                        '//o:record/o:metadata/oai_dc:dc/dc:identifier[text()="%s"]' %
-                                        self.preferred_identifier)
-        self.assertTrue(len(identifiers) == 0, response.content)
-
     def test_list_records_from_datasets_set(self):
         ms = settings.OAI['BATCH_SIZE']
         allRecords = CatalogRecord.objects.filter(
             data_catalog__catalog_json__identifier__in=MetaxOAIServer._get_default_set_filter())[:ms]
 
         response = self.client.get('/oai/?verb=ListRecords&metadataPrefix=oai_dc&set=datasets')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        records = self._get_results(response.content, '//o:record')
+        self.assertTrue(len(records) == len(allRecords), len(records))
+
+    def test_list_records_from_datacatalogs_set(self):
+        allRecords = DataCatalog.objects.all()[:settings.OAI['BATCH_SIZE']]
+
+        response = self.client.get('/oai/?verb=ListRecords&metadataPrefix=oai_dc&set=datacatalogs')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         records = self._get_results(response.content, '//o:record')
         self.assertTrue(len(records) == len(allRecords), len(records))
@@ -362,13 +206,17 @@ class OAIPMHReadTests(APITestCase, TestClassUtils):
         records = self._get_results(response.content, '//o:record')
         self.assertTrue(len(records) == len(allRecords))
 
-    def test_list_records_from_urnresolver_datasets_set(self):
-        allRecords = CatalogRecord.objects.all()[:settings.OAI['BATCH_SIZE']]
-
-        response = self.client.get('/oai/?verb=ListRecords&metadataPrefix=oai_dc_urnresolver&set=datasets')
+    def test_list_records_using_invalid_metadata_prefix(self):
+        response = self.client.get('/oai/?verb=ListRecords&metadataPrefix=oai_notavailable')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        records = self._get_results(response.content, '//o:record')
-        self.assertTrue(len(records) == len(allRecords), len(records))
+        errors = self._get_results(response.content, '//o:error[@code="cannotDisseminateFormat"]')
+        self.assertTrue(len(errors) == 1, response.content)
+
+        response = self.client.get(
+            '/oai/?verb=GetRecord&identifier=%s&metadataPrefix=oai_notavailable' % self.identifier)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        errors = self._get_results(response.content, '//o:error[@code="cannotDisseminateFormat"]')
+        self.assertTrue(len(errors) == 1, response.content)
 
     def test_distinct_records_in_set(self):
         att_resp = self.client.get('/oai/?verb=ListRecords&metadataPrefix=oai_dc&set=att_datasets')
@@ -384,11 +232,92 @@ class OAIPMHReadTests(APITestCase, TestClassUtils):
                                         '//o:record/o:header/o:identifier[text()="%s"]' % att_identifier)
         self.assertTrue(len(ida_records) == 0)
 
-    def test_get_records_from_invalid_set(self):
-        response = self.client.get('/oai/?verb=ListRecords&metadataPrefix=oai_dc&set=invalid')
+# VERB: GetRecord
+
+    def test_record_get_datacatalog(self):
+        dc = DataCatalog.objects.get(pk=1)
+        dc_identifier = dc.catalog_json['identifier']
+        response = self.client.get(
+            '/oai/?verb=GetRecord&identifier=%s&metadataPrefix=oai_dc' % dc_identifier)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        identifiers = self._get_results(response.content,
+                                        '//o:record/o:metadata/oai_dc:dc/dc:identifier[text()="%s"]' %
+                                        dc_identifier)
+        self.assertTrue(len(identifiers) == 1, response.content)
+
+    def test_get_record(self):
+        response = self.client.get(
+            '/oai/?verb=GetRecord&identifier=%s&metadataPrefix=oai_dc' % self.identifier)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        identifiers = self._get_results(response.content,
+            '//o:record/o:header/o:identifier[text()="%s"]' % self.identifier)
+        self.assertTrue(len(identifiers) == 1, response.content)
+
+        response = self.client.get(
+            '/oai/?verb=GetRecord&identifier=%s&metadataPrefix=oai_datacite' % self.identifier)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        identifiers = self._get_results(response.content,
+                                        '//o:record/o:metadata/datacite:oai_datacite/' +
+                                        'datacite:schemaVersion[text()="%s"]' % '4.1')
+        self.assertTrue(len(identifiers) == 1, response.content)
+        identifiers = self._get_results(response.content,
+                                        '//o:record/o:header/o:identifier[text()="%s"]' % self.identifier)
+        self.assertTrue(len(identifiers) == 1, response.content)
+
+        response = self.client.get(
+            '/oai/?verb=GetRecord&identifier=%s&metadataPrefix=oai_dc_urnresolver' % self.identifier)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        identifiers = self._get_results(response.content,
+                                        '//o:record/o:header/o:identifier[text()="%s"]' % self.identifier)
+        self.assertTrue(len(identifiers) == 1, response.content)
+
+    def test_get_record_non_existing(self):
+        response = self.client.get('/oai/?verb=GetRecord&identifier=urn:non:existing&metadataPrefix=oai_dc')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        errors = self._get_results(response.content, '//o:error[@code="idDoesNotExist"]')
+        self.assertTrue(len(errors) == 1, response.content)
+
+    def test_get_record_urnresolver(self):
+        response = self.client.get(
+            '/oai/?verb=GetRecord&identifier=%s&metadataPrefix=oai_dc_urnresolver' % self.identifier)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        identifiers = self._get_results(response.content,
+                                        '//o:record/o:metadata/oai_dc:dc/dc:identifier[text()="%s"]' %
+                                        self.preferred_identifier)
+        self.assertTrue(len(identifiers) == 1, response.content)
+
+    def test_get_record_datacatalog_unsupported_in_urnresolver(self):
+        dc = DataCatalog.objects.get(pk=1)
+        dc_identifier = dc.catalog_json['identifier']
+        response = self.client.get(
+            '/oai/?verb=GetRecord&identifier=%s&metadataPrefix=oai_dc_urnresolver' % dc_identifier)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         errors = self._get_results(response.content, '//o:error[@code="badArgument"]')
         self.assertTrue(len(errors) == 1, response.content)
+
+    def test_get_record_datacatalog_unsupported_in_datacite(self):
+        dc = DataCatalog.objects.get(pk=1)
+        dc_identifier = dc.catalog_json['identifier']
+        response = self.client.get(
+            '/oai/?verb=GetRecord&identifier=%s&metadataPrefix=oai_datacite' % dc_identifier)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        errors = self._get_results(response.content, '//o:error[@code="badArgument"]')
+        self.assertTrue(len(errors) == 1, response.content)
+
+    def test_get_record_legacy_catalog_datasets_are_not_urnresolved(self):
+        cr = CatalogRecord.objects.get(identifier=self.identifier)
+        cr.data_catalog.catalog_json['identifier'] = settings.LEGACY_CATALOGS[0]
+        cr.data_catalog.force_save()
+
+        response = self.client.get(
+            '/oai/?verb=GetRecord&identifier=%s&metadataPrefix=oai_dc_urnresolver&set=datasets' % self.identifier)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        identifiers = self._get_results(response.content,
+                                        '//o:record/o:metadata/oai_dc:dc/dc:identifier[text()="%s"]' %
+                                        self.preferred_identifier)
+        self.assertTrue(len(identifiers) == 0, response.content)
+
+# OAI-PMH Utilities & functionalities
 
     def test_write_oai_dc_with_lang(self):
         from metax_api.api.oaipmh.base.view import oai_dc_writer_with_lang
@@ -414,10 +343,10 @@ class OAIPMHReadTests(APITestCase, TestClassUtils):
         self.assertTrue('lang' in md['title'][0])
 
     def test_get_oai_dc_metadata_datacatalog(self):
-        cr = DataCatalog.objects.get(pk=1)
+        dc = DataCatalog.objects.get(pk=1)
         from metax_api.api.oaipmh.base.metax_oai_server import MetaxOAIServer
         s = MetaxOAIServer()
-        md = s._get_oai_dc_metadata(cr, self._datacatalog_record['catalog_json'])
+        md = s._get_oai_dc_metadata(dc, dc.catalog_json)
         self.assertTrue('identifier' in md)
         self.assertTrue('title' in md)
         self.assertTrue('lang' in md['title'][0])
@@ -452,54 +381,3 @@ class OAIPMHReadTests(APITestCase, TestClassUtils):
         response = self.client.get('/oai/?verb=GetRecord&identifier=%s&metadataPrefix=oai_datacite' % self.identifier)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         _check_fields(response.content)
-
-    def test_list_identifiers_from_datacatalogs_set(self):
-        allRecords = DataCatalog.objects.all()[:settings.OAI['BATCH_SIZE']]
-
-        response = self.client.get('/oai/?verb=ListIdentifiers&metadataPrefix=oai_dc&set=datacatalogs')
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        records = self._get_results(response.content, '//o:header')
-        self.assertTrue(len(records) == len(allRecords), len(records))
-
-    def test_list_records_from_datacatalogs_set(self):
-        allRecords = DataCatalog.objects.all()[:settings.OAI['BATCH_SIZE']]
-
-        response = self.client.get('/oai/?verb=ListRecords&metadataPrefix=oai_dc&set=datacatalogs')
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        records = self._get_results(response.content, '//o:record')
-        self.assertTrue(len(records) == len(allRecords), len(records))
-
-    def test_get_datacatalog_record(self):
-        dc = DataCatalog.objects.get(pk=1)
-        dc_identifier = dc.catalog_json['identifier']
-        response = self.client.get(
-            '/oai/?verb=GetRecord&identifier=%s&metadataPrefix=oai_dc' % dc_identifier)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        identifiers = self._get_results(response.content,
-                                        '//o:record/o:metadata/oai_dc:dc/dc:identifier[text()="%s"]' %
-                                        dc_identifier)
-        self.assertTrue(len(identifiers) == 1, response.content)
-
-    def test_get_datacatalog_record_unsupported_format_datacite(self):
-        dc = DataCatalog.objects.get(pk=1)
-        dc_identifier = dc.catalog_json['identifier']
-        response = self.client.get(
-            '/oai/?verb=GetRecord&identifier=%s&metadataPrefix=oai_datacite' % dc_identifier)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        errors = self._get_results(response.content, '//o:error[@code="badArgument"]')
-        self.assertTrue(len(errors) == 1, response.content)
-
-    def test_get_datacatalog_record_unsupported_format_urnresolver(self):
-        dc = DataCatalog.objects.get(pk=1)
-        dc_identifier = dc.catalog_json['identifier']
-        response = self.client.get(
-            '/oai/?verb=GetRecord&identifier=%s&metadataPrefix=oai_dc_urnresolver' % dc_identifier)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        errors = self._get_results(response.content, '//o:error[@code="badArgument"]')
-        self.assertTrue(len(errors) == 1, response.content)
-
-    def test_list_records_from_urnresolver_datacatalogs_set(self):
-        response = self.client.get('/oai/?verb=ListRecords&metadataPrefix=oai_dc_urnresolver&set=datacatalogs')
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        errors = self._get_results(response.content, '//o:error[@code="badArgument"]')
-        self.assertTrue(len(errors) == 1, response.content)


### PR DESCRIPTION
…ds in metax_oai_server to its own code vs. other metadataprefixes. Return data with cursor and batch size applied only after urnresolver records have been checked whether they should be included. Fix oai_dc and oai_datacite metadataprefixes.