### PR TITLE
CSCFAIRMETA-704 [FIX] merge-draft-does-not-save-changes

### DIFF
--- a/src/metax_api/models/catalog_record_v2.py
+++ b/src/metax_api/models/catalog_record_v2.py
@@ -303,6 +303,7 @@ class CatalogRecordV2(CatalogRecord):
         origin_cr = CatalogRecordV2.objects.get(next_draft_id=self.id)
         draft_cr = self
 
+        origin_cr.preservation_state = draft_cr.preservation_state
         origin_cr.date_modified = get_tz_aware_now_without_micros()
         origin_cr.user_modified = draft_cr.user_modified
 

--- a/src/metax_api/tests/api/rest/v2/views/datasets/drafts.py
+++ b/src/metax_api/tests/api/rest/v2/views/datasets/drafts.py
@@ -446,9 +446,6 @@ class CatalogRecordDraftsOfPublished(CatalogRecordApiWriteCommon):
         )
         self.assertEqual('next_draft' in response.data, False, 'next_draft link should be gone')
 
-        # merge draft changes back to original published dataset
-        self._merge_draft_changes(draft_cr['id'])
-
     def test_missing_issued_date_is_generated_when_draft_is_merged(self):
         """
         Testing a case where user removes 'issued_date' from draft before merging

--- a/src/metax_api/tests/api/rest/v2/views/datasets/drafts.py
+++ b/src/metax_api/tests/api/rest/v2/views/datasets/drafts.py
@@ -409,6 +409,7 @@ class CatalogRecordDraftsOfPublished(CatalogRecordApiWriteCommon):
         # create draft
         draft_cr = self._create_draft(cr['id'])
         draft_cr['research_dataset']['title']['en'] = 'modified title'
+        draft_cr['preservation_state'] = 20
 
         # ensure original now has a link to next_draft
         response = self.client.get('/rest/v2/datasets/%s' % cr['id'], format="json")
@@ -438,7 +439,15 @@ class CatalogRecordDraftsOfPublished(CatalogRecordApiWriteCommon):
             draft_cr['research_dataset']['title'],
             response.data
         )
+        self.assertEqual(
+            response.data['preservation_state'],
+            draft_cr['preservation_state'],
+            response.data
+        )
         self.assertEqual('next_draft' in response.data, False, 'next_draft link should be gone')
+
+        # merge draft changes back to original published dataset
+        self._merge_draft_changes(draft_cr['id'])
 
     def test_missing_issued_date_is_generated_when_draft_is_merged(self):
         """


### PR DESCRIPTION
- In merge_draft take preservation_state from draft cr