### PR TITLE
CSCFAIRMETA-716: [FIX] create-draft-internal-error-when-draft-already…

### DIFF
--- a/src/metax_api/models/catalog_record_v2.py
+++ b/src/metax_api/models/catalog_record_v2.py
@@ -1136,6 +1136,11 @@ class CatalogRecordV2(CatalogRecord):
             # a new dataset in draft state
             raise Http400('Dataset is already draft.')
 
+        if self.next_draft:
+            raise Http400(
+                'The dataset already has an existing unmerged draft: {}'.format(self.next_draft.preferred_identifier)
+            )
+
         origin_cr = self
 
         draft_cr = origin_cr._create_new_dataset_version_template()

--- a/src/metax_api/tests/api/rest/v2/views/datasets/drafts.py
+++ b/src/metax_api/tests/api/rest/v2/views/datasets/drafts.py
@@ -399,6 +399,19 @@ class CatalogRecordDraftsOfPublished(CatalogRecordApiWriteCommon):
         draft_found = CR.objects_unfiltered.filter(pk=draft_id).exists()
         self.assertEqual(draft_found, False)
 
+    def test_create_draft_not_locked_before_merge(self):
+        """
+        Tests that more than 1 temporary drafts can't be created
+        """
+        cr = self._create_dataset()
+        # create draft
+        response = self.client.post('/rpc/v2/datasets/create_draft?identifier=%d' % cr['id'], format="json")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.data)
+
+        # create draft
+        response = self.client.post('/rpc/v2/datasets/create_draft?identifier=%d' % cr['id'], format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.data)
+
     def test_create_and_merge_draft(self):
         """
         A simple test to create a draft, change some metadata, and publish the changes.


### PR DESCRIPTION
…-exists

- Add a check for next_draft