### PR TITLE
CSCMETAX-552: [ADD] Make API permissions more fine grained, by adding…

### DIFF
--- a/docs/source/files.rst
+++ b/docs/source/files.rst
@@ -11,7 +11,7 @@ The ``/rest/files`` API supports creating, retrieving, updating, and deleting fi
 
 Write-operations to the ``/rest/files`` API is generally limited only to Fairdata services. In practice, new file metadata only appears to Metax as a result of freezing files in the Fairdata IDA service.
 
-End users will only be able to browse file metadata of projects where they are a member. Details about browsing files using the Metax API can be found later in this document :ref:`here <rst-browsing-files>`, and in swagger.
+End users will only be able to browse file metadata of projects where they are a member, end edit a limited set of metadata fields. Details about browsing files using the Metax API can be found later in this document :ref:`here <rst-browsing-files>`, and in swagger.
 
 
 
@@ -28,6 +28,15 @@ File hierarchy
 ---------------
 
 When sending a list of files to ``POST /rest/files``, a file/directory hierarchy is automatically created based on the file paths, and files are assigned to their parent directories. When retrieving a file (or a directory), its parent directory information is stored in the field ``parent_directory``.
+
+
+
+End User Editable File Fields
+------------------------------
+
+End Users may edit the following file metadata fields using the API:
+
+* ``file_characteristics``
 
 
 

--- a/src/metax_api/permissions/permissions.py
+++ b/src/metax_api/permissions/permissions.py
@@ -15,8 +15,16 @@ from metax_api.exceptions import Http400
 
 
 _logger = logging.getLogger(__name__)
-READ_METHODS = ('GET', 'HEAD', 'OPTIONS')
-WRITE_METHODS = ('POST', 'PUT', 'PATCH', 'DELETE')
+
+METHOD_MAP = {
+    'GET':     'read',
+    'HEAD':    'read',
+    'OPTIONS': 'read',
+    'POST':    'create',
+    'PUT':     'update',
+    'PATCH':   'update',
+    'DELETE':  'delete',
+}
 
 
 class MetaxAPIPermissions(BasePermission):
@@ -46,7 +54,9 @@ class MetaxAPIPermissions(BasePermission):
         {
             'datasets': {
                 'read': ['service1', 'service2'],
-                'write': ['service1', 'service3']
+                'create': ['service1', 'service3'],
+                'update': ['service1', 'service3', 'endusers'],
+                'delete': ['service1'],
             }
             'files': {
                 ...
@@ -82,31 +92,9 @@ class MetaxAPIPermissions(BasePermission):
             )
             has_perm = False
         elif api_type == 'rest':
-            if request.method in READ_METHODS:
-                if 'all' in self.perms[api_type][api_name]['read']:
-                    has_perm = True
-                else:
-                    has_perm = self._check_read_perms(request, api_type, api_name)
-            elif request.method in WRITE_METHODS:
-                if 'all' in self.perms[api_type][api_name]['write']:
-                    has_perm = True
-                else:
-                    has_perm = self._check_write_perms(request, api_type, api_name)
-            else:
-                raise MethodNotAllowed
+            has_perm = self._check_rest_perms(request, api_name)
         elif api_type == 'rpc':
-            rpc_method_name = request.path.split('/')[-1]
-            if rpc_method_name not in self.perms[api_type][api_name]:
-                raise Http400({
-                    'detail': [
-                        'Unknown RPC method: %s. Valid %s RPC methods are: %s'
-                        % (rpc_method_name, api_name, ', '.join(self.perms[api_type][api_name].keys()))
-                    ]
-                })
-            elif 'all' in self.perms[api_type][api_name][rpc_method_name]['use']:
-                has_perm = True
-            else:
-                has_perm = self._check_use_perms(request, api_type, api_name, rpc_method_name)
+            has_perm = self._check_rpc_perms(request, api_name)
         else:
             _logger.info('Unknown api %s' % request.path)
             raise NotImplementedError
@@ -115,6 +103,45 @@ class MetaxAPIPermissions(BasePermission):
             'user %s has_perm for api %s == %r'
             % (request.user.username or '(anonymous)', request.path, has_perm)
         )
