### PR TITLE
CSCFAIRMETA-701: [FIX] crash on v2 dataset rpc api

### DIFF
--- a/src/metax_api/models/catalog_record_v2.py
+++ b/src/metax_api/models/catalog_record_v2.py
@@ -157,6 +157,9 @@ class CatalogRecordV2(CatalogRecord):
     def is_draft_for_another_dataset(self):
         return hasattr(self, 'draft_of') and self.draft_of is not None
 
+    def has_next_draft(self):
+        return hasattr(self, 'next_draft') and self.next_draft is not None
+
     def _save_as_draft(self):
         """
         Inherit here to always allow drafts in v2 api since the whole workflow is based on them
@@ -1206,6 +1209,11 @@ class CatalogRecordV2(CatalogRecord):
             raise Http400(
                 'Can\'t create new version. Dataset is a draft for another published dataset: %s'
                 % self.draft_of.identifier
+            )
+        elif self.has_next_draft():
+            raise Http400(
+                'Can\'t create new version. Dataset has an unmerged draft: %s'
+                % self.next_draft.identifier
             )
         elif not self.catalog_versions_datasets():
             raise Http400('Data catalog does not allow dataset versioning')

--- a/src/metax_api/tests/api/rpc/v2/views/dataset_rpc.py
+++ b/src/metax_api/tests/api/rpc/v2/views/dataset_rpc.py
@@ -295,7 +295,7 @@ class CatalogRecordVersionHandling(CatalogRecordApiWriteCommon):
 
     def test_draft_blocks_version_creation(self):
         """
-        Don't allow new versions if there are unmerged drafts
+        Don't allow new versions if there are unmerged drafts for a dataset
         """
         response = self.client.post('/rpc/v2/datasets/create_draft?identifier=1')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.data)

--- a/src/metax_api/tests/api/rpc/v2/views/dataset_rpc.py
+++ b/src/metax_api/tests/api/rpc/v2/views/dataset_rpc.py
@@ -293,6 +293,17 @@ class CatalogRecordVersionHandling(CatalogRecordApiWriteCommon):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.data)
         self.assertTrue('draft' in response.data['detail'][0], response.data)
 
+    def test_draft_blocks_version_creation(self):
+        """
+        Don't allow new versions if there are unmerged drafts
+        """
+        response = self.client.post('/rpc/v2/datasets/create_draft?identifier=1')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED, response.data)
+
+        response = self.client.post('/rpc/v2/datasets/create_new_version?identifier=1')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.data)
+        self.assertTrue('unmerged draft' in response.data['detail'][0], response.data)
+
     @responses.activate
     def test_authorization(self):
         """


### PR DESCRIPTION
- Prevents creating a new dataset version if there exists a draft