### PR TITLE
CSCMETAX-559: [ADD] Simultaneously support two different main user id…

### DIFF
--- a/src/metax_api/middleware/identifyapicaller.py
+++ b/src/metax_api/middleware/identifyapicaller.py
@@ -184,7 +184,9 @@ class _IdentifyApiCaller():
             _logger.exception('Failed to extract token from id_token string')
             raise Http403
 
-        request.user.username = token['sub']
+        # todo temporary. eventually only CSCUsername will be supported
+        # (or make field configurable, but for now support both)
+        request.user.username = token.get('CSCUserName', token['sub'])
         request.user.is_service = False
         request.user.token = token
 

--- a/src/metax_api/services/auth_service.py
+++ b/src/metax_api/services/auth_service.py
@@ -29,15 +29,23 @@ class AuthService():
           to parameterize this part in settings.py in the future)
         - Third part is the actual project identifier, as it appears in file metadata
           field 'project_identifier'.
+
+        As a temporary solution, support also an alternative representation of group names,
+        where valid group names look like: IDA01:2001036. This kind of group names are to
+        be expected when the key CSCUserName is present in the authentication token.
+        Eventually, only this form of group names will be supported (and configurable... proabably).
         '''
         if not token:
             return set()
 
         user_projects = set()
 
-        for group in token.get('group_names', []):
-            group_name_parts = group.split(':')
-            if len(group_name_parts) == 3 and group_name_parts[0] == 'fairdata' and group_name_parts[1] == 'IDA01':
-                user_projects.add(group_name_parts[2])
+        project_prefix = 'IDA01:' if 'CSCUserName' in token else 'fairdata:IDA01:'
+
+        user_projects = set(
+            group.split(':')[-1]
+            for group in token.get('group_names', [])
+            if group.startswith(project_prefix)
+        )
 
         return user_projects

--- a/src/metax_api/templates/secure/auth_success_new.html
+++ b/src/metax_api/templates/secure/auth_success_new.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Metax End User Authentication</title>
+    </head>
+    <body style="width: 75%; word-wrap:break-word;">
+        <h1>Metax API Authentication Successful</h1>
+
+        <h2>Where have I arrived?</h2>
+        <p>
+            This page gives you an authentication token that you can use to interact directly with Metax API. For more information, visit Metax documentation about <a href="/docs/end_users.html">End User Access</a>.
+        </p>
+
+        <h3>You are logged in as:</h3>
+        <p>{{ email }}</p>
+
+        {% if idm_account_exists %}
+        <h3>Your token (id_token) is:</h3>
+        <p>{{ token_string }}</p>
+
+        <h3>Valid until:</h3>
+        <p>{{ token_valid_until }}</p>
+        {% else %}
+        <h3>How to get an API authentication token?</h3>
+        <p>
+            You currently do not have a CSC account. In order to get an authentication token and interact directly with the Metax API, register a CSC account and come back to this page.
+        </p>
+        {% endif %}
+
+    </body>
+</html>

--- a/src/metax_api/tests/api/rest/base/views/datasets/write.py
+++ b/src/metax_api/tests/api/rest/base/views/datasets/write.py
@@ -2955,3 +2955,199 @@ class CatalogRecordApiEndUserAccess(CatalogRecordApiWriteCommon):
         response = self.client.get('/rest/datasets/1')
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
         _check_fields(response.data)
+
+
+class CatalogRecordApiEndUserAccessV2(CatalogRecordApiEndUserAccess):
+
+    """
+    End User Access -related permission testing for new auth proxy.
+
+    These will eventually be removed. These are basically a bunch of
+    dull copypasted tests.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.token = get_test_oidc_token(new_proxy=True)
+        self._use_http_authorization(method='bearer', token=self.token)
+
+    def _set_cr_owner_to_token_user(self, cr_id):
+        cr = CatalogRecord.objects.get(pk=cr_id)
+        cr.user_created = self.token['CSCUserName']
+        cr.metadata_provider_user = self.token['CSCUserName']
+        cr.editor = None # pretend the record was created by user directly
+        cr.force_save()
+
+    @responses.activate
+    def test_user_can_create_dataset(self):
+        '''
+        Ensure end user can create a new dataset, and required fields are
+        automatically placed and the user is only able to affect allowed
+        fields
+        '''
+        user_created = self.token['CSCUserName']
+        metadata_provider_user = self.token['CSCUserName']
+        metadata_provider_org = self.token['schacHomeOrganization']
+        metadata_owner_org = self.token['schacHomeOrganization']
+
+        self.cr_test_data['data_catalog'] = END_USER_ALLOWED_DATA_CATALOGS[0] # ida
+        self.cr_test_data['contract'] = 1
+        self.cr_test_data['editor'] = { 'nope': 'discarded by metax' }
+        self.cr_test_data['preservation_description'] = 'discarded by metax'
+        self.cr_test_data['preservation_reason_description'] = 'discarded by metax'
+        self.cr_test_data['preservation_state'] = 10
+        self.cr_test_data.pop('metadata_provider_user', None)
+        self.cr_test_data.pop('metadata_provider_org', None)
+        self.cr_test_data.pop('metadata_owner_org', None)
+
+        # test file permission checking in another test
+        self.cr_test_data['research_dataset'].pop('files', None)
+        self.cr_test_data['research_dataset'].pop('directories', None)
+
+        response = self.client.post('/rest/datasets', self.cr_test_data, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.content)
+        self.assertEqual(response.data['user_created'], user_created)
+        self.assertEqual(response.data['metadata_provider_user'], metadata_provider_user)
+        self.assertEqual(response.data['metadata_provider_org'], metadata_provider_org)
+        self.assertEqual(response.data['metadata_owner_org'], metadata_owner_org)
+        self.assertEqual('contract' in response.data, False)
+        self.assertEqual('editor' in response.data, False)
+        self.assertEqual('preservation_description' in response.data, False)
+        self.assertEqual('preservation_reason_description' in response.data, False)
+        self.assertEqual(response.data['preservation_state'], 0)
+
+    @responses.activate
+    def test_owner_can_edit_dataset(self):
+        '''
+        Ensure end users are able to edit datasets owned by them.
+        Ensure end users can only edit permitted fields.
+        Note: File project permissions should not be checked, since files are not changed.
+        '''
+
+        # create test record
+        self.cr_test_data['data_catalog'] = END_USER_ALLOWED_DATA_CATALOGS[0]
+        self.cr_test_data['research_dataset'].pop('files', None) # test file permission checking in another test
+        self.cr_test_data['research_dataset'].pop('directories', None)
+        response = self.client.post('/rest/datasets', self.cr_test_data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.data)
+
+        modified_data = response.data
+        # research_dataset is the only permitted field to edit
+        modified_data['research_dataset']['value'] = 112233
+        modified_data['contract'] = 1
+        modified_data['editor'] = { 'nope': 'discarded by metax' }
+        modified_data['preservation_description'] = 'discarded by metax'
+        modified_data['preservation_reason_description'] = 'discarded by metax'
+        modified_data['preservation_state'] = 10
+
+        response = self.client.put('/rest/datasets/%d' % modified_data['id'], modified_data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
+        self.assertEqual(response.data['research_dataset']['value'], 112233) # value we set
+        self.assertEqual(response.data['user_modified'], self.token['CSCUserName']) # set by metax
+
+        # none of these should have been affected
+        self.assertEqual('contract' in response.data, False)
+        self.assertEqual('editor' in response.data, False)
+        self.assertEqual('preservation_description' in response.data, False)
+        self.assertEqual('preservation_reason_description' in response.data, False)
+        self.assertEqual(response.data['preservation_state'], 0)
+
+    @responses.activate
+    def test_owner_can_edit_datasets_only_in_permitted_catalogs(self):
+        '''
+        Ensure end users are able to edit datasets only in permitted catalogs, even if they
+        own the record (catalog may be disabled from end user editing for reason or another).
+        '''
+
+        # create test record
+        self.cr_test_data['data_catalog'] = 1
+        self.cr_test_data['user_created'] = self.token['CSCUserName']
+        self.cr_test_data['metadata_provider_user'] = self.token['CSCUserName']
+        self.cr_test_data.pop('editor', None)
+
+        self._use_http_authorization() # create cr as a service-user
+        response = self.client.post('/rest/datasets', self.cr_test_data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.data)
+
+        modified_data = response.data
+        modified_data['research_dataset']['value'] = 112233
+
+        self._use_http_authorization(method='bearer', token=self.token)
+        response = self.client.put('/rest/datasets/%d' % modified_data['id'], modified_data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN, response.data)
+
+    @responses.activate
+    def test_owner_can_edit_dataset_check_perms_from_editor_field(self):
+        '''
+        Ensure end user perms are also checked from the field 'editor', which may be
+        set by .e.g. qvain.
+        '''
+        self.cr_test_data['data_catalog'] = END_USER_ALLOWED_DATA_CATALOGS[0]
+        self.cr_test_data['user_created'] = 'editor field is checked before this field, so should be ok'
+        self.cr_test_data['editor'] = { 'owner_id': self.token['CSCUserName'] }
+
+        self._use_http_authorization() # create cr as a service-user to ensure editor-field is set
+        response = self.client.post('/rest/datasets', self.cr_test_data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.data)
+
+        response = self.client.get('/rest/datasets/%d' % response.data['id'], format="json")
+        modified_data = response.data
+        modified_data['research_dataset']['value'] = 112233
+        response = self.client.put('/rest/datasets/%d' % response.data['id'], modified_data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    @responses.activate
+    def test_user_file_permissions_are_checked_during_dataset_create(self):
+        '''
+        Ensure user's association with a project is checked during dataset create when
+        attaching files or directories to a dataset.
+        '''
+
+        # try creating without proper permisisons
+        self.cr_test_data['data_catalog'] = END_USER_ALLOWED_DATA_CATALOGS[0] # ida
+        response = self.client.post('/rest/datasets', self.cr_test_data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN, response.content)
+
+        # add project membership to user's token and try again
+        file_identifier = self.cr_test_data['research_dataset']['files'][0]['identifier']
+        project_identifier = File.objects.get(identifier=file_identifier).project_identifier
+        self.token['group_names'].append('IDA01:%s' % project_identifier)
+        self._use_http_authorization(method='bearer', token=self.token)
+
+        response = self.client.post('/rest/datasets', self.cr_test_data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.content)
+
+    @responses.activate
+    def test_user_file_permissions_are_checked_during_dataset_update(self):
+        '''
+        Ensure user's association with a project is checked during dataset update when
+        attaching files or directories to a dataset. The permissions should be checked
+        only for changed files (newly added, or removed).
+        '''
+        # get some files to add to another dataset
+        response = self.client.get('/rest/datasets/2', format="json")
+        new_files = response.data['research_dataset']['files']
+
+        # this is the dataset we'll modify
+        self._set_cr_owner_to_token_user(1)
+        self._set_cr_to_permitted_catalog(1)
+        response = self.client.get('/rest/datasets/1', format="json")
+        # ensure the files really are new
+        for f in new_files:
+            for existing_f in response.data['research_dataset']['files']:
+                assert f['identifier'] != existing_f['identifier'], 'test preparation failure, files should differ'
+        modified_data = response.data
+        modified_data['research_dataset']['files'].extend(new_files)
+
+        # should fail, since user's token has no permission for the newly added files
+        response = self.client.put('/rest/datasets/1', modified_data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN, response.content)
+
+        # add project membership to user's token and try again
+        project_identifier = File.objects.get(identifier=new_files[0]['identifier']).project_identifier
+        self.token['group_names'].append('IDA01:%s' % project_identifier)
+        self._use_http_authorization(method='bearer', token=self.token)
+
+        response = self.client.put('/rest/datasets/1', modified_data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.content)

--- a/src/metax_api/tests/utils.py
+++ b/src/metax_api/tests/utils.py
@@ -36,8 +36,8 @@ def get_json_schema(model_name):
     with open(path.dirname(path.realpath(__file__)) + '/../api/rest/base/schemas/%s_schema.json' % model_name) as f:
         return json_load(f)
 
-def get_test_oidc_token():
-    return {
+def get_test_oidc_token(new_proxy=False):
+    token = {
         "sub": "testuser123456@fairdataid",
         "linkedIds": [
             "testuser123456@fairdataid",
@@ -65,6 +65,12 @@ def get_test_oidc_token():
         "family_name": "Testaaja",
         "email": "teppo.testaaja@csc.fi"
     }
+
+    if new_proxy:
+        token["CSCUserName"] = "testuser"
+        token["CSCOrgNameFi"] = "IT Center for Science"
+
+    return token
 
 def generate_test_identifier(itype, index, urn=True):
     '''

