### PR TITLE
CSCFAIRMETA-318: [REM] Remove unnecessary code that was intended as a…

### DIFF
--- a/src/metax_api/api/rest/base/views/common_view.py
+++ b/src/metax_api/api/rest/base/views/common_view.py
@@ -129,12 +129,6 @@ class CommonViewSet(ModelViewSet):
         if CS.get_boolean_query_param(self.request, 'no_pagination'):
             return None
 
-        if self.request.query_params.get('ordering'):
-            # for some reason ordering is not taken into account when using pagination.
-            # ensure queryset is ordered.
-            ordering = self.request.query_params.get('ordering').split(',')
-            queryset.order_by(*ordering)
-
         return super(CommonViewSet, self).paginate_queryset(queryset)
 
     def get_queryset(self):


### PR DESCRIPTION
… fix previously. The real solution was using additional query parameters so that ordering could be reliably determined by the db