### PR TITLE
CSCFAIRMETA-639-Issued-date

### DIFF
--- a/src/metax_api/models/catalog_record.py
+++ b/src/metax_api/models/catalog_record.py
@@ -1065,9 +1065,10 @@ class CatalogRecord(Common):
         return CommonService.get_boolean_query_param(self.request, 'draft') and settings.DRAFT_ENABLED
 
     def _handle_issued_date(self):
-        if not (self.catalog_is_harvested()):
+        if not (self.catalog_is_harvested() or self._save_as_draft()):
             if 'issued' not in self.research_dataset:
-                self.research_dataset['issued'] = datetime_to_str(self.date_created)[0:10]
+                date = self.date_modified if self.date_modified else self.date_created
+                self.research_dataset['issued'] = datetime_to_str(date)[0:10]
 
     def get_metadata_version_listing(self):
         entries = []

--- a/src/metax_api/models/catalog_record.py
+++ b/src/metax_api/models/catalog_record.py
@@ -1065,7 +1065,7 @@ class CatalogRecord(Common):
         return CommonService.get_boolean_query_param(self.request, 'draft') and settings.DRAFT_ENABLED
 
     def _handle_issued_date(self):
-        if not (self.catalog_is_harvested() or self._save_as_draft()):
+        if not (self.catalog_is_harvested()):
             if 'issued' not in self.research_dataset:
                 self.research_dataset['issued'] = datetime_to_str(self.date_created)[0:10]
 

--- a/src/metax_api/models/catalog_record.py
+++ b/src/metax_api/models/catalog_record.py
@@ -1064,6 +1064,11 @@ class CatalogRecord(Common):
         from metax_api.services import CommonService
         return CommonService.get_boolean_query_param(self.request, 'draft') and settings.DRAFT_ENABLED
 
+    def _handle_issued_date(self):
+        if not (self.catalog_is_harvested() or self._save_as_draft()):
+            if 'issued' not in self.research_dataset:
+                self.research_dataset['issued'] = datetime_to_str(self.date_created)[0:10]
+
     def get_metadata_version_listing(self):
         entries = []
         for entry in self.research_dataset_versions.all():
@@ -1201,12 +1206,7 @@ class CatalogRecord(Common):
 
             self.date_cumulation_started = self.date_created
 
-        if (self.catalog_is_ida() or self.catalog_is_att()):
-            if 'issued' not in self.research_dataset:
-                try:
-                    self.research_dataset['issued'] = datetime_to_str(self.date_created)[0:10]
-                except:
-                    raise Http400('Issued_date must have a value')
+        self._handle_issued_date()
 
         self._set_api_version()
 

