### PR TITLE
CSCFAIRMETA-639-Make-issued-date-mandatory

### DIFF
--- a/src/metax_api/api/rest/base/schemas/att_dataset_schema.json
+++ b/src/metax_api/api/rest/base/schemas/att_dataset_schema.json
@@ -1322,7 +1322,8 @@
                 "creator",
                 "description",
                 "access_rights",
-                "title"
+                "title",
+                "issued"
             ],
             "additionalProperties": false
         },

--- a/src/metax_api/api/rest/base/schemas/ida_dataset_schema.json
+++ b/src/metax_api/api/rest/base/schemas/ida_dataset_schema.json
@@ -1485,7 +1485,8 @@
                 "creator",
                 "description",
                 "access_rights",
-                "title"
+                "title",
+                "issued"
             ],
             "additionalProperties": false
         },

--- a/src/metax_api/api/rest/v2/api_schemas/ida_dataset_schema.json
+++ b/src/metax_api/api/rest/v2/api_schemas/ida_dataset_schema.json
@@ -1484,7 +1484,8 @@
                 "creator",
                 "description",
                 "access_rights",
-                "title"
+                "title",
+                "issued"
             ],
             "additionalProperties": false
         },

--- a/src/metax_api/api/rest/v2/schemas/att_dataset_schema.json
+++ b/src/metax_api/api/rest/v2/schemas/att_dataset_schema.json
@@ -1269,7 +1269,8 @@
                 "creator",
                 "description",
                 "access_rights",
-                "title"
+                "title",
+                "issued"
             ],
             "additionalProperties": false
         },

--- a/src/metax_api/api/rest/v2/schemas/ida_dataset_schema.json
+++ b/src/metax_api/api/rest/v2/schemas/ida_dataset_schema.json
@@ -1432,7 +1432,8 @@
                 "creator",
                 "description",
                 "access_rights",
-                "title"
+                "title",
+                "issued"
             ],
             "additionalProperties": false
         },

--- a/src/metax_api/exampledata/dataset_minimal.json
+++ b/src/metax_api/exampledata/dataset_minimal.json
@@ -19,6 +19,7 @@
                 }
             }
         ],
+        "issued": "2000-01-01",
         "access_rights": {
             "access_type": {
                 "identifier": "http://uri.suomi.fi/codelist/fairdata/access_type/code/open"

--- a/src/metax_api/tests/api/rpc/base/views/dataset_rpc.py
+++ b/src/metax_api/tests/api/rpc/base/views/dataset_rpc.py
@@ -89,7 +89,6 @@ class DatasetRPCTests(APITestCase, TestClassUtils):
         cr_json.pop('identifier')
         cr_json['research_dataset'].pop('preferred_identifier', None)
         cr_json['data_catalog'] = dc_id
-        cr_json['research_dataset']['issued'] = '2018-01-01'
         cr_json['research_dataset']['publisher'] = {
             '@type': 'Organization',
             'name': { 'en': 'publisher' }
@@ -108,7 +107,7 @@ class DatasetRPCTests(APITestCase, TestClassUtils):
         self.assertEqual(response.data, response2.data['preservation_identifier'], response2.data)
 
         # Return 400 if request is not correct datacite format
-        response2.data['research_dataset'].pop('issued')
+        response2.data['research_dataset'].pop('publisher')
         response = self.client.put(f'/rest/datasets/{identifier}', response2.data, format="json")
         self.assertEqual(response2.status_code, status.HTTP_200_OK, response2.data)
 

--- a/src/metax_api/tests/api/rpc/base/views/statistic_rpc.py
+++ b/src/metax_api/tests/api/rpc/base/views/statistic_rpc.py
@@ -179,6 +179,7 @@ class StatisticRPCCommon(APITestCase, TestClassUtils):
                         }
                     }
                 ],
+                "issued": "2010-01-01",
                 "access_rights": {
                     "access_type": {
                         "identifier": "http://uri.suomi.fi/codelist/fairdata/access_type/code/open",

--- a/src/metax_api/tests/api/rpc/v2/views/dataset_rpc.py
+++ b/src/metax_api/tests/api/rpc/v2/views/dataset_rpc.py
@@ -111,7 +111,6 @@ class DatasetRPCTests(APITestCase, TestClassUtils):
         cr_json.pop('identifier')
         cr_json['research_dataset'].pop('preferred_identifier', None)
         cr_json['data_catalog'] = dc_id
-        cr_json['research_dataset']['issued'] = '2018-01-01'
         cr_json['research_dataset']['publisher'] = {
             '@type': 'Organization',
             'name': { 'en': 'publisher' }
@@ -130,7 +129,7 @@ class DatasetRPCTests(APITestCase, TestClassUtils):
         self.assertEqual(response.data, response2.data['preservation_identifier'], response2.data)
 
         # Return 400 if request is not correct datacite format
-        response2.data['research_dataset'].pop('issued')
+        response2.data['research_dataset'].pop('publisher')
         response = self.client.put(f'/rest/v2/datasets/{identifier}', response2.data, format="json")
         self.assertEqual(response2.status_code, status.HTTP_200_OK, response2.data)
 

--- a/src/metax_api/tests/api/rpc/v2/views/statistic_rpc.py
+++ b/src/metax_api/tests/api/rpc/v2/views/statistic_rpc.py
@@ -179,6 +179,7 @@ class StatisticRPCCommon(APITestCase, TestClassUtils):
                         }
                     }
                 ],
+                "issued": "2010-01-01",
                 "access_rights": {
                     "access_type": {
                         "identifier": "http://uri.suomi.fi/codelist/fairdata/access_type/code/open",


### PR DESCRIPTION
Add "issued" into required fields in IDA and ATT catalogs