### PR TITLE
CSCFAIRMETA-263: [ADD] New query parameter 'dummy_doi=bool' to be use…

### DIFF
--- a/src/metax_api/api/rest/base/views/dataset_view.py
+++ b/src/metax_api/api/rest/base/views/dataset_view.py
@@ -56,7 +56,8 @@ class DatasetViewSet(CommonViewSet):
 
         if 'dataset_format' in request.query_params:
             try:
-                res.data = CRS.transform_datasets_to_format(res.data, request.query_params['dataset_format'])
+                res.data = CRS.transform_datasets_to_format(
+                    res.data, request.query_params['dataset_format'], request=request)
             except DataciteException as e:
                 raise Http400(str(e))
             request.accepted_renderer = XMLRenderer()

--- a/src/metax_api/services/catalog_record_service.py
+++ b/src/metax_api/services/catalog_record_service.py
@@ -292,17 +292,22 @@ class CatalogRecordService(CommonService, ReferenceDataMixin):
                 del f['details']['identifier']
 
     @classmethod
-    def transform_datasets_to_format(cls, catalog_records_json, target_format, include_xml_declaration=True):
+    def transform_datasets_to_format(cls, catalog_records_json, target_format,
+            include_xml_declaration=True, request=None):
         """
         params:
         catalog_records: a list of catalog record dicts, or a single dict
         """
