### PR TITLE
CSCMETAX-529-530-541: [ADD|REF]

### DIFF
--- a/src/metax_api/middleware/request_logging.py
+++ b/src/metax_api/middleware/request_logging.py
@@ -99,7 +99,7 @@ class RequestLogging():
                 }
             }
 
-            if response.status_code not in SUCCESS_CODES and 'error_identifier' in response.data:
+            if response.status_code not in SUCCESS_CODES and response.data and 'error_identifier' in response.data:
                 request_info['error'] = { 'error_identifier': response.data['error_identifier'] }
 
             json_logger.info(**request_info)

--- a/src/metax_api/services/catalog_record_service.py
+++ b/src/metax_api/services/catalog_record_service.py
@@ -214,14 +214,17 @@ class CatalogRecordService(CommonService, ReferenceDataMixin):
                 del f['details']['identifier']
 
     @classmethod
-    def transform_datasets_to_format(cls, catalog_records, target_format, include_xml_declaration=True):
+    def transform_datasets_to_format(cls, catalog_records_json, target_format, include_xml_declaration=True):
         """
         params:
         catalog_records: a list of catalog record dicts, or a single dict
         """
-
         if target_format == 'datacite':
-            return DataciteService().convert_catalog_record_to_datacite_xml(catalog_records, include_xml_declaration)
+            return DataciteService().convert_catalog_record_to_datacite_xml(catalog_records_json,
+                                                                            include_xml_declaration, True)
+        elif target_format == 'fairdata_datacite':
+            return DataciteService().convert_catalog_record_to_datacite_xml(catalog_records_json,
+                                                                            include_xml_declaration, False)
 
         def item_func(parent_name):
             """
@@ -233,12 +236,12 @@ class CatalogRecordService(CommonService, ReferenceDataMixin):
                 'researchdatasets': 'researchdataset'
             }.get(parent_name, 'item')
 
-        if isinstance(catalog_records, dict):
+        if isinstance(catalog_records_json, dict):
             is_list = False
-            content_to_transform = catalog_records['research_dataset']
+            content_to_transform = catalog_records_json['research_dataset']
         else:
             is_list = True
-            content_to_transform = (cr['research_dataset'] for cr in catalog_records)
+            content_to_transform = (cr['research_dataset'] for cr in catalog_records_json)
 
         xml_str = dicttoxml(
             content_to_transform,

--- a/src/metax_api/services/datacite_service.py
+++ b/src/metax_api/services/datacite_service.py
@@ -12,13 +12,22 @@ import jsonschema
 from datacite import schema41 as datacite_schema41, DataCiteMDSClient
 from django.conf import settings as django_settings
 
-from metax_api.exceptions import Http400
-from metax_api.utils import extract_doi_from_doi_identifier, get_identifier_type, is_metax_generated_doi_identifier, \
-    IdentifierType, executing_travis, executing_test_case
+from metax_api.utils import extract_doi_from_doi_identifier, is_metax_generated_doi_identifier, executing_travis, \
+    executing_test_case, is_metax_generated_urn_identifier, datetime_to_str
 from .common_service import CommonService
 
 
 _logger = logging.getLogger(__name__)
+
+
+def convert_cr_to_datacite_cr_json(cr):
+    cr_json = {'research_dataset': cr.research_dataset}
+    if cr.date_created:
+        cr_json['date_created'] = datetime_to_str(cr.date_created)
+    if cr.preservation_identifier:
+        cr_json['preservation_identifier'] = cr.preservation_identifier
+
+    return cr_json
 
 
 def DataciteService(*args, **kwargs):
@@ -30,6 +39,10 @@ def DataciteService(*args, **kwargs):
         return _DataciteServiceDummy(*args, **kwargs)
     else:
         return _DataciteService(*args, **kwargs)
+
+
+class DataciteException(Exception):
+    pass
 
 
 class _DataciteService(CommonService):
@@ -108,34 +121,79 @@ class _DataciteService(CommonService):
         except:
             pass
 
-    def convert_catalog_record_to_datacite_xml(self, catalog_record, include_xml_declaration):
-        """
-        Convert dataset from metax dataset datamodel to datacite json datamodel, validate datacite json,
-        and convert to and return datacite xml as string.
+    def get_validated_datacite_json(self, cr_json, is_strict):
+        if isinstance(cr_json, list):
+            raise DataciteException('Datacite conversion can only be done to individual datasets, not lists.')
 
