### PR TITLE
CSCFAIRADM-430: Update Travis links (.com) 

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,7 +1,12 @@
-metax-api service is made by:
+metax-api has been developed by:
 
-Hannu Kämäräinen
-Juha-Matti Lehtinen
-Joonas Kesäniemi
-Miika Alonen
-Osma Suominen
+junsk1
+tompulli
+jkesanie
+genie9
+osma
+amiika
+katrite
+hannu40k
+wvh
+MattiasLevlin

--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@ This repository contains the code for Metax API service.
 # Build status
 
 ## Test branch
-[![Build Status](https://travis-ci.org/CSCfi/metax-api.svg?branch=test)](https://travis-ci.org/CSCfi/metax-api)
+[![Build Status](https://travis-ci.com/CSCfi/metax-api.svg?branch=test)](https://travis-ci.com/CSCfi/metax-api)
 
 ## Stable branch
-[![Build Status](https://travis-ci.org/CSCfi/metax-api.svg?branch=stable)](https://travis-ci.org/CSCfi/metax-api)
+[![Build Status](https://travis-ci.com/CSCfi/metax-api.svg?branch=stable)](https://travis-ci.com/CSCfi/metax-api)
 
 License
 -------
-Copyright (c) 2018 Ministry of Education and Culture, Finland
+Copyright (c) 2018-2020 Ministry of Education and Culture, Finland
 
 Licensed under [GNU GPLv2 License](LICENSE)


### PR DESCRIPTION
- Update the Travis badges so that they link to travis-ci.com instead of the old travis-ci.org
- Also update license and authors info