### PR TITLE
CSCFAIRMETA-433-Draft-datasets-can-be-updated-only-by-dataset-owner

### DIFF
--- a/src/metax_api/middleware/identifyapicaller.py
+++ b/src/metax_api/middleware/identifyapicaller.py
@@ -14,6 +14,7 @@ import requests
 from django.conf import settings as django_settings
 from django.http import HttpResponseForbidden
 
+from django.http import Http404
 from metax_api.exceptions import Http403
 from metax_api.utils import executing_test_case, executing_travis
 
@@ -103,12 +104,13 @@ class _IdentifyApiCaller():
 
         Valid service users and authentication methods are listed in app_config.
         """
+
         http_auth_header = request.META.get('HTTP_AUTHORIZATION', None)
 
         if not http_auth_header:
             _logger.warning('Unauthenticated access attempt from ip: %s. Authorization header missing'
                             % request.META['REMOTE_ADDR'])
-            raise Http403
+            raise Http404
 
         try:
             auth_method, auth_b64 = http_auth_header.split(' ')

--- a/src/metax_api/middleware/identifyapicaller.py
+++ b/src/metax_api/middleware/identifyapicaller.py
@@ -14,7 +14,6 @@ import requests
 from django.conf import settings as django_settings
 from django.http import HttpResponseForbidden
 
-from django.http import Http404
 from metax_api.exceptions import Http403
 from metax_api.utils import executing_test_case, executing_travis
 
@@ -110,7 +109,7 @@ class _IdentifyApiCaller():
         if not http_auth_header:
             _logger.warning('Unauthenticated access attempt from ip: %s. Authorization header missing'
                             % request.META['REMOTE_ADDR'])
-            raise Http404
+            raise Http403
 
         try:
             auth_method, auth_b64 = http_auth_header.split(' ')

--- a/src/metax_api/models/catalog_record.py
+++ b/src/metax_api/models/catalog_record.py
@@ -30,6 +30,7 @@ from .file import File
 
 
 READ_METHODS = ('GET', 'HEAD', 'OPTIONS')
+UPDATE_METHODS = ('PUT', 'PATCH')
 DEBUG = settings.DEBUG
 _logger = logging.getLogger(__name__)
 
@@ -384,6 +385,10 @@ class CatalogRecord(Common):
                     return True
                 else:
                     raise Http404
+
+        elif request.method in UPDATE_METHODS:
+            if self.state == self.STATE_DRAFT and self.metadata_provider_user != request.user.username:
+                raise Http404
 
         # write operation
         return self.user_is_owner(request)

--- a/src/metax_api/models/catalog_record.py
+++ b/src/metax_api/models/catalog_record.py
@@ -30,7 +30,6 @@ from .file import File
 
 
 READ_METHODS = ('GET', 'HEAD', 'OPTIONS')
-UPDATE_METHODS = ('PUT', 'PATCH')
 DEBUG = settings.DEBUG
 _logger = logging.getLogger(__name__)
 
@@ -386,9 +385,8 @@ class CatalogRecord(Common):
                 else:
                     raise Http404
 
-        elif request.method in UPDATE_METHODS:
-            if self.state == self.STATE_DRAFT and self.metadata_provider_user != request.user.username:
-                raise Http404
+        if self.state == self.STATE_DRAFT and self.metadata_provider_user != request.user.username:
+            raise Http404
 
         # write operation
         return self.user_is_owner(request)
@@ -399,6 +397,8 @@ class CatalogRecord(Common):
         elif self.metadata_provider_user:
             return request.user.username == self.metadata_provider_user
 
+        if self.state == self.STATE_DRAFT and self.metadata_provider_user != request.user.username:
+            raise Http404
         # note: once access control plans evolve, user_created may not be a legit field ever
         # to check access from. but until then ...
         return request.user.username == self.user_created

--- a/src/metax_api/models/catalog_record.py
+++ b/src/metax_api/models/catalog_record.py
@@ -385,9 +385,6 @@ class CatalogRecord(Common):
                 else:
                     raise Http404
 
-        if self.state == self.STATE_DRAFT and self.metadata_provider_user != request.user.username:
-            raise Http404
-
         # write operation
         return self.user_is_owner(request)
 


### PR DESCRIPTION
[ADD]owner can update datasets