### PR TITLE
CSCMETAX-61: [FIX] Rabbitmq publis method is called basic_publish sin…

### DIFF
--- a/src/metax_api/middleware/identifyapicaller.py
+++ b/src/metax_api/middleware/identifyapicaller.py
@@ -78,7 +78,7 @@ class _IdentifyApiCaller():
         Services, or other pre-defined api users.
         """
         with open('/home/metax-user/app_config') as app_config:
-            app_config_dict = yaml.load(app_config)
+            app_config_dict = yaml.load(app_config, Loader=yaml.FullLoader)
         try:
             return app_config_dict['API_USERS']
         except:

--- a/src/metax_api/services/rabbitmq_service.py
+++ b/src/metax_api/services/rabbitmq_service.py
@@ -85,7 +85,7 @@ class _RabbitMQService():
             for message in messages:
                 if isinstance(message, dict):
                     message = json_dumps(message)
-                self._channel.publish(body=message, routing_key=routing_key, exchange=exchange, **additional_args)
+                self._channel.basic_publish(body=message, routing_key=routing_key, exchange=exchange, **additional_args)
         except Exception as e:
             _logger.error(e)
             _logger.error("Unable to publish message to RabbitMQ")

--- a/src/metax_api/settings.py
+++ b/src/metax_api/settings.py
@@ -31,7 +31,7 @@ executing_in_test_case = executing_test_case()
 
 if not executing_in_travis:
     with open('/home/metax-user/app_config') as app_config:
-        app_config_dict = yaml.load(app_config)
+        app_config_dict = yaml.load(app_config, Loader=yaml.FullLoader)
 
     if 'METAX_ENV' in app_config_dict:
         METAX_ENV = app_config_dict['METAX_ENV']


### PR DESCRIPTION
…ce pika 1.0.0. Define loaded in yaml.load() since default is getting deprecated