--- a/src/metax_api/models/catalog_record.py
+++ b/src/metax_api/models/catalog_record.py
@@ -44,7 +44,6 @@ ACCESS_TYPES = {
 LEGACY_CATALOGS = settings.LEGACY_CATALOGS
 IDA_CATALOG = settings.IDA_DATA_CATALOG_IDENTIFIER
 PAS_CATALOG = settings.PAS_DATA_CATALOG_IDENTIFIER
-ATT_CATALOG = settings.ATT_DATA_CATALOG_IDENTIFIER
 
 
 class DiscardRecord(Exception):
@@ -1050,9 +1049,6 @@ class CatalogRecord(Common):
 
     def catalog_is_ida(self):
         return self.data_catalog.catalog_json['identifier'] == IDA_CATALOG
-
-    def catalog_is_att(self):
-        return self.data_catalog.catalog_json['identifier'] == ATT_CATALOG
 
     def catalog_is_pas(self):
         return self.data_catalog.catalog_json['identifier'] == PAS_CATALOG

--- a/src/metax_api/models/catalog_record.py
+++ b/src/metax_api/models/catalog_record.py
@@ -1064,11 +1064,11 @@ class CatalogRecord(Common):
         from metax_api.services import CommonService
         return CommonService.get_boolean_query_param(self.request, 'draft') and settings.DRAFT_ENABLED
 
-    def _handle_issued_date(self):
-        if not (self.catalog_is_harvested() or self._save_as_draft()):
+    def _generate_issued_date(self):
+        if not (self.catalog_is_harvested()):
             if 'issued' not in self.research_dataset:
-                date = self.date_modified if self.date_modified else self.date_created
-                self.research_dataset['issued'] = datetime_to_str(date)[0:10]
+                current_time = get_tz_aware_now_without_micros()
+                self.research_dataset['issued'] = datetime_to_str(current_time)[0:10]
 
     def get_metadata_version_listing(self):
         entries = []
@@ -1207,7 +1207,7 @@ class CatalogRecord(Common):
 
             self.date_cumulation_started = self.date_created
 
-        self._handle_issued_date()
+        self._generate_issued_date()
 
         self._set_api_version()
 

--- a/src/metax_api/models/catalog_record.py
+++ b/src/metax_api/models/catalog_record.py
@@ -44,6 +44,7 @@ ACCESS_TYPES = {
 LEGACY_CATALOGS = settings.LEGACY_CATALOGS
 IDA_CATALOG = settings.IDA_DATA_CATALOG_IDENTIFIER
 PAS_CATALOG = settings.PAS_DATA_CATALOG_IDENTIFIER
+ATT_CATALOG = settings.ATT_DATA_CATALOG_IDENTIFIER
 
 
 class DiscardRecord(Exception):
@@ -1050,6 +1051,9 @@ class CatalogRecord(Common):
     def catalog_is_ida(self):
         return self.data_catalog.catalog_json['identifier'] == IDA_CATALOG
 
+    def catalog_is_att(self):
+        return self.data_catalog.catalog_json['identifier'] == ATT_CATALOG
+
     def catalog_is_pas(self):
         return self.data_catalog.catalog_json['identifier'] == PAS_CATALOG
 
@@ -1196,6 +1200,13 @@ class CatalogRecord(Common):
                 raise Http400('Dataset cannot be cumulative if it is in PAS process')
 
             self.date_cumulation_started = self.date_created
+
+        if (self.catalog_is_ida() or self.catalog_is_att()):
+            if 'issued' not in self.research_dataset:
+                try:
+                    self.research_dataset['issued'] = datetime_to_str(self.date_created)[0:10]
+                except:
+                    raise Http400('Issued_date must have a value')
 
         self._set_api_version()
 

--- a/src/metax_api/models/catalog_record_v2.py
+++ b/src/metax_api/models/catalog_record_v2.py
@@ -99,7 +99,9 @@ class CatalogRecordV2(CatalogRecord):
 
         self.research_dataset['metadata_version_identifier'] = generate_uuid_identifier()
         self.identifier = generate_uuid_identifier()
-        self._handle_issued_date() # For drafts to be merged this is called in _pre_update_operations
+
+        if not self._save_as_draft():
+            self._generate_issued_date()
 
         self._set_api_version()
 
@@ -189,7 +191,7 @@ class CatalogRecordV2(CatalogRecord):
 
         self.state = self.STATE_PUBLISHED
 
-        self._handle_issued_date() # This has to be here for drafts, that are published without modifying
+        self._generate_issued_date()
 
         if self.catalog_is_pas():
             _logger.debug('Catalog is PAS - Using DOI as pref_id_type')
@@ -350,6 +352,9 @@ class CatalogRecordV2(CatalogRecord):
         # the save will not raise errors about it
         draft_cr.research_dataset['preferred_identifier'] = origin_cr.preferred_identifier
 
+        if 'issued' not in draft_cr.research_dataset:
+            draft_cr._generate_issued_date()
+
         # other than that, all values from research_dataset should be copied over
         origin_cr.research_dataset = draft_cr.research_dataset
 
@@ -456,7 +461,6 @@ class CatalogRecordV2(CatalogRecord):
         if draft_publish:
             # permit updating files and directories (user metadata) when
             # draft record is being merged into a published record.
-            self._handle_issued_date() # This has to be here for drafts, that are merged back to original
             pass
         else:
             # "normal" PUT or PATCH to the record (draft or published). these fields should

--- a/src/metax_api/models/catalog_record_v2.py
+++ b/src/metax_api/models/catalog_record_v2.py
@@ -99,6 +99,7 @@ class CatalogRecordV2(CatalogRecord):
 
         self.research_dataset['metadata_version_identifier'] = generate_uuid_identifier()
         self.identifier = generate_uuid_identifier()
+        self._handle_issued_date()
 
         self._set_api_version()
 
@@ -125,8 +126,6 @@ class CatalogRecordV2(CatalogRecord):
                 self.use_doi_for_published = True
             else:
                 self.use_doi_for_published = False
-
-            self._handle_issued_date()
 
             super(Common, self).save(update_fields=['research_dataset', 'use_doi_for_published'])
 
@@ -164,14 +163,6 @@ class CatalogRecordV2(CatalogRecord):
         """
         from metax_api.services import CommonService
         return CommonService.get_boolean_query_param(self.request, 'draft')
-
-    def _handle_issued_date(self):
-        if (self.catalog_is_ida() or self.catalog_is_att()):
-            if 'issued' not in self.research_dataset:
-                try:
-                    self.research_dataset['issued'] = datetime_to_str(self.date_created)[0:10]
-                except:
-                    raise Http400('Issued_date must have a value')
 
     def publish_dataset(self, pid_type=None):
         """
@@ -279,8 +270,6 @@ class CatalogRecordV2(CatalogRecord):
 
         if self._dataset_has_rems_managed_access() and settings.REMS['ENABLED']:
             self._pre_rems_creation()
-
-        self._handle_issued_date()
 
         if self.api_version != self.api_meta['version']:
             self._set_api_version()

--- a/src/metax_api/models/catalog_record_v2.py
+++ b/src/metax_api/models/catalog_record_v2.py
@@ -99,7 +99,7 @@ class CatalogRecordV2(CatalogRecord):
 
         self.research_dataset['metadata_version_identifier'] = generate_uuid_identifier()
         self.identifier = generate_uuid_identifier()
-        self._handle_issued_date()
+        self._handle_issued_date() # For drafts to be merged this is called in _pre_update_operations
 
         self._set_api_version()
 
@@ -169,6 +169,7 @@ class CatalogRecordV2(CatalogRecord):
         Execute actions necessary to make the dataset publicly findable, in the following order:
         - set status to 'published'
         - generate preferred_identifier according to requested pid_type
+        - generate issued_date for datasets that were created first as drafts
         - publish objects to REMS as necessary
         - publish metadata to datacite as necessary
         - publish message to rabbitmq
@@ -187,6 +188,8 @@ class CatalogRecordV2(CatalogRecord):
             )
 
         self.state = self.STATE_PUBLISHED
+
+        self._handle_issued_date() # This has to be here for drafts, that are published without modifying
 
         if self.catalog_is_pas():
             _logger.debug('Catalog is PAS - Using DOI as pref_id_type')
@@ -453,6 +456,7 @@ class CatalogRecordV2(CatalogRecord):
         if draft_publish:
             # permit updating files and directories (user metadata) when
             # draft record is being merged into a published record.
+            self._handle_issued_date() # This has to be here for drafts, that are merged back to original
             pass
         else:
             # "normal" PUT or PATCH to the record (draft or published). these fields should

--- a/src/metax_api/tests/api/rest/base/views/datasets/write.py
+++ b/src/metax_api/tests/api/rest/base/views/datasets/write.py
@@ -440,8 +440,8 @@ class CatalogRecordApiWriteCreateTests(CatalogRecordApiWriteCommon):
     #
     #
 
-    def test_issued_date_is_mandatory(self):
-        ''' Issued date is mandatory only for ida and att- catalogs '''
+    def test_issued_date_is_generated(self):
+        ''' Issued date is generated for all but harvested catalogs if it doesn't exists '''
         # ATT
         for catalog in [ATT_CATALOG, IDA_CATALOG]:
             dc = DataCatalog.objects.get(pk=2)

--- a/src/metax_api/tests/api/rest/base/views/datasets/write.py
+++ b/src/metax_api/tests/api/rest/base/views/datasets/write.py
@@ -27,7 +27,7 @@ END_USER_ALLOWED_DATA_CATALOGS = django_settings.END_USER_ALLOWED_DATA_CATALOGS
 LEGACY_CATALOGS = django_settings.LEGACY_CATALOGS
 IDA_CATALOG = django_settings.IDA_DATA_CATALOG_IDENTIFIER
 EXT_CATALOG = django_settings.EXT_DATA_CATALOG_IDENTIFIER
-
+ATT_CATALOG = django_settings.ATT_DATA_CATALOG_IDENTIFIER
 
 class CatalogRecordApiWriteCommon(APITestCase, TestClassUtils):
     """
@@ -195,7 +195,7 @@ class CatalogRecordDraftTests(CatalogRecordApiWriteCommon):
         cr.data_catalog_id = DataCatalog.objects.get(catalog_json__identifier=END_USER_ALLOWED_DATA_CATALOGS[0]).id
         cr.force_save()
 
-    def test_field_exists(self):
+    def test_field_state_exists(self):
         """Try fetching any dataset, field 'state' should be returned'"""
 
         cr = self.client.get('/rest/datasets/13').data
@@ -439,6 +439,22 @@ class CatalogRecordApiWriteCreateTests(CatalogRecordApiWriteCommon):
     #
     #
     #
+
+    def test_issued_date_is_mandatory(self):
+        ''' Issued date is mandatory only for ida and att- catalogs '''
+        # ATT
+        for catalog in [ATT_CATALOG, IDA_CATALOG]:
+            dc = DataCatalog.objects.get(pk=2)
+            dc.catalog_json['identifier'] = catalog
+            dc.force_save()
+
+            # Create a catalog record in att catalog
+            self.cr_test_data['data_catalog'] = dc.catalog_json
+            self.cr_test_data['research_dataset'].pop('issued', None)
+
+            response = self.client.post('/rest/datasets', self.cr_test_data, format="json")
+            self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.data)
+            self.assertTrue('issued' in response.data['research_dataset'], response.data)
 
     def test_create_catalog_record(self):
         self.cr_test_data['research_dataset']['preferred_identifier'] = 'this_should_be_overwritten'