-        Currently only supports datacite version 4.1.
-        """
-        if isinstance(catalog_record, list):
-            raise Http400({ 'detail': ['datacite conversion can only be done to individual datasets, not lists.']})
+        if not cr_json or 'research_dataset' not in cr_json:
+            raise DataciteException("Catalog record containing research_dataset required to convert anything "
+                                    "to datacite format")
 
-        rd = catalog_record['research_dataset']
-        pref_id = rd['preferred_identifier']
+        rd = cr_json['research_dataset']
 
-        if 'language' in rd:
+        # Figure out main lang for the dataset, if applicable
+        if 'language' in rd and len(rd['language']) > 0:
             # used when trying to get most relevant name from langString when only one value is allowed.
             # note: language contains a three-letter language. we need a two-letter language, in order to
             # access the langString translations. this may not work as intended for some languages
-            main_lang = rd['language'][0]['identifier'].split('http://lexvo.org/id/iso639-3/')[1][:2]
+            lid = rd['language'][0]['identifier']
+            start_idx = lid.rindex('/') + 1
+            main_lang = lid[start_idx:start_idx + 2]
         else:
-            main_lang = 'fi'
+            main_lang = None
 
-        try:
+        # Identifier
+        pref_id = rd['preferred_identifier']
+        identifier = cr_json.get('preservation_identifier', None) or pref_id
+        is_metax_doi = is_metax_generated_doi_identifier(identifier)
+        is_metax_urn = is_metax_generated_urn_identifier(identifier)
+
+        if is_metax_doi:
+            identifier_value = extract_doi_from_doi_identifier(identifier)
+            identifier_type = 'DOI'
+        elif not is_strict and is_metax_urn:
+            identifier_value = identifier
+            identifier_type = 'URN'
+        else:
+            raise DataciteException('Dataset does not have a valid preferred identifier (field: '
+                                    'research_dataset.preferred_identifier), which should contain a Metax '
+                                    'generated DOI, which is a required value for datacite format')
+
+        # Creators
+        if rd.get('creator', False):
+            creators = self._creators(rd['creator'], main_lang=main_lang)
+        else:
+            raise DataciteException('Dataset does not have a creator (field: research_dataset.creator), which is a '
+                                    'required value for datacite format')
+
+        # Titles
+        if rd.get('title', False):
+            titles = [{'lang': lang, 'title': title} for lang, title in rd['title'].items()]
+        else:
+            raise DataciteException('Dataset does not have a title (field: research_dataset.title), which is '
+                                    'a required value for datacite format')
+
+        # Publisher
+        if rd.get('publisher', False):
             publisher = self._main_lang_or_default(rd['publisher']['name'], main_lang)
-        except:
+        elif is_strict:
+            raise DataciteException('Dataset does not have a publisher (field: research_dataset.publisher), which '
+                                    'is a required value for datacite format')
+        else:
             publisher = self._main_lang_or_default(rd['creator'][0]['name'], main_lang)
 
+        # Publication year
+        if rd.get('issued', False):
+            publication_year = rd['issued'][0:4]
+        elif is_strict:
+            raise DataciteException('Dataset does not have a date of issuance (field: research_dataset.issued), which '
+                                    'is a required value for datacite format')
+        else:
+            publication_year = cr_json['date_created'][0:4]
+
         """
-        here contains required fields only, as specified by datacite:
+        Required fields, as specified by datacite:
+
         identifier
         creators
         titles