-        if target_format == 'datacite':
-            return DataciteService().convert_catalog_record_to_datacite_xml(catalog_records_json,
-                                                                            include_xml_declaration, True)
-        elif target_format == 'fairdata_datacite':
-            return DataciteService().convert_catalog_record_to_datacite_xml(catalog_records_json,
-                                                                            include_xml_declaration, False)
+        if target_format in ('datacite', 'fairdata_datacite'):
+
+            is_strict = target_format == 'datacite'
+            dummy_doi = False
+
+            if request:
+                dummy_doi = CommonService.get_boolean_query_param(request, 'dummy_doi')
+
+            return DataciteService().convert_catalog_record_to_datacite_xml(
+                catalog_records_json, include_xml_declaration, is_strict, dummy_doi=dummy_doi)
 
         def _preprocess_list(key, value):
             """

--- a/src/metax_api/services/datacite_service.py
+++ b/src/metax_api/services/datacite_service.py
@@ -126,7 +126,7 @@ class _DataciteService(CommonService):
             _logger.warning('Could not delete doi in draft state')
             _logger.warning(e)
 
-    def get_validated_datacite_json(self, cr_json, is_strict):
+    def get_validated_datacite_json(self, cr_json, is_strict, dummy_doi=False):
         if isinstance(cr_json, list):
             raise DataciteException('Datacite conversion can only be done to individual datasets, not lists.')
 
@@ -187,6 +187,9 @@ class _DataciteService(CommonService):
 
         if is_metax_doi:
             identifier_value = extract_doi_from_doi_identifier(identifier)
+            identifier_type = 'DOI'
+        elif dummy_doi:
+            identifier_value = '10.0/%s' % identifier
             identifier_type = 'DOI'
         elif not is_strict and is_metax_urn:
             identifier_value = identifier
@@ -288,14 +291,14 @@ class _DataciteService(CommonService):
 
         return datacite_json
 
-    def convert_catalog_record_to_datacite_xml(self, cr_json, include_xml_declaration, is_strict):
+    def convert_catalog_record_to_datacite_xml(self, cr_json, include_xml_declaration, is_strict, dummy_doi=False):
         """
         Convert dataset from catalog record data model to datacite json data model. Validate the json against datacite
         schema. On success, convert and return as XML. Raise exceptions on errors.
 
         Currently only supports datacite version 4.1.
         """
-        datacite_json = self.get_validated_datacite_json(cr_json, is_strict)
+        datacite_json = self.get_validated_datacite_json(cr_json, is_strict, dummy_doi=dummy_doi)
 
         # generate and return datacite xml
         output_xml = datacite_schema41.tostring(datacite_json)

--- a/src/metax_api/tests/api/rest/base/views/datasets/read.py
+++ b/src/metax_api/tests/api/rest/base/views/datasets/read.py
@@ -693,25 +693,12 @@ class CatalogRecordApiReadQueryParamsTests(CatalogRecordApiReadCommon):
 
 
 class CatalogRecordApiReadXMLTransformationTests(CatalogRecordApiReadCommon):
+
     """
     dataset xml transformations
     """
 
-    def test_read_dataset_xml_format_metax(self):
-        response = self.client.get('/rest/datasets/1?dataset_format=metax')
-        self._check_dataset_xml_format_response(response, '<researchdataset')
-
-    def test_read_dataset_xml_format_datacite(self):
-        for id in CatalogRecord.objects.all().values_list('id', flat=True):
-            response = self.client.get('/rest/datasets/%d?dataset_format=fairdata_datacite' % id)
-            self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
-            self._check_dataset_xml_format_response(response, '<resource')
-
-    def test_read_dataset_xml_format_error_unknown_format(self):
-        response = self.client.get('/rest/datasets/1?dataset_format=doesnotexist')
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-
-    def test_read_datacite_xml_format_identifier(self):
+    def _create_dataset_with_doi(self):
         # Create ida data catalog
         dc = self._get_object_from_test_data('datacatalog', requested_index=0)
         dc_id = settings.IDA_DATA_CATALOG_IDENTIFIER
@@ -728,10 +715,28 @@ class CatalogRecordApiReadXMLTransformationTests(CatalogRecordApiReadCommon):
         cr_json['data_catalog'] = dc_id
         response = self.client.post('/rest/datasets?pid_type=doi', cr_json, format="json")
         self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.data)
-        doi = response.data['preservation_identifier']
+        return response.data
+
+    def test_read_dataset_xml_format_metax(self):
+        response = self.client.get('/rest/datasets/1?dataset_format=metax')
+        self._check_dataset_xml_format_response(response, '<researchdataset')
+
+    def test_read_dataset_xml_format_datacite(self):
+        for id in CatalogRecord.objects.all().values_list('id', flat=True):
+            response = self.client.get('/rest/datasets/%d?dataset_format=fairdata_datacite' % id)
+            self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
+            self._check_dataset_xml_format_response(response, '<resource')
+
+    def test_read_dataset_xml_format_error_unknown_format(self):
+        response = self.client.get('/rest/datasets/1?dataset_format=doesnotexist')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_read_datacite_xml_format_identifier(self):
+        cr = self._create_dataset_with_doi()
+        doi = cr['preservation_identifier']
 
         # Datacite xml should contain the doi created
-        response = self.client.get('/rest/datasets/%s?dataset_format=datacite' % response.data['identifier'])
+        response = self.client.get('/rest/datasets/%s?dataset_format=datacite' % cr['identifier'])
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
         self.assertEqual('<identifier identifierType="DOI">%s' % doi[len('doi:'):] in response.data,
                          True, response.data)
@@ -742,6 +747,29 @@ class CatalogRecordApiReadXMLTransformationTests(CatalogRecordApiReadCommon):
         cr.force_save()
         response = self.client.get('/rest/datasets/1?dataset_format=fairdata_datacite')
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
+
+    def test_read_dataset_format_dummy_datacite_doi(self):
+        """
+        Ensure query parameter ?dummy_doi=true returns datacite xml with identifierType=DOI
+        and identifier value prefixed with 10.0/<preferred_identifier>. If a real DOI is
+        available in the dataset, then dummy should NOT be returned.
+        """
+        pid = self.client.get('/rest/datasets/12').data['research_dataset']['preferred_identifier']
+        self.assertEqual(pid.startswith('doi:'), False, pid)
+
+        for dataset_format in ['datacite', 'fairdata_datacite']:
+            response = self.client.get('/rest/datasets/12?dataset_format=%s&dummy_doi=true' % dataset_format)
+            self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
+            self.assertEqual('<identifier identifierType="DOI">' in response.data, True, response.data)
+            self.assertEqual('10.0/%s' % pid in response.data, True, response.data)
+
+        # ensure if a real doi exists, then dummy should never be returned
+        cr = self._create_dataset_with_doi()
+        response = self.client.get('/rest/datasets/%d?dataset_format=datacite&dummy_doi=true' % cr['id'])
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
+        self.assertEqual('<identifier identifierType="DOI">' in response.data, True, response.data)
+        self.assertEqual(cr['preservation_identifier'][len('doi:'):] in response.data, True, response.data)
+        self.assertEqual('10.0/%s' % pid in response.data, False, response.data)
 
     def _check_dataset_xml_format_response(self, response, element_name):
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -1000,9 +1000,23 @@ paths:
           type: string
         - name: dataset_format
           in: query
-          description: Name of the format the dataset should be returned in. <b>Note:</b> Using this parameter causes the api to return only the field research_dataset, transformed to the requested format.
+          description: |
+            Format the dataset should be returned in.
+            Possible formats are:
+            - datacite (Datacite XML)
+            - fairdata_datacite (a less strict version of official Datacite XML. research_dataset.issued and research_dataset.publisher are not required, and identifierType can be URN, if the dataset does not have a real DOI identifier.)
+            - metax (a simple json -> xml transformation)
+            <b>Note:</b> Using this parameter causes the api to return only the field research_dataset, transformed to the requested format.
           required: false
           type: string
+        - name: dummy_doi
+          in: path
+          description: |
+            Can be used with query parameter dataset_format, when dataset_format value is either datacite, or fairdata_datacite.
+            If specified to true, and the dataset does not have a real DOI identifier, then a dummy DOI is used in place, using the form 10.0/<preferred_identifier>.
+            If the dataset does already have a valid DOI, then the real DOI is used instead, and this parameter has no effect.
+          required: false
+          type: boolean
         - name: file_details
           in: query
           description: |


### PR DESCRIPTION
…d with query param 'dataset_format' when retrieving datasets. If the dataset does not already have a valid DOI identifier, then a dummy DOI is used in place, using the form 10.0/<preferred_identifier>. If there alreaxy exists a real DOI, then the real DOI is used instead