@@ -3492,6 +3508,16 @@ class CatalogRecordApiWriteLegacyDataCatalogs(CatalogRecordApiWriteCommon):
         dc.force_save()
         del self.cr_test_data['research_dataset']['files']
         del self.cr_test_data['research_dataset']['total_files_byte_size']
+
+    def test_issued_date_not_mandatory(self):
+        # Issued date is mandatory only for ida and att- catalogs
+        self.cr_test_data['data_catalog'] = LEGACY_CATALOGS[0]
+        self.cr_test_data['research_dataset']['preferred_identifier'] = 'a'
+        self.cr_test_data['research_dataset'].pop('issued', None)
+
+        response = self.client.post('/rest/datasets', self.cr_test_data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.data)
+        self.assertTrue('issued' not in response.data['research_dataset'], response.data)
 
     def test_legacy_catalog_pids_are_not_unique(self):
         # values provided as pid values in legacy catalogs are not required to be unique

--- a/src/metax_api/tests/api/rest/base/views/datasets/write.py
+++ b/src/metax_api/tests/api/rest/base/views/datasets/write.py
@@ -3509,16 +3509,6 @@ class CatalogRecordApiWriteLegacyDataCatalogs(CatalogRecordApiWriteCommon):
         del self.cr_test_data['research_dataset']['files']
         del self.cr_test_data['research_dataset']['total_files_byte_size']
 
