### PR TITLE
CSCFAIRMETA-536: [FIX] access_granter is handled as a field

### DIFF
--- a/src/metax_api/api/rest/base/serializers/catalog_record_serializer.py
+++ b/src/metax_api/api/rest/base/serializers/catalog_record_serializer.py
@@ -125,7 +125,6 @@ class CatalogRecordSerializer(CommonSerializer):
         self.initial_data.pop('preservation_dataset_version', None)
         self.initial_data.pop('preservation_dataset_origin_version', None)
         self.initial_data.pop('rems_identifier', None)
-        self.initial_data.pop('access_granter', None)
 
         if self._data_catalog_is_changed():
             # updating data catalog, but not necessarily research_dataset.

--- a/src/metax_api/models/catalog_record.py
+++ b/src/metax_api/models/catalog_record.py
@@ -5,10 +5,8 @@
 # :author: CSC - IT Center for Science Ltd., Espoo Finland <servicedesk@csc.fi>
 # :license: MIT
 
-from base64 import urlsafe_b64decode
 from collections import defaultdict
 from copy import deepcopy
-import json
 import logging
 
 from django.conf import settings
@@ -345,6 +343,7 @@ class CatalogRecord(Common):
     def __init__(self, *args, **kwargs):
         super(CatalogRecord, self).__init__(*args, **kwargs)
         self.track_fields(
+            'access_granter',
             'cumulative_state',
             'date_deprecated',
             'deprecated',
@@ -1023,8 +1022,12 @@ class CatalogRecord(Common):
         Parses query parameter or token to fetch needed information for REMS user
         """
         if self.request.user.is_service:
-            b64_access_granter = self.request.query_params.get('access_granter')
-            user_info = json.loads(urlsafe_b64decode(f'{b64_access_granter}===').decode('utf-8'))
+            # use constant keys for easier validation
+            user_info = {
+                'userid':   self.access_granter.get('userid'),
+                'name':     self.access_granter.get('name'),
+                'email':    self.access_granter.get('email')
+            }
         else:
             # end user api
             user_info = {
@@ -1048,8 +1051,8 @@ class CatalogRecord(Common):
         if self._access_type_is_permit() and not self.research_dataset['access_rights'].get('license', False):
             raise Http400('You must define license for dataset in order to make it REMS manageable')
 
-        if self.request.user.is_service and not self.request.query_params.get('access_granter', False):
-            raise Http400('Missing query parameter access_granter')
+        if self.request.user.is_service and not self.access_granter:
+            raise Http400('Missing access_granter')
 
     def _pre_create_operations(self, pid_type=None):
 
@@ -1260,9 +1263,15 @@ class CatalogRecord(Common):
                             REMSUpdate(self, 'update', rems_id=self.rems_identifier, reason='license change')
                         )
                         self.rems_identifier = generate_uuid_identifier()
+                        # make sure that access_granter is not changed during license update
+                        self.access_granter = self._initial_data['access_granter']
 
                     else:
                         self._pre_rems_deletion(reason='license deletion')
+
+            elif self.field_changed('access_granter'):
+                # do not allow access_granter changes if no real REMS changes occur
+                self.access_granter = self._initial_data['access_granter']
 
         if self.field_changed('research_dataset'):
             if self.preservation_state in (


### PR DESCRIPTION
- access_granter information is now provided in a field
- field change validation is moved from serializer to models to
  enable this feature
- new test to ensure that there are no changes in access_granter
  when license is updated because this is a special case