### PR TITLE
CSCMETAX-524: structured logging

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,5 +27,6 @@ Sphinx==1.8.2  # custom license
 sphinx-autobuild==0.7.1 # MIT-license
 sphinx-rtd-theme==0.4.2 # MIT-license
 strict-rfc3339==0.7 # GPLv3
+structlog==18.2.0 # Apache 2.0-license, MIT
 simplejson==3.16.0  # MIT-license
 urllib3==1.24.1

--- a/src/metax_api/middleware/request_logging.py
+++ b/src/metax_api/middleware/request_logging.py
@@ -7,11 +7,17 @@
 
 from base64 import b64decode
 from json import loads as json_loads
+from time import time
 import logging
+import os
+
+from metax_api.utils import json_logger
 
 
 _logger = logging.getLogger('metax_api')
 
+
+SUCCESS_CODES = (200, 201, 204)
 
 """
 Log basic information about a request before and after the request is executed.
@@ -22,9 +28,28 @@ class RequestLogging():
 
     def __init__(self, get_response):
         self.get_response = get_response
+        self._pid = os.getpid()
 
     def __call__(self, request):
-        username = self.get_username(request)
+
+        start_time = time()
+
+        username, user_type = self.get_username(request)
+
+        try:
+            json_logger.info(
+                event='request_start',
+                query_string=request.environ['QUERY_STRING'],
+                url_path=request.environ['PATH_INFO'],
+                ip=request.environ['HTTP_X_REAL_IP'],
+                user_type=user_type,
+                username=username,
+                http_method=request.environ['REQUEST_METHOD'],
+                process_id=self._pid,
+            )
+        except:
+            _logger.exception('Exception during trying to json-log request start')
+
         try:
             _logger.info(
                 '%s - %s - "%s %s %s" %s'
@@ -56,6 +81,27 @@ class RequestLogging():
         except:
             _logger.exception('Exception during trying to log request end')
 
+        try:
+            request_info = {
+                'event': 'request_end',
+                'query_string': request.environ['QUERY_STRING'],
+                'url_path': request.environ['PATH_INFO'],
+                'ip': request.environ['HTTP_X_REAL_IP'],
+                'user_type': user_type,
+                'username': username,
+                'http_method': request.environ['REQUEST_METHOD'],
+                'http_status': response.status_code,
+                'process_id': self._pid,
+                'request_duration': float('%.3f' % (time() - start_time)),
+            }
+
+            if response.status_code not in SUCCESS_CODES and 'error_identifier' in response.data:
+                request_info['error_identifier'] = request.data['error_identifier']
+
+            json_logger.info(**request_info)
+        except:
+            _logger.exception('Exception during trying to json-log request end')
+
         return response
 
     def get_username(self, request):
@@ -63,16 +109,22 @@ class RequestLogging():
         Add more auth methods as necessary...
         """
         auth_header = request.environ.get('HTTP_AUTHORIZATION', None)
+        user = ''
+        user_type = 'guest'
+
         if not auth_header:
-            return ''
+            return user, user_type
+
         if 'Basic' in auth_header:
             try:
-                return b64decode(auth_header.split(' ')[1]).decode('utf-8').split(':')[0]
+                user_type = 'service'
+                user = b64decode(auth_header.split(' ')[1]).decode('utf-8').split(':')[0]
             except:
                 _logger.exception('Could not extract username from http auth header')
         elif 'Bearer' in auth_header or 'bearer' in auth_header:
             try:
-                return json_loads(b64decode(auth_header.split(' ')[1].split('.')[1] + '===').decode('utf-8'))['sub']
+                user_type = 'end_user'
+                user = json_loads(b64decode(auth_header.split(' ')[1].split('.')[1] + '===').decode('utf-8'))['sub']
             except:
                 # dont log as an error or crash, since we dont want to get bothered by
                 # errors about malformed tokens. auth middleware is going to reject this
@@ -80,4 +132,5 @@ class RequestLogging():
                 _logger.info('Faulty token: Could not extract username from bearer token')
         else:
             _logger.info('HTTP Auth method not basic or bearer - unable to get username')
-        return ''
+
+        return user, user_type

--- a/src/metax_api/services/statistic_service.py
+++ b/src/metax_api/services/statistic_service.py
@@ -62,11 +62,11 @@ class StatisticService():
         sql_args = []
 
         if from_date:
-            where_args.append('and date_created >= %s::date')
+            where_args.append('and cr.date_created >= %s::date')
             sql_args.append(from_date)
 
         if to_date:
-            where_args.append('and date_created <= %s::date')
+            where_args.append('and cr.date_created <= %s::date')
             sql_args.append(to_date)
 
         if access_type:

--- a/src/metax_api/settings.py
+++ b/src/metax_api/settings.py
@@ -21,6 +21,7 @@ import logging.config
 import os
 import time
 
