### PR TITLE
Merge pkg update to stable: v1.7.1-rc3

### DIFF
--- a/src/metax_api/api/rest/base/api_schemas/catalogrecord.json
+++ b/src/metax_api/api/rest/base/api_schemas/catalogrecord.json
@@ -327,7 +327,7 @@
                     "description":"Catalog record deprecation state.",
                     "type":"string",
                     "readonly": true
-                },
+                }
             }
         },
         "CatalogRecordVersionCreatedInfo":{
@@ -359,7 +359,7 @@
                     "readonly": true,
                     "enum":[
                         "dataset",
-                        "pas",
+                        "pas"
                     ]
                 }
             },

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -1841,13 +1841,13 @@ parameters:
 
 definitions:
   CatalogRecord:
-    $ref: 'https://__METAX_ENV_DOMAIN__/apischemas/catalogrecord.json#/definitions/CatalogRecord'
+    $ref: 'https://__METAX_ENV_DOMAIN__/apischemas/v1/catalogrecord.json#/definitions/CatalogRecord'
   DataCatalog:
-    $ref: 'https://__METAX_ENV_DOMAIN__/apischemas/datacatalog.json#/definitions/Catalog'
+    $ref: 'https://__METAX_ENV_DOMAIN__/apischemas/v1/datacatalog.json#/definitions/Catalog'
   File:
-    $ref: 'https://__METAX_ENV_DOMAIN__/apischemas/file.json#/definitions/File'
+    $ref: 'https://__METAX_ENV_DOMAIN__/apischemas/v1/file.json#/definitions/File'
   Directory:
-    $ref: 'https://__METAX_ENV_DOMAIN__/apischemas/file.json#/definitions/Directory'
+    $ref: 'https://__METAX_ENV_DOMAIN__/apischemas/v1/file.json#/definitions/Directory'
   StringList:
     type: array
     items:


### PR DESCRIPTION
- v1 swagger remote references were not updated to point to v1 api-
  schemas. This was discovered only after running deploy_nginx.
- Api-schemas had some extra trailing commas which caused swagger to
  not showing the model