-    def test_issued_date_not_mandatory(self):
-        # Issued date is mandatory only for ida and att- catalogs
-        self.cr_test_data['data_catalog'] = LEGACY_CATALOGS[0]
-        self.cr_test_data['research_dataset']['preferred_identifier'] = 'a'
-        self.cr_test_data['research_dataset'].pop('issued', None)
-
-        response = self.client.post('/rest/datasets', self.cr_test_data, format="json")
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.data)
-        self.assertTrue('issued' not in response.data['research_dataset'], response.data)
-
     def test_legacy_catalog_pids_are_not_unique(self):
         # values provided as pid values in legacy catalogs are not required to be unique
         # within the catalog.

--- a/src/metax_api/tests/api/rest/base/views/datasets/write.py
+++ b/src/metax_api/tests/api/rest/base/views/datasets/write.py
@@ -27,7 +27,6 @@ END_USER_ALLOWED_DATA_CATALOGS = django_settings.END_USER_ALLOWED_DATA_CATALOGS
 LEGACY_CATALOGS = django_settings.LEGACY_CATALOGS
 IDA_CATALOG = django_settings.IDA_DATA_CATALOG_IDENTIFIER
 EXT_CATALOG = django_settings.EXT_DATA_CATALOG_IDENTIFIER
-ATT_CATALOG = django_settings.ATT_DATA_CATALOG_IDENTIFIER
 
 class CatalogRecordApiWriteCommon(APITestCase, TestClassUtils):
     """
@@ -442,19 +441,16 @@ class CatalogRecordApiWriteCreateTests(CatalogRecordApiWriteCommon):
 
     def test_issued_date_is_generated(self):
         ''' Issued date is generated for all but harvested catalogs if it doesn't exists '''
-        # ATT
-        for catalog in [ATT_CATALOG, IDA_CATALOG]:
-            dc = DataCatalog.objects.get(pk=2)
-            dc.catalog_json['identifier'] = catalog
-            dc.force_save()
+        dc = DataCatalog.objects.get(pk=2)
+        dc.catalog_json['identifier'] = IDA_CATALOG # Test with IDA catalog
+        dc.force_save()
 
-            # Create a catalog record in att catalog
-            self.cr_test_data['data_catalog'] = dc.catalog_json
-            self.cr_test_data['research_dataset'].pop('issued', None)
+        self.cr_test_data['data_catalog'] = dc.catalog_json
+        self.cr_test_data['research_dataset'].pop('issued', None)
 
-            response = self.client.post('/rest/datasets', self.cr_test_data, format="json")
-            self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.data)
-            self.assertTrue('issued' in response.data['research_dataset'], response.data)
+        response = self.client.post('/rest/datasets', self.cr_test_data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.data)
+        self.assertTrue('issued' in response.data['research_dataset'], response.data)
 
     def test_create_catalog_record(self):
         self.cr_test_data['research_dataset']['preferred_identifier'] = 'this_should_be_overwritten'

--- a/src/metax_api/tests/api/rest/v2/views/datasets/__init__.py
+++ b/src/metax_api/tests/api/rest/v2/views/datasets/__init__.py
@@ -13,3 +13,4 @@ from .filehandling import *
 from .pas import *
 from .referencedata import *
 from .rems import *
+from .api_version_lock import *

--- a/src/metax_api/tests/api/rest/v2/views/datasets/api_version_lock.py
+++ b/src/metax_api/tests/api/rest/v2/views/datasets/api_version_lock.py
@@ -7,7 +7,6 @@
 
 from copy import deepcopy
 
-from metax_api.tests.api.rest.v2.views.datasets import __init__
 from rest_framework import status
 
 from metax_api.models import (
@@ -15,8 +14,6 @@ from metax_api.models import (
     CatalogRecordV2
 )
 from .write import CatalogRecordApiWriteCommon
-
-
 
 CR = CatalogRecordV2
 

--- a/src/metax_api/tests/api/rest/v2/views/datasets/api_version_lock.py
+++ b/src/metax_api/tests/api/rest/v2/views/datasets/api_version_lock.py
@@ -7,6 +7,7 @@
 
 from copy import deepcopy
 
+from metax_api.tests.api.rest.v2.views.datasets import __init__
 from rest_framework import status
 
 from metax_api.models import (
@@ -14,6 +15,7 @@ from metax_api.models import (
     CatalogRecordV2
 )
 from .write import CatalogRecordApiWriteCommon
+
 
 
 CR = CatalogRecordV2

--- a/src/metax_api/tests/api/rest/v2/views/datasets/drafts.py
+++ b/src/metax_api/tests/api/rest/v2/views/datasets/drafts.py
@@ -64,27 +64,19 @@ class CatalogRecordDraftTests(CatalogRecordApiWriteCommon):
         cr.data_catalog_id = DataCatalog.objects.get(catalog_json__identifier=END_USER_ALLOWED_DATA_CATALOGS[0]).id
         cr.force_save()
 
-    def test_field_exists(self):
+    def test_field_state_exists(self):
         """Try fetching any dataset, field 'state' should be returned'"""
 
         cr = self.client.get('/rest/v2/datasets/13').data
         self.assertEqual('state' in cr, True)
 
