### PR TITLE
CSCFAIRMETA-760-Return-pids-instead-of-urns

### DIFF
--- a/src/metax_api/services/file_service.py
+++ b/src/metax_api/services/file_service.py
@@ -231,17 +231,17 @@ class FileService(CommonService, ReferenceDataMixin):
                      % (params, '\n'.join(str(id) for id in ids[:10])))
 
         noparams = """
-            SELECT research_dataset->>'preferred_identifier' AS preferred_identifier
+            SELECT cr.identifier
             FROM metax_api_catalogrecord cr
             INNER JOIN metax_api_catalogrecord_files cr_f
                 ON catalogrecord_id = cr.id
             WHERE cr_f.file_id IN %s
                 AND cr.removed = false AND cr.active = true AND cr.deprecated = false
-            GROUP BY preferred_identifier
+            GROUP BY cr.identifier
             """
 
         files = """
-            SELECT f.identifier, json_agg(cr.research_dataset->>'preferred_identifier')
+            SELECT f.identifier, json_agg(cr.identifier)
             FROM metax_api_file f
             JOIN metax_api_catalogrecord_files cr_f
                 ON f.id=cr_f.file_id
@@ -256,7 +256,7 @@ class FileService(CommonService, ReferenceDataMixin):
         files_keysonly = files.replace(", json_agg(cr.research_dataset->>'preferred_identifier')", "")
 
         datasets = """
-            SELECT cr.research_dataset->>'preferred_identifier', json_agg(f.identifier)
+            SELECT cr.identifier, json_agg(f.identifier)
             FROM metax_api_file f
             JOIN metax_api_catalogrecord_files cr_f
                 ON f.id=cr_f.file_id

--- a/src/metax_api/tests/api/rest/base/views/files/read.py
+++ b/src/metax_api/tests/api/rest/base/views/files/read.py
@@ -125,6 +125,27 @@ class FileApiReadGetRelatedDatasets(FileApiReadCommon):
         self._assert_results_length(response, 2) # Only datasets 1 and 2 have files
         self.assertEqual(type(response.data), list, type(response.data)) # no dict keys
 