+import structlog
 import yaml
 
 from metax_api.utils import executing_test_case, executing_travis
@@ -366,7 +367,7 @@ LOGGING = {
             'filename': '/var/log/metax-api/metax_api.log',
             'formatter': 'standard',
             'filters': ['require_debug_false'],
-        }
+        },
     },
     'loggers': {
         'django': {
@@ -374,13 +375,32 @@ LOGGING = {
         },
         'metax_api': {
             'handlers': ['general', 'console', 'debug'],
-        }
+        },
     }
 }
 
 logging.Formatter.converter = time.gmtime
 logger = logging.getLogger('metax_api')
 logger.setLevel(logging.DEBUG if DEBUG else logging.INFO)
+
+structlog.configure(
+    processors=[
+        structlog.stdlib.add_log_level,
+        structlog.processors.TimeStamper(fmt="iso"),
+        structlog.processors.JSONRenderer()
+    ],
+    context_class=dict,
+    logger_factory=structlog.stdlib.LoggerFactory(),
+    wrapper_class=structlog.stdlib.BoundLogger,
+    cache_logger_on_first_use=True,
+)
+
+handler = logging.FileHandler('/var/log/metax-api/metax_api.json.log')
+handler.setFormatter(logging.Formatter('%(message)s'))
+json_logger = logging.getLogger('structlog')
+json_logger.addHandler(handler)
+json_logger.setLevel(logging.INFO)
+
 
 # Internationalization
 # https://docs.djangoproject.com/en/1.11/topics/i18n/

--- a/src/metax_api/settings.py
+++ b/src/metax_api/settings.py
@@ -19,6 +19,7 @@ https://docs.djangoproject.com/en/1.11/ref/settings/
 
 import logging.config
 import os
+import time
 
 import yaml
 
@@ -333,7 +334,8 @@ LOGGING = {
     'formatters': {
         'standard': {
             # timestamp, process id, python module name, loglevel, msg content...
-            'format': '%(asctime)s p%(process)d %(name)s %(levelname)s: %(message)s'
+            'format': '%(asctime)s p%(process)d %(name)s %(levelname)s: %(message)s',
+            'datefmt': '%Y-%m-%dT%H:%M:%S.%03dZ',
         },
     },
     'filters': {
@@ -376,6 +378,7 @@ LOGGING = {
     }
 }
 
+logging.Formatter.converter = time.gmtime
 logger = logging.getLogger('metax_api')
 logger.setLevel(logging.DEBUG if DEBUG else logging.INFO)
 

--- a/src/metax_api/utils/utils.py
+++ b/src/metax_api/utils/utils.py
@@ -144,4 +144,21 @@ def leave_keys_in_dict(dict_obj, fields_to_leave):
             del dict_obj[key]
 
 
-json_logger = structlog.get_logger('structlog')
+if executing_test_case() or executing_travis():
+    class TestJsonLogger():
+
+        def info(self, *args, **kwargs):
+            pass
+
+        def error(self, *args, **kwargs):
+            pass
+
+        def warning(self, *args, **kwargs):
+            pass
+
+        def debug(self, *args, **kwargs):
+            pass
+
+    json_logger = TestJsonLogger()
+else:
+    json_logger = structlog.get_logger('structlog')

--- a/src/metax_api/utils/utils.py
+++ b/src/metax_api/utils/utils.py
@@ -13,6 +13,7 @@ from uuid import uuid4
 from dateutil import parser
 from django.conf import settings
 from django.utils import timezone
+import structlog
 
 
 class IdentifierType(Enum):
@@ -141,3 +142,6 @@ def leave_keys_in_dict(dict_obj, fields_to_leave):
     for key in list(dict_obj):
         if key not in fields_to_leave:
             del dict_obj[key]
+
+
+json_logger = structlog.get_logger('structlog')

--- a/src/metax_api/views/secure/secure_view.py
+++ b/src/metax_api/views/secure/secure_view.py
@@ -12,6 +12,8 @@ import json
 from django.shortcuts import render
 from django.views.generic import TemplateView
 
+from metax_api.utils import json_logger
+
 
 _logger = logging.getLogger(__name__)
 
@@ -39,6 +41,12 @@ class SecureLoginView(TemplateView):
                 break
         else:
             csc_account_linked = False
+
+        json_logger.info(
+            event='user_login_visit',
+            user_id=token_payload['sub'],
+            org=token_payload['schacHomeOrganization'],
+        )
 
         context = {
             'email': token_payload['email'],


### PR DESCRIPTION
Facilities to do json-logging in metax-app. Some initial logs to get into testing:

- http request start and end
- process start
- secure_view (login page)

metax-test should have related filebeat etc installed and configured, so safe to merge whenever.