--- a/src/metax_api/views/secure/secure_view.py
+++ b/src/metax_api/views/secure/secure_view.py
@@ -33,6 +33,12 @@ class SecureLoginView(TemplateView):
         token_payload = json.loads(request.META['HTTP_OIDC_ID_TOKEN_PAYLOAD'])
         _logger.debug(token_payload)
 
+        if 'CSCUserName' in token_payload:
+            return self._new_proxy(request, token_payload)
+        else:
+            return self._old_proxy(request, token_payload)
+
+    def _old_proxy(self, request, token_payload):
         linked_accounts = self._get_linked_accounts(token_payload)
 
         for acc in linked_accounts:
@@ -58,6 +64,26 @@ class SecureLoginView(TemplateView):
 
         # note: django automatically searches templates from root directory templates/
         return render(request, 'secure/auth_success.html', context=context)
+
+    def _new_proxy(self, request, token_payload):
+
+        json_logger.info(
+            event='user_login_visit',
+            user_id=token_payload['CSCUserName'],
+            org_id=token_payload.get('schacHomeOrganization', 'org_missing'),
+        )
+
+        idm_account_exists = len(token_payload.get('CSCUserName', '')) > 0
+
+        context = {
+            'email': token_payload['email'],
+            'idm_account_exists': idm_account_exists,
+            'token_string': request.META['HTTP_OIDC_ID_TOKEN'] if idm_account_exists else '',
+            'token_valid_until': datetime.fromtimestamp(token_payload['exp']).strftime('%Y-%m-%d %H:%M:%S'),
+        }
+
+        # note: django automatically searches templates from root directory templates/
+        return render(request, 'secure/auth_success_new.html', context=context)
 
     def _get_linked_accounts(self, token_payload):
         return [ acc for acc in token_payload.get('linkedIds', []) if not acc.endswith('@fairdataid') ]


### PR DESCRIPTION
… attributes and different file project prefixes

Eventually the alternate hacks will be removed. The main user id attribute and project name prefix should probably be made configurable in settings.py.

A different login page is done as well (/secure/ url).