+
+        return has_perm
+
+    def _check_rest_perms(self, request, api_name):
+        """
+        Check if user (service user) or user type (endusers) has permission to
+        execute specific operation type on given API endpoint.
+        """
+        if request.method in METHOD_MAP:
+
+            operation_type = METHOD_MAP[request.method]
+
+            if 'all' in self.perms['rest'][api_name].get(operation_type, []):
+                has_perm = True
+            else:
+                has_perm = self._check_user_rest_perms(request, api_name, operation_type)
+        else:
+            raise MethodNotAllowed
+
+        return has_perm
+
+    def _check_rpc_perms(self, request, api_name, rpc_method_name):
+        """
+        Check if user (service user) or user type (endusers) has permission to
+        use given RPC method.
+        """
+        rpc_method_name = request.path.split('/')[-1]
+
+        if rpc_method_name not in self.perms['rpc'][api_name]:
+            raise Http400({
+                'detail': [
+                    'Unknown RPC method: %s. Valid %s RPC methods are: %s'
+                    % (rpc_method_name, api_name, ', '.join(self.perms['rpc'][api_name].keys()))
+                ]
+            })
+        elif 'all' in self.perms['rpc'][api_name][rpc_method_name]['use']:
+            has_perm = True
+        else:
+            has_perm = self._check_user_rpc_perms(request, api_name, rpc_method_name)
 
         return has_perm
 
@@ -131,14 +158,11 @@ class EndUserPermissions(MetaxAPIPermissions):
     service_permission = False
     message = 'End Users are not allowed to access this api.'
 
-    def _check_read_perms(self, request, api_type, api_name):
-        return 'endusers' in self.perms[api_type][api_name]['read']
+    def _check_user_rest_perms(self, request, api_name, operation_type):
+        return 'endusers' in self.perms['rest'][api_name].get(operation_type, [])
 
-    def _check_write_perms(self, request, api_type, api_name):
-        return 'endusers' in self.perms[api_type][api_name]['write']
-
-    def _check_use_perms(self, request, api_type, api_name, rpc_method_name):
-        return 'endusers' in self.perms[api_type][api_name][rpc_method_name]['use']
+    def _check_user_rpc_perms(self, request, api_name, rpc_method_name):
+        return 'endusers' in self.perms['rpc'][api_name][rpc_method_name]['use']
 
     def has_object_permission(self, request, view, obj):
         """
@@ -166,14 +190,11 @@ class ServicePermissions(MetaxAPIPermissions):
             self.message = self.message % request.user.username
         return has_perm
 
-    def _check_read_perms(self, request, api_type, api_name):
-        return request.user.username in self.perms[api_type][api_name]['read']
+    def _check_user_rest_perms(self, request, api_name, operation_type):
+        return request.user.username in self.perms['rest'][api_name].get(operation_type, [])
 
-    def _check_write_perms(self, request, api_type, api_name):
-        return request.user.username in self.perms[api_type][api_name]['write']
-
-    def _check_use_perms(self, request, api_type, api_name, rpc_method_name):
-        return request.user.username in self.perms[api_type][api_name][rpc_method_name]['use']
+    def _check_user_rpc_perms(self, request, api_name, rpc_method_name):
+        return request.user.username in self.perms['rpc'][api_name][rpc_method_name]['use']
 
     def has_object_permission(self, request, view, obj):
         """

