### PR TITLE
CSCFAIRMETA-566: [ADD] filter datasets by their api version

### DIFF
--- a/src/metax_api/services/catalog_record_service.py
+++ b/src/metax_api/services/catalog_record_service.py
@@ -105,6 +105,15 @@ class CatalogRecordService(CommonService, ReferenceDataMixin):
             queryset_search_params['data_catalog__catalog_json__identifier__iregex'] = \
                 request.query_params['data_catalog']
 
+        if request.query_params.get('api_version', False):
+            try:
+                value = int(request.query_params['api_version'])
+            except ValueError:
+                value = request.query_params['api_version']
+                raise Http400({ 'api_version': ['Value \'%s\' is not an integer' % value] })
+
+            queryset_search_params['api_meta__contains'] = { 'version': value }
+
         return queryset_search_params
 
     @staticmethod

--- a/src/metax_api/tests/api/rest/base/views/datasets/read.py
+++ b/src/metax_api/tests/api/rest/base/views/datasets/read.py
@@ -5,7 +5,6 @@
 # :author: CSC - IT Center for Science Ltd., Espoo Finland <servicedesk@csc.fi>
 # :license: MIT
 
-from copy import deepcopy
 from datetime import timedelta
 import urllib.parse
 

--- a/src/metax_api/tests/api/rest/base/views/datasets/read.py
+++ b/src/metax_api/tests/api/rest/base/views/datasets/read.py
@@ -16,7 +16,7 @@ import responses
 from rest_framework import status
 from rest_framework.test import APITestCase
 
-from metax_api.models import CatalogRecord, CatalogRecordV2, Contract, File
+from metax_api.models import CatalogRecord, Contract, File
 from metax_api.tests.utils import test_data_file_path, TestClassUtils
 
 

--- a/src/metax_api/tests/api/rest/base/views/datasets/read.py
+++ b/src/metax_api/tests/api/rest/base/views/datasets/read.py
@@ -723,6 +723,10 @@ class CatalogRecordApiReadQueryParamsTests(CatalogRecordApiReadCommon):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(v2_count, response.data['count'], response.data)
 
+        response = self.client.get('/rest/datasets?api_version=not_int')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertTrue('not an integer' in response.data['api_version'][0], response.data)
+
 class CatalogRecordApiReadXMLTransformationTests(CatalogRecordApiReadCommon):
 
     """

--- a/src/metax_api/tests/api/rest/base/views/datasets/read.py
+++ b/src/metax_api/tests/api/rest/base/views/datasets/read.py
@@ -5,6 +5,7 @@
 # :author: CSC - IT Center for Science Ltd., Espoo Finland <servicedesk@csc.fi>
 # :license: MIT
 
+from copy import deepcopy
 from datetime import timedelta
 import urllib.parse
 
@@ -16,7 +17,7 @@ import responses
 from rest_framework import status
 from rest_framework.test import APITestCase
 
-from metax_api.models import CatalogRecord, Contract, File
+from metax_api.models import CatalogRecord, CatalogRecordV2, Contract, File
 from metax_api.tests.utils import test_data_file_path, TestClassUtils
 
 
@@ -704,6 +705,24 @@ class CatalogRecordApiReadQueryParamsTests(CatalogRecordApiReadCommon):
         response = self.client.get('/rest/datasets?deprecated=badbool')
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
+    def test_filter_by_api_version(self):
+
+        # update one dataset to v2 so that we get non-zero values for that as well
+        response = self.client.put('/rest/v2/datasets', [self.cr_from_test_data], format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # both models return correct count because v2 model is just a proxy
+        v1_count = CatalogRecord.objects.filter(api_meta__contains={'version': 1}).count()
+
+        v2_count = CatalogRecord.objects.filter(api_meta__contains={'version': 2}).count()
+
+        response = self.client.get('/rest/datasets?api_version=1')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(v1_count, response.data['count'], response.data)
+
+        response = self.client.get('/rest/datasets?api_version=2')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(v2_count, response.data['count'], response.data)
 
 class CatalogRecordApiReadXMLTransformationTests(CatalogRecordApiReadCommon):
 

--- a/src/metax_api/tests/api/rest/v2/views/datasets/read.py
+++ b/src/metax_api/tests/api/rest/v2/views/datasets/read.py
@@ -572,6 +572,24 @@ class CatalogRecordApiReadQueryParamsTests(CatalogRecordApiReadCommon):
         response = self.client.get('/rest/v2/datasets?deprecated=badbool')
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
+    def test_filter_by_api_version(self):
+
+        # update one dataset to v2 so that we get non-zero values for that as well
+        response = self.client.put('/rest/v2/datasets', [self.cr_from_test_data], format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # both models return correct count because v2 model is just a proxy
+        v1_count = CatalogRecordV2.objects.filter(api_meta__contains={'version': 1}).count()
+
+        response = self.client.get('/rest/v2/datasets?api_version=1')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(v1_count, response.data['count'], response.data)
+
+        v2_count = CatalogRecordV2.objects.filter(api_meta__contains={'version': 2}).count()
+
+        response = self.client.get('/rest/v2/datasets?api_version=2')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(v2_count, response.data['count'], response.data)
 
 class CatalogRecordApiReadXMLTransformationTests(CatalogRecordApiReadCommon):
 

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -956,6 +956,11 @@ paths:
             '?publisher_organization=some organisation&creator_person=person_name&condition_separator=or'
           required: false
           type: string
+        - name: api_version
+          in: query
+          description: returns datasets that can be edited with certain api version. Possible values are 1 and 2
+          type: integer
+          required: false
         - $ref: "#/parameters/fields"
       responses:
         "200":

--- a/swagger/v2/swagger.yaml
+++ b/swagger/v2/swagger.yaml
@@ -961,6 +961,11 @@ paths:
             '?publisher_organization=some organisation&creator_person=person_name&condition_separator=or'
           required: false
           type: string
+        - name: api_version
+          in: query
+          description: returns datasets that can be edited with certain api version. Possible values are 1 and 2
+          type: integer
+          required: false
         - $ref: "#/parameters/include_user_metadata"
         - $ref: "#/parameters/fields"
       responses:


### PR DESCRIPTION
Creating this PR already but should be merged only after 565