-    def _test_issued_date_is_mandatory(self):
-        ''' Issued date is mandatory only for ida and att- catalogs '''
-        # ATT
-        self.cr_full_att_test_data['research_dataset'].pop('issued', None)
-
-        response = self.client.post('/rest/v2/datasets?draft=true', self.cr_full_att_test_data, format="json")
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.data)
-        self.assertTrue('issued' in response.data['research_dataset'], response.data)
-
-        # IDA
+    def _test_issued_date_is_not_mandatory(self):
+        ''' Issued date is not mandatory for drafts '''
         self.cr_full_ida_test_data['research_dataset'].pop('issued', None)
 
-        response = self.client.post('/rest/v2/datasets', self.cr_full_ida_test_data, format="json")
+        response = self.client.post('/rest/v2/datasets?draft=true', self.cr_full_ida_test_data, format="json")
         self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.data)
-        self.assertTrue('issued' in response.data['research_dataset'], response.data)
+        self.assertTrue('issued' not in response.data['research_dataset'], response.data)
 
     def test_change_state_field_through_API(self):
         """Fetch a dataset and change its state.

--- a/src/metax_api/tests/api/rest/v2/views/datasets/drafts.py
+++ b/src/metax_api/tests/api/rest/v2/views/datasets/drafts.py
@@ -74,15 +74,15 @@ class CatalogRecordDraftTests(CatalogRecordApiWriteCommon):
         '''  Drafts will not have the issued date generated
              Field is created when dataset is published
         '''
-        # Draft without issued date
+        # Dataset without issued date
         self.cr_full_ida_test_data['research_dataset'].pop('issued', None)
 
-        # Create issued date for drafts
+        # Create draft
         response = self.client.post('/rest/v2/datasets?draft=true', self.cr_full_ida_test_data, format="json")
         self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.data)
         self.assertTrue('issued' not in response.data['research_dataset'], response.data)
 
-        # Field is created when dataset is published
+        # Issued_date is generated when dataset is published
         publish = self.client.post('/rpc/v2/datasets/publish_dataset?identifier={}'.format(response.data['identifier']))
         self.assertEqual(publish.status_code, status.HTTP_200_OK, publish.data)
 
@@ -439,49 +439,33 @@ class CatalogRecordDraftsOfPublished(CatalogRecordApiWriteCommon):
         )
         self.assertEqual('next_draft' in response.data, False, 'next_draft link should be gone')
 
-    def test_issued_date_remains_original_in_merged_draft(self):
-        ''' When draft is created from published dataset and issued_date is not modified,
-        issued date should remain the same as in original dataset '''
-
+    def test_missing_issued_date_is_generated_when_draft_is_merged(self):
+        """
+        Testing a case where user removes 'issued_date' from draft before merging
+        it back to original published dataset
+        """
         cr = self._create_dataset()
-        self.assertEqual('issued' in cr['research_dataset'], True, cr)
+        initial_issued_date = cr['research_dataset']['issued']
 
         # create draft
         draft_cr = self._create_draft(cr['id'])
-        self.assertEqual('issued' in draft_cr['research_dataset'], True, draft_cr)
-        # merge draft back to original
-        self._merge_draft_changes(draft_cr['id'])
-
-        # Issued date should be the same as in original published dataset
-        response = self.client.get('/rest/v2/datasets/%s' % cr['id'], format="json")
-        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
-        self.assertEqual(draft_cr['research_dataset']['issued'],
-            cr['research_dataset']['issued'], 'issued_date should be the same')
-
-    def test_missing_issued_date_is_generated_when_draft_is_merged(self):
-        '''If issued_date is removed in draft update, it is created from date_modified
-            when dataset is published and is thus different to issued_date in original dataset
-        '''
-        cr = self._create_dataset()
-        self.assertEqual('issued' in cr['research_dataset'], True, cr)
-        issued_date = cr['research_dataset'] # Original from date_created
-
-        # create draft and remove issued_date
-        draft_cr = self._create_draft(cr['id'])
         draft_cr['research_dataset'].pop('issued', None)
+
         # update the draft
         response = self.client.put('/rest/v2/datasets/%d' % draft_cr['id'], draft_cr, format="json")
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
-        # merge draft back to original published dataset
+
+        # merge draft changes back to original published dataset
         self._merge_draft_changes(draft_cr['id'])
 
-        # Issued date should be created to original dataset
+        # changes should now reflect on original published dataset
         response = self.client.get('/rest/v2/datasets/%s' % cr['id'], format="json")
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
-        self.assertEqual('issued' in response.data['research_dataset'], True, response.data)
-        # Issued date should be created based on date_modified
-        self.assertNotEqual(issued_date,
-            cr['research_dataset']['issued'], 'issued should now be created from date_modified')
+        self.assertNotEqual(
+            response.data['research_dataset']['issued'],
+            initial_issued_date,
+            response.data
+        )
 
     def test_add_files_to_draft_normal_dataset(self):
         """

