### PR TITLE
CSCMETAX-535: [REF]

### DIFF
--- a/src/metax_api/renderers/renderers.py
+++ b/src/metax_api/renderers/renderers.py
@@ -19,6 +19,7 @@ class HTMLToJSONRenderer(renderers.JSONRenderer):
     """
 
     media_type = 'text/html'
+    charset = 'utf-8'
 
 
 class XMLRenderer(renderers.BaseRenderer):


### PR DESCRIPTION
- When debug is false and json is requested from api using Accept-header 'text/html' (e.g. browser), fix encoding of some characters.