### PR TITLE
CSCFAIRMETA-312: [ADD] deprecation closes REMS entities

### DIFF
--- a/src/metax_api/models/catalog_record.py
+++ b/src/metax_api/models/catalog_record.py
@@ -879,6 +879,10 @@ class CatalogRecord(Common):
     def deprecate(self, timestamp=None):
         self.deprecated = True
         self.date_deprecated = self.date_modified = timestamp or get_tz_aware_now_without_micros()
+
+        if self._dataset_has_rems_managed_access() and settings.REMS['ENABLED']:
+            self.add_post_request_callable(REMSUpdate(self, 'close'))
+
         super().save(update_fields=['deprecated', 'date_deprecated', 'date_modified'])
         self.add_post_request_callable(DelayedLog(
             event='dataset_deprecated',


### PR DESCRIPTION
- When dataset is deprecated, Metax closes all REMS related entities
  same as in deletion
- Added new tests and did some refactoring for the old REMS tests