@@ -144,48 +202,39 @@ class _DataciteService(CommonService):
         resourceType
         """
 
-        # 10.0/0 is a dummy value for catalog records that do not have a DOI identifier.
-        # This is done so because datacite xml won't validate unless there is some (any) DOI in identifier field
-        # Primarily use cr preservation_identifier. If it does not exist, use pref_id.
-        identifier = catalog_record.get('preservation_identifier', None) or pref_id
-        is_metax_doi = is_metax_generated_doi_identifier(identifier)
-        identifier_value = extract_doi_from_doi_identifier(identifier) if is_metax_doi else '10.0/0'
         datacite_json = {
             'identifier': {
-                # dummy-value until we start utilizing real DOI identifiers
                 'identifier': identifier_value,
-                'identifierType': 'DOI',
+                'identifierType': identifier_type
             },
-            'publicationYear': rd['modified'][0:4],
-            'creators': self._creators(rd['creator'], main_lang=main_lang),
-            'titles': [
-                { 'lang': lang, 'title': title } for lang, title in rd['title'].items()
-            ],
+            'creators': creators,
+            'titles': titles,
             'publisher': publisher,
+            'publicationYear': publication_year,
             'resourceType': {
-                'resourceTypeGeneral': self._resourceTypeGeneral(rd)
+                'resourceTypeGeneral': self._resource_type_general(rd)
             }
         }
 
-        # add optional fields
+        # Optional fields
 
-        if get_identifier_type(rd['preferred_identifier']) == IdentifierType.URN:
+        if is_metax_generated_urn_identifier(pref_id) and pref_id != identifier:
             datacite_json['alternateIdentifiers'] = [{
-                'alternateIdentifier': rd['preferred_identifier'],
+                'alternateIdentifier': pref_id,
                 'alternateIdentifierType': 'URN'
             }]
 
-        if 'issued' in rd or 'modified' in rd:
+        if 'modified' in rd or 'available' in rd.get('access_rights', {}):
             datacite_json['dates'] = []
-            if 'issued' in rd:
-                datacite_json['dates'].append({ 'dateType': 'Issued', 'date': rd['issued']})
             if 'modified' in rd:
-                datacite_json['dates'].append({ 'dateType': 'Updated', 'date': rd['modified']})
+                datacite_json['dates'].append({'dateType': 'Updated', 'date': rd['modified']})
+            if 'available' in rd.get('access_rights', {}):
+                datacite_json['dates'].append({'dateType': 'Available', 'date': rd['access_rights']['available']})
 
         if 'keyword' in rd or 'field_of_science' in rd or 'theme' in rd:
             datacite_json['subjects'] = []
             for kw in rd.get('keyword', []):
-                datacite_json['subjects'].append({ 'subject': kw })
+                datacite_json['subjects'].append({'subject': kw})
             for fos in rd.get('field_of_science', []):
                 datacite_json['subjects'].extend(self._subjects(fos))
             for theme in rd.get('theme', []):
@@ -194,17 +243,18 @@ class _DataciteService(CommonService):
         if 'total_ida_byte_size' in rd:
             datacite_json['sizes'] = [str(rd['total_ida_byte_size'])]
 
-        if 'description' in rd:
+        if rd.get('description', False):
             datacite_json['descriptions'] = [
-                { 'lang': lang, 'description': desc, 'descriptionType': 'Abstract' }
+                {'lang': lang, 'description': desc, 'descriptionType': 'Abstract'}
                 for lang, desc in rd['description'].items()
             ]
 
         if 'license' in rd['access_rights']:
             datacite_json['rightsList'] = self._licenses(rd['access_rights'])
 
-        if 'language' in rd:
-            datacite_json['language'] = rd['language'][0]['identifier'].split('http://lexvo.org/id/iso639-3/')[1]
+        if rd.get('language', False):
+            lid = rd['language'][0]['identifier']
+            datacite_json['language'] = lid[lid.rindex('/') + 1:]
 
         if 'curator' in rd or 'contributor' in rd or 'creator' in rd or 'rights_holder' in rd or 'publisher' in rd:
             datacite_json['contributors'] = []
@@ -221,17 +271,28 @@ class _DataciteService(CommonService):
         if 'spatial' in rd:
             datacite_json['geoLocations'] = self._spatials(rd['spatial'])
 
-        try:
-            jsonschema.validate(
-                datacite_json,
-                self.get_json_schema(join(dirname(dirname(__file__)), 'api/rest/base/schemas'), 'datacite_4.1')
-            )
-        except:
-            _logger.exception('Failed to validate metax dataset -> datacite conversion json')
-            raise
+        if is_strict:
+            try:
+                jsonschema.validate(
+                    datacite_json,
+                    self.get_json_schema(join(dirname(dirname(__file__)), 'api/rest/base/schemas'), 'datacite_4.1')
+                )
+            except Exception as e:
+                _logger.error("Failed to validate catalog record against datacite schema")
+                raise DataciteException(e)
+
+        return datacite_json
+
+    def convert_catalog_record_to_datacite_xml(self, cr_json, include_xml_declaration, is_strict):
+        """
+        Convert dataset from catalog record data model to datacite json data model. Validate the json against datacite
+        schema. On success, convert and return as XML. Raise exceptions on errors.
+
+        Currently only supports datacite version 4.1.
+        """
+        datacite_json = self.get_validated_datacite_json(cr_json, is_strict)
 
         # generate and return datacite xml
-
         output_xml = datacite_schema41.tostring(datacite_json)
         if not include_xml_declaration:
             # the +1 is linebreak character
@@ -256,7 +317,7 @@ class _DataciteService(CommonService):
             return field
 
     @staticmethod
-    def _resourceTypeGeneral(rd):
+    def _resource_type_general(rd):
         """
         Probably needs mapping from metax resource_type to dc resourceTypeGeneral...
         """
@@ -265,17 +326,12 @@ class _DataciteService(CommonService):
     def _creators(self, research_agents, main_lang):
         creators = []
         for ra in research_agents:
-
-            cr = { 'creatorName': self._main_lang_or_default(ra['name'], main_lang=main_lang) }
-
+            cr = {'creatorName': self._main_lang_or_default(ra['name'], main_lang=main_lang)}
             if 'identifier' in ra:
-                cr['nameIdentifiers'] = [{ 'nameIdentifier': ra['identifier'], 'nameIdentifierScheme': 'URI' }]
-
+                cr['nameIdentifiers'] = [{'nameIdentifier': ra['identifier'], 'nameIdentifierScheme': 'URI'}]
             if 'member_of' in ra:
                 cr['affiliations'] = self._person_affiliations(ra, main_lang)
-
             creators.append(cr)
-
         return creators
 
     def _contributors(self, research_agents, main_lang=None):

--- a/src/metax_api/tests/api/oaipmh/minimal_api.py
+++ b/src/metax_api/tests/api/oaipmh/minimal_api.py
@@ -74,7 +74,7 @@ class OAIPMHReadTests(APITestCase, TestClassUtils):
         response = self.client.get('/oai/?verb=ListMetadataFormats')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         formats = self._get_single_result(response.content, '//o:ListMetadataFormats')
-        self.assertEqual(len(formats), 3)
+        self.assertEqual(len(formats), 4)
 
         metadataPrefix = self._get_results(formats, '//o:metadataPrefix[text() = "oai_dc"]')
         self.assertEqual(len(metadataPrefix), 1)
@@ -135,7 +135,7 @@ class OAIPMHReadTests(APITestCase, TestClassUtils):
         records = self._get_results(response.content, '//o:record')
         self.assertTrue(len(records) == len(allRecords))
 
-        response = self.client.get('/oai/?verb=ListRecords&metadataPrefix=oai_datacite')
+        response = self.client.get('/oai/?verb=ListRecords&metadataPrefix=oai_fairdata_datacite')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         records = self._get_results(response.content, '//o:record')
         self.assertTrue(len(records) == len(allRecords))
@@ -257,10 +257,10 @@ class OAIPMHReadTests(APITestCase, TestClassUtils):
         self.assertTrue(len(identifiers) == 1, response.content)
 
         response = self.client.get(
-            '/oai/?verb=GetRecord&identifier=%s&metadataPrefix=oai_datacite' % self.identifier)
+            '/oai/?verb=GetRecord&identifier=%s&metadataPrefix=oai_fairdata_datacite' % self.identifier)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         identifiers = self._get_results(response.content,
-                                        '//o:record/o:metadata/datacite:oai_datacite/' +
+                                        '//o:record/o:metadata/datacite:oai_fairdata_datacite/' +
                                         'datacite:schemaVersion[text()="%s"]' % '4.1')
         self.assertTrue(len(identifiers) == 1, response.content)
         identifiers = self._get_results(response.content,

--- a/src/metax_api/tests/api/rest/base/views/datasets/read.py
+++ b/src/metax_api/tests/api/rest/base/views/datasets/read.py
@@ -590,7 +590,7 @@ class CatalogRecordApiReadXMLTransformationTests(CatalogRecordApiReadCommon):
 
     def test_read_dataset_xml_format_datacite(self):
         for id in CatalogRecord.objects.all().values_list('id', flat=True):
-            response = self.client.get('/rest/datasets/%d?dataset_format=datacite' % id)
+            response = self.client.get('/rest/datasets/%d?dataset_format=fairdata_datacite' % id)
             self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
             self._check_dataset_xml_format_response(response, '<resource')
 
@@ -610,6 +610,8 @@ class CatalogRecordApiReadXMLTransformationTests(CatalogRecordApiReadCommon):
         cr_json.pop('preservation_identifier', None)
         cr_json.pop('identifier')
         cr_json['research_dataset'].pop('preferred_identifier', None)
+        cr_json['research_dataset']['publisher'] = {'@type': 'Organization', 'name': {'und': 'Testaaja'}}
+        cr_json['research_dataset']['issued'] = '2010-01-01'
         cr_json['data_catalog'] = dc_id
         response = self.client.post('/rest/datasets?pid_type=doi', cr_json, format="json")
         self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.data)

--- a/src/metax_api/tests/api/rest/base/views/datasets/write.py
+++ b/src/metax_api/tests/api/rest/base/views/datasets/write.py
@@ -47,6 +47,9 @@ class CatalogRecordApiWriteCommon(APITestCase, TestClassUtils):
         slightly as approriate for different purposes
         """
         self.cr_test_data = self._get_new_test_cr_data()