--- a/src/metax_api/settings.py
+++ b/src/metax_api/settings.py
@@ -62,7 +62,7 @@ if executing_in_test_case or executing_in_travis:
     }
     API_AUTH_TEST_USER = {
         'username': 'api_auth_user',
-        'password': 'assword'
+        'password': 'password'
     }
 
     API_TEST_USERS = [
@@ -75,35 +75,45 @@ if executing_in_test_case or executing_in_travis:
         "rest": {
             "apierrors":    {
                 "read": ["testuser", "metax"],
-                "write": ["testuser", "metax"]
+                "create": ["testuser", "metax"],
+                "update": ["testuser", "metax"],
+                "delete": ["testuser", "metax"]
             },
             "contracts":    {
                 "read": ["testuser", "metax"],
-                "write": ["testuser", "metax"]
+                "create": ["testuser", "metax"],
+                "update": ["testuser", "metax"],
+                "delete": ["testuser", "metax"]
             },
             "datacatalogs": {
                 "read": ["all"],
-                "write": ["testuser", "metax"]
+                "create": ["testuser", "metax"],
+                "update": ["testuser", "metax"],
+                "delete": ["testuser", "metax"]
             },
             "datasets":     {
                 "read": ["all"],
-                "write": ["testuser", "metax", "api_auth_user", "endusers"]
+                "create": ["testuser", "metax", "api_auth_user", "endusers"],
+                "update": ["testuser", "metax", "api_auth_user", "endusers"],
+                "delete": ["testuser", "metax", "api_auth_user", "endusers"]
             },
             "directories":  {
                 "read": ["testuser", "metax", "endusers"],
-                "write": ["testuser", "metax"]
             },
             "files":        {
                 "read": ["testuser", "metax", "api_auth_user", "endusers"],
-                "write": ["testuser", "metax"]
+                "create": ["testuser", "metax"],
+                "update": ["testuser", "metax", "endusers"],
+                "delete": ["testuser", "metax"]
             },
             "filestorages": {
                 "read": ["testuser", "metax"],
-                "write": ["testuser", "metax"]
+                "create": ["testuser", "metax"],
+                "update": ["testuser", "metax"],
+                "delete": ["testuser", "metax"]
             },
             "schemas":      {
                 "read": ["all"],
-                "write": ["testuser", "metax"]
             }
         },
         "rpc": {
@@ -122,10 +132,10 @@ elif METAX_ENV == 'test':
     API_ACCESS = app_config_dict['API_ACCESS']
 
     for api, perms in API_ACCESS['rest'].items():
-        if 'all' not in perms['read']:
-            perms['read'].append('all')
-        if 'all' not in perms['write']:
-            perms['write'].append('all')
+        perms['read'] = ['all']
+        perms['create'] = ['all']
+        perms['update'] = ['all']
+        perms['delete'] = ['all']
 else:
     # localdev, stable, production
     API_ACCESS = app_config_dict['API_ACCESS']

--- a/src/metax_api/tests/api/rest/base/views/files/write.py
+++ b/src/metax_api/tests/api/rest/base/views/files/write.py
@@ -1119,19 +1119,58 @@ class FileApiWriteEndUserAccess(FileApiWriteCommon):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     @responses.activate
-    def test_user_cant_update_files(self):
+    def test_user_can_only_update_permitted_file_fields(self):
         '''
-        Ensure users are unable to modify existing files.
+        Ensure users are only able to modify permitted fields.
         '''
-
         # ensure user belongs to same project
         proj = File.objects.get(pk=1).project_identifier
         self.token['group_names'].append('fairdata:IDA01:%s' % proj)
         self._use_http_authorization(method='bearer', token=self.token)
 
         response = self.client.get('/rest/files/1', format="json")
-        response = self.client.put('/rest/files/1', response.data, format="json")
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN, response.data)
+        file = response.data
+        original_file = deepcopy(file)
+        file['byte_size'] = 200
+        file['checksum']['value'] = 'changed'
+        file['parent_directory'] = 1
+        file['file_frozen'] = '3' + file['file_frozen'][1:]
+        file['file_format'] = 'changed'
+        file['file_name'] = 'changed'
+        file['file_path'] = '/oh/no'
+        file['file_storage'] = 2
+        file['file_uploaded'] = '3' + file['file_uploaded'][1:]
+        file['identifier'] = 'changed'
+        file['open_access'] = True
+        file['project_identifier'] = 'changed'
+        file['service_modified'] = 'changed'
+        file['service_created'] = 'changed'
+        file['removed'] = True
+
+        # the only field that should be changed
+        file['file_characteristics'] = { 'title': 'new title'}
+
+        response = self.client.put('/rest/files/1', file, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
+        self.assertEqual(response.data['file_characteristics']['title'], 'new title', response.data)
+
+        for key, value in response.data.items():
+            try:
+                if key in ('date_modified', 'file_modified'):
+                    # these fields are changed by metax
+                    continue
+                elif key == 'file_characteristics':
+                    # the field that should have been changed by the user
+                    self.assertNotEqual(original_file[key], response.data[key])
+                else:
+                    # must not have changed
+                    self.assertEqual(original_file[key], response.data[key])
+            except KeyError as e:
+                if e.args[0] == 'user_modified':
+                    # added by metax
+                    continue
+                raise
+
 
 class FileApiWriteDryrunTest(FileApiWriteCommon):
 


### PR DESCRIPTION
… read, create, update, delete permissions per service or user group (end users), instead of only read or write