--- a/src/metax_api/tests/api/rest/v2/views/datasets/drafts.py
+++ b/src/metax_api/tests/api/rest/v2/views/datasets/drafts.py
@@ -70,6 +70,22 @@ class CatalogRecordDraftTests(CatalogRecordApiWriteCommon):
         cr = self.client.get('/rest/v2/datasets/13').data
         self.assertEqual('state' in cr, True)
 
+    def _test_issued_date_is_mandatory(self):
+        ''' Issued date is mandatory only for ida and att- catalogs '''
+        # ATT
+        self.cr_full_att_test_data['research_dataset'].pop('issued', None)
+
+        response = self.client.post('/rest/v2/datasets?draft=true', self.cr_full_att_test_data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.data)
+        self.assertTrue('issued' in response.data['research_dataset'], response.data)
+
+        # IDA
+        self.cr_full_ida_test_data['research_dataset'].pop('issued', None)
+
+        response = self.client.post('/rest/v2/datasets', self.cr_full_ida_test_data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.data)
+        self.assertTrue('issued' in response.data['research_dataset'], response.data)
+
     def test_change_state_field_through_API(self):
         """Fetch a dataset and change its state.
         Value should remain: 'published' """

--- a/src/metax_api/tests/api/rest/v2/views/datasets/drafts.py
+++ b/src/metax_api/tests/api/rest/v2/views/datasets/drafts.py
@@ -71,8 +71,9 @@ class CatalogRecordDraftTests(CatalogRecordApiWriteCommon):
         self.assertEqual('state' in cr, True)
 
     def _test_issued_date_is_not_generated_for_drafts(self):