+        self.cr_test_data['research_dataset']['publisher'] = {'@type': 'Organization', 'name': {'und': 'Testaaja'}}
+        self.cr_test_data['research_dataset']['issued'] = '2010-01-01'
+
         self.cr_att_test_data = self._get_new_test_cr_data(cr_index=14, dc_index=5)
         self.cr_test_data_new_identifier = self._get_new_test_cr_data_with_updated_identifier()
         self.cr_full_ida_test_data = self._get_new_full_test_ida_cr_data()

--- a/src/metax_api/utils/utils.py
+++ b/src/metax_api/utils/utils.py
@@ -107,6 +107,19 @@ def is_metax_generated_doi_identifier(identifier):
     return identifier.startswith('doi:{0}/'.format(settings.DATACITE.get('PREFIX')))
 
 
+def is_metax_generated_urn_identifier(identifier):
+    """
+    Check whether given identifier is a metax generated urn identifier
+
+    :param identifier:
+    :return: boolean
+    """
+    if not identifier:
+        return False
+
+    return identifier.startswith('urn:nbn:fi:att:') or identifier.startswith('urn:nbn:fi:csc')
+
+
 def generate_doi_identifier(doi_suffix=None):
     """
     Until a better mechanism for generating DOI suffix is conceived, use UUIDs.


### PR DESCRIPTION
- OAI Server and datasets REST API (using dataset_format parameter) now offer two datacite formats (OAI: oai_datacite, oai_fairdata_datacite / datasets REST: datacite, fairdata_datacite)
  - datacite is the strict version, which requires datacite required fields to be present and which is validated against datacite schema
  - fairdata-datacite is the less strict version, which allows urn as datacite identifier and uses fallback values on some required but missing datacite field values
- Datacite xml creation separated from datacite validation
  - This is done due to the fact that when doi creation is requested for a dataset, the dataset must adhere to the strict datacite schema - otherwise the datacite xml along with the doi could not be sent to Datacite API as it would fail the validation. So, catalog record needs to be validated against datacite schema before it can be created or updated
- Fix a bug in request_logging