### PR TITLE
CSCFAIRMETA-437: [ADD] Allow-creating-new-datasets-into-draft-state

### DIFF
--- a/src/metax_api/services/catalog_record_service.py
+++ b/src/metax_api/services/catalog_record_service.py
@@ -71,6 +71,9 @@ class CatalogRecordService(CommonService, ReferenceDataMixin):
         if CommonService.get_boolean_query_param(request, 'latest'):
             queryset_search_params['next_dataset_version_id'] = None
 
+        if request.query_params.get('draft', None) is not None:
+            queryset_search_params['draft'] = CommonService.get_boolean_query_param(request, 'draft')
+
         if request.query_params.get('deprecated', None) is not None:
             queryset_search_params['deprecated'] = CommonService.get_boolean_query_param(request, 'deprecated')
 

--- a/src/metax_api/services/catalog_record_service.py
+++ b/src/metax_api/services/catalog_record_service.py
@@ -71,9 +71,6 @@ class CatalogRecordService(CommonService, ReferenceDataMixin):
         if CommonService.get_boolean_query_param(request, 'latest'):
             queryset_search_params['next_dataset_version_id'] = None
 
-        if request.query_params.get('draft', None) is not None:
-            queryset_search_params['draft'] = CommonService.get_boolean_query_param(request, 'draft')
-
         if request.query_params.get('deprecated', None) is not None:
             queryset_search_params['deprecated'] = CommonService.get_boolean_query_param(request, 'deprecated')
 

--- a/src/metax_api/settings.py
+++ b/src/metax_api/settings.py
@@ -610,3 +610,5 @@ else:
         'AUTO_APPROVER':        app_config_dict.get('REMS', {}).get('AUTO_APPROVER'),
         'FORM_ID':          int(app_config_dict.get('REMS', {}).get('FORM_ID')),
     }
+
+DRAFT_ENABLED = app_config_dict.get('DRAFT_ENABLED', False)

--- a/src/metax_api/settings.py
+++ b/src/metax_api/settings.py
@@ -611,4 +611,7 @@ else:
         'FORM_ID':          int(app_config_dict.get('REMS', {}).get('FORM_ID')),
     }
 
-DRAFT_ENABLED = app_config_dict.get('DRAFT_ENABLED', False)
+if executing_in_travis:
+    DRAFT_ENABLED = 'DRAFT_ENABLED'
+else:
+    DRAFT_ENABLED = app_config_dict.get('DRAFT_ENABLED', False)

--- a/src/metax_api/settings.py
+++ b/src/metax_api/settings.py
@@ -612,6 +612,6 @@ else:
     }
 
 if executing_in_travis:
-    DRAFT_ENABLED = 'DRAFT_ENABLED'
+    DRAFT_ENABLED = True
 else:
     DRAFT_ENABLED = app_config_dict.get('DRAFT_ENABLED', False)

--- a/src/metax_api/tests/api/rest/base/views/datasets/write.py
+++ b/src/metax_api/tests/api/rest/base/views/datasets/write.py
@@ -375,6 +375,26 @@ class CatalogRecordDraftTests(CatalogRecordApiWriteCommon):
         response = self.client.delete('/rest/datasets/3')
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND, response.status_code)
 
+    ###
+    # Tests for saving drafts
+    ###
+
+    def test_service_users_can_save_draft_datasets(self):
+        ''' Drafts should be saved without preferred identifier '''
+        # test access as a service-user
+        self._use_http_authorization(method='basic', username='metax')
+
+        for i in ('?draft', '?draft=true'):
+            response = self.client.post('/rest/datasets{}'.format(i), self.cr_test_data, format="json")
+            self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.data)
+            self.assertFalse('preferred_identifier' in response.data['research_dataset'], response.data)
+            self.assertTrue(response.data['state'] == 'draft', response.data)
+
+        for i in ('', '?draft=false'):
+            response = self.client.post('/rest/datasets{}'.format(i), self.cr_test_data, format="json")
+            self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.data)
+            self.assertTrue('preferred_identifier' in response.data['research_dataset'], response.data)
+            self.assertTrue(response.data['state'] == 'published', response.data)
 
 class CatalogRecordApiWriteCreateTests(CatalogRecordApiWriteCommon):
     #

--- a/src/metax_api/tests/api/rest/base/views/datasets/write.py
+++ b/src/metax_api/tests/api/rest/base/views/datasets/write.py
@@ -384,16 +384,18 @@ class CatalogRecordDraftTests(CatalogRecordApiWriteCommon):
         # test access as a service-user
         self._use_http_authorization(method='basic', username='metax')
 
-        for i in ('?draft', '?draft=true'):
-            response = self.client.post('/rest/datasets{}'.format(i), self.cr_test_data, format="json")
-            self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.data)
-            self.assertFalse('preferred_identifier' in response.data['research_dataset'], response.data)
-            self.assertTrue(response.data['state'] == 'draft', response.data)
+        response = self.client.post('/rest/datasets?draft', self.cr_test_data, format="json")
 
-        for i in ('', '?draft=false'):
-            response = self.client.post('/rest/datasets{}'.format(i), self.cr_test_data, format="json")
+        pid = response.data['research_dataset']['preferred_identifier']
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.data)
+        self.assertTrue(pid == response.data['identifier'], response.data)
+        self.assertTrue('urn' not in pid, response.data)
+        self.assertTrue('doi' not in pid, response.data)
+        self.assertTrue(response.data['state'] == 'draft', response.data)
+
+        for queryparam in ('', '?draft=false'):
+            response = self.client.post('/rest/datasets{}'.format(queryparam), self.cr_test_data, format="json")
             self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.data)
-            self.assertTrue('preferred_identifier' in response.data['research_dataset'], response.data)
             self.assertTrue(response.data['state'] == 'published', response.data)
 
 class CatalogRecordApiWriteCreateTests(CatalogRecordApiWriteCommon):


### PR DESCRIPTION
Create new query parameter ?draft
Create feature switch for draft datasets
Save drafts without preferred identifier
Do not publish into publish into rabbitmq,
rems or datacite.