-        '''  Drafts will not have the issued date generated
-             Field is created when dataset is published
+        '''
+        Drafts will not have the issued date generated
+        Field is created when dataset is published
         '''
         # Dataset without issued date
         self.cr_full_ida_test_data['research_dataset'].pop('issued', None)

--- a/src/metax_api/tests/api/rest/v2/views/datasets/write.py
+++ b/src/metax_api/tests/api/rest/v2/views/datasets/write.py
@@ -186,7 +186,7 @@ class CatalogRecordApiWriteCreateTests(CatalogRecordApiWriteCommon):
 
     def test_issued_date_is_mandatory(self):
         ''' Issued date is mandatory only for ida and att- catalogs '''
-        # ATT
+
         for catalog in [ATT_CATALOG, IDA_CATALOG]:
             dc = DataCatalog.objects.get(pk=2)
             dc.catalog_json['identifier'] = catalog
@@ -196,7 +196,7 @@ class CatalogRecordApiWriteCreateTests(CatalogRecordApiWriteCommon):
             self.cr_test_data['data_catalog'] = dc.catalog_json
             self.cr_test_data['research_dataset'].pop('issued', None)
 
-            response = self.client.post('/rest/datasets', self.cr_test_data, format="json")
+            response = self.client.post('/rest/v2/datasets', self.cr_test_data, format="json")
             self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.data)
             self.assertTrue('issued' in response.data['research_dataset'], response.data)
 
@@ -1345,16 +1345,6 @@ class CatalogRecordApiWriteLegacyDataCatalogs(CatalogRecordApiWriteCommon):
         dc.force_save()
         del self.cr_test_data['research_dataset']['files']
         del self.cr_test_data['research_dataset']['total_files_byte_size']
-
-    def test_issued_date_not_mandatory(self):
-        # Issued date is mandatory only for ida and att- catalogs
-        self.cr_test_data['data_catalog'] = LEGACY_CATALOGS[0]
-        self.cr_test_data['research_dataset']['preferred_identifier'] = 'a'
-        self.cr_test_data['research_dataset'].pop('issued', None)
-
-        response = self.client.post('/rest/v2/datasets', self.cr_test_data, format="json")
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.data)
-        self.assertTrue('issued' not in response.data['research_dataset'], response.data)
 
     def test_legacy_catalog_pids_are_not_unique(self):
         # values provided as pid values in legacy catalogs are not required to be unique

--- a/src/metax_api/tests/api/rest/v2/views/datasets/write.py
+++ b/src/metax_api/tests/api/rest/v2/views/datasets/write.py
@@ -34,6 +34,7 @@ END_USER_ALLOWED_DATA_CATALOGS = django_settings.END_USER_ALLOWED_DATA_CATALOGS
 LEGACY_CATALOGS = django_settings.LEGACY_CATALOGS
 IDA_CATALOG = django_settings.IDA_DATA_CATALOG_IDENTIFIER
 EXT_CATALOG = django_settings.EXT_DATA_CATALOG_IDENTIFIER
+ATT_CATALOG = django_settings.ATT_DATA_CATALOG_IDENTIFIER
 
 
 def create_end_user_catalogs():
@@ -180,6 +181,24 @@ class CatalogRecordApiWriteCreateTests(CatalogRecordApiWriteCommon):
     #
     #
     #
+    def setUp(self):
+        super().setUp()
+
+    def test_issued_date_is_mandatory(self):
+        ''' Issued date is mandatory only for ida and att- catalogs '''
+        # ATT
+        for catalog in [ATT_CATALOG, IDA_CATALOG]:
+            dc = DataCatalog.objects.get(pk=2)
+            dc.catalog_json['identifier'] = catalog
+            dc.force_save()
+
+            # Create a catalog record in att catalog
+            self.cr_test_data['data_catalog'] = dc.catalog_json
+            self.cr_test_data['research_dataset'].pop('issued', None)
+
+            response = self.client.post('/rest/datasets', self.cr_test_data, format="json")
+            self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.data)
+            self.assertTrue('issued' in response.data['research_dataset'], response.data)
 
     def test_create_catalog_record(self):
         self.cr_test_data['research_dataset']['preferred_identifier'] = 'this_should_be_overwritten'
@@ -1326,6 +1345,16 @@ class CatalogRecordApiWriteLegacyDataCatalogs(CatalogRecordApiWriteCommon):
         dc.force_save()
         del self.cr_test_data['research_dataset']['files']
         del self.cr_test_data['research_dataset']['total_files_byte_size']
+
+    def test_issued_date_not_mandatory(self):
+        # Issued date is mandatory only for ida and att- catalogs
+        self.cr_test_data['data_catalog'] = LEGACY_CATALOGS[0]
+        self.cr_test_data['research_dataset']['preferred_identifier'] = 'a'
+        self.cr_test_data['research_dataset'].pop('issued', None)
+
+        response = self.client.post('/rest/v2/datasets', self.cr_test_data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.data)
+        self.assertTrue('issued' not in response.data['research_dataset'], response.data)
 
     def test_legacy_catalog_pids_are_not_unique(self):
         # values provided as pid values in legacy catalogs are not required to be unique

--- a/src/metax_api/tests/api/rest/v2/views/datasets/write.py
+++ b/src/metax_api/tests/api/rest/v2/views/datasets/write.py
@@ -184,8 +184,8 @@ class CatalogRecordApiWriteCreateTests(CatalogRecordApiWriteCommon):
     def setUp(self):
         super().setUp()
 
-    def test_issued_date_is_mandatory(self):
-        ''' Issued date is mandatory only for ida and att- catalogs '''
+    def test_issued_date_is_generated(self):
+        ''' Issued date is generated for all but harvested catalogs if it doesn't exists '''
 
         for catalog in [ATT_CATALOG, IDA_CATALOG]:
             dc = DataCatalog.objects.get(pk=2)


### PR DESCRIPTION
Make issued_date mandatory field for ida and att-catalogs
If issued_date is not set, todays date is filled in
If issued_date is empty, error is returned