### PR TITLE
CSCMETAX-584: [ADD] Support for licenses outside reference data

### DIFF
--- a/src/metax_api/api/rest/base/schemas/att_dataset_schema.json
+++ b/src/metax_api/api/rest/base/schemas/att_dataset_schema.json
@@ -991,8 +991,11 @@
                     "format":"uri"
                 }
             },
-            "required":[
-                "identifier"
+            "anyOf":[
+                {"required":
+                  ["identifier"]},
+                {"required":
+                  ["license"]}
             ],
             "additionalProperties": false
         },

--- a/src/metax_api/api/rest/base/schemas/ida_dataset_schema.json
+++ b/src/metax_api/api/rest/base/schemas/ida_dataset_schema.json
@@ -1015,8 +1015,11 @@
                     "format":"uri"
                 }
             },
-            "required":[
-                "identifier"
+            "anyOf":[
+                {"required":
+                  ["identifier"]},
+                {"required":
+                  ["license"]}
             ],
             "additionalProperties": false
         },

--- a/src/metax_api/tests/api/rest/base/views/datasets/write.py
+++ b/src/metax_api/tests/api/rest/base/views/datasets/write.py
@@ -1019,6 +1019,37 @@ class CatalogRecordApiWriteReferenceDataTests(CatalogRecordApiWriteCommon):
         response = self.client.post('/rest/datasets', self.cr_test_data, format="json")
         self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.data)
 
+    def test_missing_license_identifier_ok(self):
+        """
+        Missing license identifier is ok if url is provided.
+        Works on att and ida datasets
+        """
+        rd_ida = self.cr_full_ida_test_data['research_dataset']
+        rd_ida['access_rights']['license'] = [{
+            'license': "http://a.very.nice.custom/url"
+        }]
+        response = self.client.post('/rest/datasets', self.cr_full_ida_test_data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.data)
+        self.assertEqual(len(response.data['research_dataset']['access_rights']['license'][0]), 1, response.data)
+
+        rd_att = self.cr_full_att_test_data['research_dataset']
+        rd_att['access_rights']['license'] = [{
+            'license': "http://also.fine.custom/uri",
+            'description': {
+                'en': "This is very informative description of this custom license."
+            }
+        }]
+        rd_att['remote_resources'][0]['license'] = [{
+            'license': "http://cool.remote.uri",
+            'description': {
+                'en': "Proof that also remote licenses can be used with custom urls."
+            }
+        }]
+        response = self.client.post('/rest/datasets', self.cr_full_att_test_data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.data)
+        self.assertEqual(len(response.data['research_dataset']['access_rights']['license'][0]), 2, response.data)
+        self.assertEqual(len(response.data['research_dataset']['remote_resources'][0]['license'][0]), 2, response.data)
+
     def test_create_catalog_record_with_invalid_reference_data(self):
         rd_ida = self.cr_full_ida_test_data['research_dataset']
         rd_ida['theme'][0]['identifier'] = 'nonexisting'


### PR DESCRIPTION
Licenses can be outside reference data for att and ida datasets but
either license identifier or url must be provided. Custom url can also
be provided when using identifier.