### PR TITLE
CSCFAIRMETA-710: [FIX] _mapping endpoint and ES in testcases

### DIFF
--- a/src/metax_api/api/rpc/base/views/elasticsearch_rpc.py
+++ b/src/metax_api/api/rpc/base/views/elasticsearch_rpc.py
@@ -27,11 +27,19 @@ class ElasticsearchRPC(CommonRPC):
         if not isinstance(django_settings, dict):
             settings = django_settings.ELASTICSEARCH
 
-        connection_params = RDL._get_connection_parameters(settings)
-        esclient, scan = RDL._get_es_imports(settings['HOSTS'], connection_params)
+        connection_params = RDL.get_connection_parameters(settings)
+        esclient, scan = RDL.get_es_imports(settings['HOSTS'], connection_params)
 
         if not self.request.query_params:
             return Response(status=status.HTTP_200_OK)
+
+        elif '_mapping' in self.request.query_params:
+            try:
+                res = esclient.indices.get_mapping()
+            except Exception as e:
+                raise Http400(f'Error when accessing elasticsearch. {e}')
+
+            return Response(data=res, status=status.HTTP_200_OK)
 
         params = {}
         for k, v in self.request.query_params.items():

--- a/src/metax_api/api/rpc/base/views/elasticsearch_rpc.py
+++ b/src/metax_api/api/rpc/base/views/elasticsearch_rpc.py
@@ -28,7 +28,8 @@ class ElasticsearchRPC(CommonRPC):
             settings = django_settings.ELASTICSEARCH
 
         connection_params = RDL.get_connection_parameters(settings)
-        esclient, scan = RDL.get_es_imports(settings['HOSTS'], connection_params)
+        # returns scan object as well but that is not needed here
+        esclient = RDL.get_es_imports(settings['HOSTS'], connection_params)[0]
 
         if not self.request.query_params:
             return Response(status=status.HTTP_200_OK)

--- a/src/metax_api/settings.py
+++ b/src/metax_api/settings.py
@@ -521,9 +521,9 @@ if not executing_in_travis:
         }
     }
 
-if executing_in_test_case or executing_in_travis:
+if executing_in_travis:
     ELASTICSEARCH = {
-        'HOSTS': ['metax-demo.fairdata.fi/es'],
+        'HOSTS': ['metax.demo.fairdata.fi/es'],
         'USE_SSL': True,
         'ALWAYS_RELOAD_REFERENCE_DATA_ON_RESTART': True,
     }

--- a/src/metax_api/utils/reference_data_loader.py
+++ b/src/metax_api/utils/reference_data_loader.py
@@ -72,8 +72,8 @@ class ReferenceDataLoader():
         if not isinstance(settings, dict):
             settings = settings.ELASTICSEARCH
 
-        connection_params = cls._get_connection_parameters(settings)
-        esclient, scan = cls._get_es_imports(settings['HOSTS'], connection_params)
+        connection_params = cls.get_connection_parameters(settings)
+        esclient, scan = cls.get_es_imports(settings['HOSTS'], connection_params)
 
         reference_data = {}
         for index_name in esclient.indices.get_mapping().keys():
@@ -151,7 +151,7 @@ class ReferenceDataLoader():
         return reference_data
 
     @staticmethod
-    def _get_connection_parameters(settings):
+    def get_connection_parameters(settings):
         """
         https://docs.objectrocket.com/elastic_python_examples.html
         """
@@ -165,7 +165,7 @@ class ReferenceDataLoader():
         return {}
 
     @staticmethod
-    def _get_es_imports(hosts, conn_params):
+    def get_es_imports(hosts, conn_params):
         """
         Returns correct version of the elasticsearch python client.
         This is needed in the transition between elasticsearch major versions because


### PR DESCRIPTION
- Correctly call elasticsearch when request comes to _mapping endpoint
- Local tests can be run against local elasticsearch which reduces the
  population time
- Follow naming convention in refdata loader with non-internal
  functions