+    def test_return_is_pids_not_urns(self):
+        """
+        Endpoint should return pids, not urns
+        """
+        dataset_identifiers = ["cr955e904-e3dd-4d7e-99f1-3fed446f96d1",
+                    2,
+                    3,
+                    "cr955e904-e3dd-4d7e-99f1-3fed446f96d5"]
+
+        # Check that keys=datasets returns dataset pids as keys and not urns
+        response = self.client.post('/rest/files/datasets?keys=datasets', dataset_identifiers, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
+        for pid in response.data.keys():
+            self.assertEqual('urn:' not in pid, True, response.data)
+
+        # Check that keys=files returns dataset pids and not urns
+        response = self.client.post('/rest/files/datasets?keys=files', ["pid:urn:1"], format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
+        for pid in response.data.values():
+            self.assertEqual('urn:' not in pid, True, response.data)
+
     def test_get_detailed_related_datasets_ok_1(self):
         """
         File identifiers listed below should belong to 3 datasets

--- a/src/metax_api/tests/api/rest/base/views/files/read.py
+++ b/src/metax_api/tests/api/rest/base/views/files/read.py
@@ -125,27 +125,6 @@ class FileApiReadGetRelatedDatasets(FileApiReadCommon):
         self._assert_results_length(response, 2) # Only datasets 1 and 2 have files
         self.assertEqual(type(response.data), list, type(response.data)) # no dict keys
 
-    def test_return_is_pids_not_urns(self):
-        """
-        Endpoint should return pids, not urns
-        """
-        dataset_identifiers = ["cr955e904-e3dd-4d7e-99f1-3fed446f96d1",
-                    2,
-                    3,
-                    "cr955e904-e3dd-4d7e-99f1-3fed446f96d5"]
-
-        # Check that keys=datasets returns dataset pids as keys and not urns
-        response = self.client.post('/rest/files/datasets?keys=datasets', dataset_identifiers, format='json')
-        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
-        for pid in response.data.keys():
-            self.assertEqual('urn:' not in pid, True, response.data)
-
-        # Check that keys=files returns dataset pids and not urns
-        response = self.client.post('/rest/files/datasets?keys=files', ["pid:urn:1"], format='json')
-        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
-        for pid in response.data.values():
-            self.assertEqual('urn:' not in pid, True, response.data)
-
     def test_get_detailed_related_datasets_ok_1(self):
         """
         File identifiers listed below should belong to 3 datasets
@@ -220,6 +199,47 @@ class FileApiReadGetRelatedDatasets(FileApiReadCommon):
         # set of all returned datasets
         self.assertEqual(len(set(sum(response.data.values(), []))), 10, response.data)
 
+    def test_get_right_files_and_datasets(self):
+        """
+        Check that returned files and datasets are the right ones
+        """
+        testfile = self._get_object_from_test_data('file')
+
+        cr = self.client.get('/rest/datasets/10', format='json')
+        self.assertEqual(cr.status_code, status.HTTP_200_OK, cr.data)
+
+        response = self.client.post('/rest/files/datasets?keys=datasets', [cr.data['identifier']], format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
+        # cr 10 has 2 default files
+        self.assertEqual(response.data == {'cr955e904-e3dd-4d7e-99f1-3fed446f9610':
+        ['pid:urn:19', 'pid:urn:20']}, True, response.data)
+
+        response = self.client.post('/rest/files/datasets?keys=files', [testfile['identifier']], format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
+        # file 1 belongs to 3 datasets
+        self.assertEqual(response.data == {'pid:urn:1': ['cr955e904-e3dd-4d7e-99f1-3fed446f96d1',
+            'cr955e904-e3dd-4d7e-99f1-3fed446f9611', 'cr955e904-e3dd-4d7e-99f1-3fed446f9612']}, True, response.data)
+
+        # Dataset 11 has 20 files in a directory
+        cr = self.client.get('/rest/datasets/11', format='json')
+        self.assertEqual(cr.status_code, status.HTTP_200_OK, cr.data)
+
+        # Compare using return from different api
+        files_in_cr11 = self.client.get('/rest/datasets/11/files', format='json')
+        self.assertEqual(files_in_cr11.status_code, status.HTTP_200_OK, files_in_cr11.data)
+        identifiers = []
+        [identifiers.append(i['identifier']) for i in files_in_cr11.data]
+
+        response = self.client.post('/rest/files/datasets?keys=datasets', [11], format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
+        # This should have the same file id's as the return from /rest/v2/datasets/11/files
+        self.assertEqual(response.data['cr955e904-e3dd-4d7e-99f1-3fed446f9611'], identifiers, response.data)
+
+        response = self.client.post('/rest/files/datasets?keys=files', ['pid:urn:20'], format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
+        # Dataset 11 should be found from results
+        self.assertTrue('cr955e904-e3dd-4d7e-99f1-3fed446f9611' in response.data['pid:urn:20'], response.data)
+
     def test_get_related_datasets_files_not_found(self):
         """
         When the files themselves are not found, 404 should be returned
@@ -258,7 +278,6 @@ class FileApiReadGetRelatedDatasets(FileApiReadCommon):
     def _assert_results_length(self, response, length):
         self.assertTrue(isinstance(response.data, dict) or isinstance(response.data, list), response.data)
         self.assertEqual(len(response.data), length)
-
 
 class FileApiReadEndUserAccess(FileApiReadCommon):
 

--- a/src/metax_api/tests/api/rest/v2/views/files/read.py
+++ b/src/metax_api/tests/api/rest/v2/views/files/read.py
@@ -125,27 +125,6 @@ class FileApiReadGetRelatedDatasets(FileApiReadCommon):
         self._assert_results_length(response, 2) # Only datasets 1 and 2 have files
         self.assertEqual(type(response.data), list, type(response.data)) # no dict keys
 
-    def test_return_is_pids_not_urns(self):
-        """
-        Endpoint should return pids, not urns
-        """
-        dataset_identifiers = ["cr955e904-e3dd-4d7e-99f1-3fed446f96d1",
-                    2,
-                    3,
-                    "cr955e904-e3dd-4d7e-99f1-3fed446f96d5"]
-
-        # Check that keys=datasets returns dataset pids as keys and not urns
-        response = self.client.post('/rest/v2/files/datasets?keys=datasets', dataset_identifiers, format='json')
-        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
-        for pid in response.data.keys():
-            self.assertEqual('urn:' not in pid, True, response.data)
-
-        # Check that keys=files returns dataset pids and not urns
-        response = self.client.post('/rest/v2/files/datasets?keys=files', ["pid:urn:1"], format='json')
-        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
-        for pid in response.data.values():
-            self.assertEqual('urn:' not in pid, True, response.data)
-
     def test_get_detailed_related_datasets_ok_1(self):
         """
         File identifiers listed below should belong to 3 datasets

--- a/src/metax_api/tests/api/rest/v2/views/files/read.py
+++ b/src/metax_api/tests/api/rest/v2/views/files/read.py
@@ -148,7 +148,7 @@ class FileApiReadGetRelatedDatasets(FileApiReadCommon):
 
     def test_get_detailed_related_datasets_ok_1(self):
         """
-        File identifiers listed below should belong to 5 datasets
+        File identifiers listed below should belong to 3 datasets
         """
         response = self.client.post('/rest/v2/files/datasets?keys=files', [1], format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
@@ -219,6 +219,47 @@ class FileApiReadGetRelatedDatasets(FileApiReadCommon):
 
         # set of all returned datasets
         self.assertEqual(len(set(sum(response.data.values(), []))), 10, response.data)
+
+    def test_get_right_files_and_datasets(self):
+        """
+        Check that returned files and datasets are the right ones
+        """
+        testfile = self._get_object_from_test_data('file')
+
+        cr = self.client.get('/rest/v2/datasets/10', format='json')
+        self.assertEqual(cr.status_code, status.HTTP_200_OK, cr.data)
+
+        response = self.client.post('/rest/v2/files/datasets?keys=datasets', [cr.data['identifier']], format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
+        # cr 10 has 2 default files
+        self.assertEqual(response.data == {'cr955e904-e3dd-4d7e-99f1-3fed446f9610':
+        ['pid:urn:19', 'pid:urn:20']}, True, response.data)
+
+        response = self.client.post('/rest/v2/files/datasets?keys=files', [testfile['identifier']], format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
+        # file 1 belongs to 3 datasets
+        self.assertEqual(response.data == {'pid:urn:1': ['cr955e904-e3dd-4d7e-99f1-3fed446f96d1',
+            'cr955e904-e3dd-4d7e-99f1-3fed446f9611', 'cr955e904-e3dd-4d7e-99f1-3fed446f9612']}, True, response.data)
+
+        # Dataset 11 has 20 files in a directory
+        cr = self.client.get('/rest/v2/datasets/11', format='json')
+        self.assertEqual(cr.status_code, status.HTTP_200_OK, cr.data)
+
+        # Compare using return from different api
+        files_in_cr11 = self.client.get('/rest/v2/datasets/11/files', format='json')
+        self.assertEqual(files_in_cr11.status_code, status.HTTP_200_OK, files_in_cr11.data)
+        identifiers = []
+        [identifiers.append(i['identifier']) for i in files_in_cr11.data]
+
+        response = self.client.post('/rest/v2/files/datasets?keys=datasets', [11], format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
+        # This should have the same file id's as the return from /rest/v2/datasets/11/files
+        self.assertEqual(response.data['cr955e904-e3dd-4d7e-99f1-3fed446f9611'], identifiers, response.data)
+
+        response = self.client.post('/rest/v2/files/datasets?keys=files', ['pid:urn:20'], format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
+        # Dataset 11 should be found from results
+        self.assertTrue('cr955e904-e3dd-4d7e-99f1-3fed446f9611' in response.data['pid:urn:20'], response.data)
 
     def test_get_related_datasets_files_not_found(self):
         """

--- a/src/metax_api/tests/api/rest/v2/views/files/read.py
+++ b/src/metax_api/tests/api/rest/v2/views/files/read.py
@@ -111,19 +111,40 @@ class FileApiReadGetRelatedDatasets(FileApiReadCommon):
         """
         Parameter ?keysonly should return just values
         """
-        response = self.client.post('/rest/files/datasets?keys=files&keysonly', [1, 2, 121], format='json')
+        response = self.client.post('/rest/v2/files/datasets?keys=files&keysonly', [1, 2, 121], format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
         self._assert_results_length(response, 2) # pid:urn:121 does not belong to any dataset
         self.assertEqual(type(response.data), list, type(response.data)) # no dict keys
 
-        response = self.client.post('/rest/files/datasets?keys=files&keysonly=false', [1, 2], format='json')
+        response = self.client.post('/rest/v2/files/datasets?keys=files&keysonly=false', [1, 2], format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
         self.assertEqual(type(response.data), dict, response.data) # Return by keys
 
-        response = self.client.post('/rest/files/datasets?keys=datasets&keysonly', [1, 2, 14], format='json')
+        response = self.client.post('/rest/v2/files/datasets?keys=datasets&keysonly', [1, 2, 14], format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
         self._assert_results_length(response, 2) # Only datasets 1 and 2 have files
         self.assertEqual(type(response.data), list, type(response.data)) # no dict keys
+
+    def test_return_is_pids_not_urns(self):
+        """
+        Endpoint should return pids, not urns
+        """
+        dataset_identifiers = ["cr955e904-e3dd-4d7e-99f1-3fed446f96d1",
+                    2,
+                    3,
+                    "cr955e904-e3dd-4d7e-99f1-3fed446f96d5"]
+
+        # Check that keys=datasets returns dataset pids as keys and not urns
+        response = self.client.post('/rest/v2/files/datasets?keys=datasets', dataset_identifiers, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
+        for pid in response.data.keys():
+            self.assertEqual('urn:' not in pid, True, response.data)
+
+        # Check that keys=files returns dataset pids and not urns
+        response = self.client.post('/rest/v2/files/datasets?keys=files', ["pid:urn:1"], format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
+        for pid in response.data.values():
+            self.assertEqual('urn:' not in pid, True, response.data)
 
     def test_get_detailed_related_datasets_ok_1(self):
         """

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -491,9 +491,32 @@ paths:
           schema:
             $ref: '#/definitions/StringList'
         - $ref: "#/parameters/dryrun"
+        - name: keys=datasets
+          in: query
+          description: A list of dataset id's (integers) or identifiers (strings).
+                      Returns the files that belong to datasets. If dataset doesn't contain files,
+                      an empty list is returned.
+          required: false
+          schema:
+            $ref: '#/definitions/StringList'
+        - name: keys=files
+          in: query
+          description: A list of file id's (integers) or identifiers (strings).
+                        Returns the datasets that the file belongs to. If a file doesn't belong to any dataset,
+                        an empty list is returned.
+          required: false
+          schema:
+            $ref: '#/definitions/StringList'
+        - name: keysonly
+          in: query
+          description: Returns those files from original input that belong to a dataset,
+                        or in case of keys=datasets, returns those datasets from original list of datasets
+                        that have files.
+          required: false
+          type: boolean
       responses:
         '200':
-          description: A list of preferred_identifiers. if the files were not found to belong to any datasets, an empty list is returned
+          description: A list of pids. if the files were not found to belong to any datasets, or dataset didn't contain any files, an empty list is returned
         '403':
           description: Forbidden. Must have permission for resource
         '404':
@@ -617,7 +640,7 @@ paths:
           type: string
         - name: pagination
           in: query
-          description: Sets paging on with default limit of 10 
+          description: Sets paging on with default limit of 10
           required: false
           type: bolean
         - name: offset

--- a/swagger/v2/swagger.yaml
+++ b/swagger/v2/swagger.yaml
@@ -491,6 +491,29 @@ paths:
           schema:
             $ref: '#/definitions/StringList'
         - $ref: "#/parameters/dryrun"
+        - name: keys=datasets
+          in: query
+          description: A list of dataset id's (integers) or identifiers (strings).
+                      Returns the files that belong to datasets. If dataset doesn't contain files,
+                      an empty list is returned.
+          required: false
+          schema:
+            $ref: '#/definitions/StringList'
+        - name: keys=files
+          in: query
+          description: A list of file id's (integers) or identifiers (strings).
+                        Returns the datasets that the file belongs to. If a file doesn't belong to any dataset,
+                        an empty list is returned.
+          required: false
+          schema:
+            $ref: '#/definitions/StringList'
+        - name: keysonly
+          in: query
+          description: Returns those files from original input that belong to a dataset,
+                        or in case of keys=datasets, returns those datasets from original list of datasets
+                        that have files.
+          required: false
+          type: boolean
       responses:
         '200':
           description: A list of preferred_identifiers. if the files were not found to belong to any datasets, an empty list is returned
@@ -617,7 +640,7 @@ paths:
           type: string
         - name: pagination
           in: query
-          description: Sets paging on with default limit of 10 
+          description: Sets paging on with default limit of 10
           required: false
           type: bolean
         - name: offset


### PR DESCRIPTION
- Replace urn with pid in return
- Describe new parameters in swagger