### PR TITLE
CSCFAIRMETA-890-DOI-as-pref-identifier

### DIFF
--- a/src/metax_api/models/catalog_record.py
+++ b/src/metax_api/models/catalog_record.py
@@ -960,7 +960,7 @@ class CatalogRecord(Common):
         elif self.state == self.STATE_PUBLISHED:
             if self.has_alternate_records():
                 self._remove_from_alternate_record_set()
-            if get_identifier_type(self.preferred_identifier) == IdentifierType.DOI:
+            if is_metax_generated_doi_identifier(self.research_dataset['preferred_identifier']):
                 self.add_post_request_callable(DataciteDOIUpdate(self, self.research_dataset['preferred_identifier'],
                                                                 'delete'))
 
@@ -1253,7 +1253,8 @@ class CatalogRecord(Common):
             if (get_identifier_type(self.preferred_identifier) == IdentifierType.DOI or
                     self.use_doi_for_published is True):
                 self._validate_cr_against_datacite_schema()
-                self.add_post_request_callable(DataciteDOIUpdate(self,
+            if is_metax_generated_doi_identifier(self.research_dataset['preferred_identifier']):
+                    self.add_post_request_callable(DataciteDOIUpdate(self,
                                         self.research_dataset['preferred_identifier'], 'create'))
 
             if self._dataset_has_rems_managed_access() and settings.REMS['ENABLED']:
@@ -1458,8 +1459,9 @@ class CatalogRecord(Common):
         if get_identifier_type(self.preferred_identifier) == IdentifierType.DOI and \
                 self.update_datacite:
             self._validate_cr_against_datacite_schema()
-            self.add_post_request_callable(DataciteDOIUpdate(self, self.research_dataset['preferred_identifier'],
-                                                             'update'))
+            if is_metax_generated_doi_identifier(self.research_dataset['preferred_identifier']):
+                self.add_post_request_callable(DataciteDOIUpdate(self,
+                                                    self.research_dataset['preferred_identifier'], 'update'))
 
         if self.state == self.STATE_PUBLISHED:
             self.add_post_request_callable(RabbitMQPublishRecord(self, 'update'))
@@ -2035,7 +2037,7 @@ class CatalogRecord(Common):
 
         new_version.calculate_directory_byte_sizes_and_file_counts()
 
-        if pref_id_type == IdentifierType.DOI:
+        if is_metax_generated_doi_identifier(self.research_dataset['preferred_identifier']):
             self.add_post_request_callable(DataciteDOIUpdate(new_version,
                                                              new_version.research_dataset['preferred_identifier'],
                                                              'create'))

--- a/src/metax_api/models/catalog_record.py
+++ b/src/metax_api/models/catalog_record.py
@@ -1254,7 +1254,7 @@ class CatalogRecord(Common):
                     self.use_doi_for_published is True):
                 self._validate_cr_against_datacite_schema()
             if is_metax_generated_doi_identifier(self.research_dataset['preferred_identifier']):
-                    self.add_post_request_callable(DataciteDOIUpdate(self,
+                self.add_post_request_callable(DataciteDOIUpdate(self,
                                         self.research_dataset['preferred_identifier'], 'create'))
 
             if self._dataset_has_rems_managed_access() and settings.REMS['ENABLED']:

--- a/src/metax_api/services/datacite_service.py
+++ b/src/metax_api/services/datacite_service.py
@@ -185,8 +185,11 @@ class _DataciteService(CommonService):
         is_metax_urn = is_metax_generated_urn_identifier(identifier)
         is_remote_doi = is_remote_doi_identifier(identifier)
 
-        if is_metax_doi or is_remote_doi or dummy_doi:
+        if is_metax_doi or is_remote_doi:
             identifier_value = extract_doi_from_doi_identifier(identifier)
+            identifier_type = 'DOI'
+        elif dummy_doi:
+            identifier_value = '10.0/%s' % identifier
             identifier_type = 'DOI'
         elif not is_strict and is_metax_urn:
             identifier_value = identifier

--- a/src/metax_api/services/datacite_service.py
+++ b/src/metax_api/services/datacite_service.py
@@ -14,7 +14,7 @@ from datacite import schema41 as datacite_schema41, DataCiteMDSClient
 from django.conf import settings as django_settings
 
 from metax_api.utils import extract_doi_from_doi_identifier, is_metax_generated_doi_identifier, executing_travis, \
-    executing_test_case, is_metax_generated_urn_identifier, datetime_to_str
+    executing_test_case, is_metax_generated_urn_identifier, datetime_to_str, is_remote_doi_identifier
 from .common_service import CommonService
 
 _logger = logging.getLogger(__name__)
@@ -183,12 +183,10 @@ class _DataciteService(CommonService):
         identifier = cr_json.get('preservation_identifier', None) or pref_id
         is_metax_doi = is_metax_generated_doi_identifier(identifier)
         is_metax_urn = is_metax_generated_urn_identifier(identifier)
+        is_remote_doi = is_remote_doi_identifier(identifier)
 
-        if is_metax_doi:
+        if is_metax_doi or is_remote_doi or dummy_doi:
             identifier_value = extract_doi_from_doi_identifier(identifier)
-            identifier_type = 'DOI'
-        elif dummy_doi:
-            identifier_value = '10.0/%s' % identifier
             identifier_type = 'DOI'
         elif not is_strict and is_metax_urn:
             identifier_value = identifier

--- a/src/metax_api/settings/.env.template
+++ b/src/metax_api/settings/.env.template
@@ -11,5 +11,6 @@ METAX_DATABASE=<required>
 METAX_DATABASE_PASSWORD=<required>
 METAX_DATABASE_USER=<required>
 OAI_BASE_URL=<required>
+OAI_ETSIN_URL_TEMPLATE=<required>
 RABBIT_MQ_VHOST=<required>
 REMS_ENABLED=false

--- a/src/metax_api/tests/api/rest/base/views/datasets/write.py
+++ b/src/metax_api/tests/api/rest/base/views/datasets/write.py
@@ -847,6 +847,19 @@ class CatalogRecordApiWriteIdentifierUniqueness(CatalogRecordApiWriteCommon):
         self.assertEqual('preferred_identifier' in response.data['research_dataset'][0], True,
                          'The error should be about preferred_identifier already existing')
 
+    def test_remote_doi_dataset_is_validated_against_datacite_format(self):
+        # Remote input DOI ids need to take datasets for datacite validation
+        cr = {'research_dataset': self.cr_test_data['research_dataset']}
+        cr['research_dataset']['preferred_identifier'] = 'doi:10.5061/dryad.10188854'
+        cr['data_catalog'] = 3
+        cr['metadata_provider_org'] = 'metax'
+        cr['metadata_provider_user'] = 'metax'
+        cr['research_dataset'].pop('publisher', None)
+
+        response = self.client.post('/rest/datasets', cr, format="json")
+        # Publisher value is required for datacite format, so this should return Http400
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual('a required value for datacite format' in response.data['detail'][0], True, response.data)
     #
     # helpers
     #
@@ -863,7 +876,6 @@ class CatalogRecordApiWriteIdentifierUniqueness(CatalogRecordApiWriteCommon):
         cr.force_save()
         cr._handle_preferred_identifier_changed()
         return unique_identifier
-
 
 class CatalogRecordApiWriteDatasetSchemaSelection(CatalogRecordApiWriteCommon):
     #

--- a/src/metax_api/tests/api/rest/v2/views/datasets/write.py
+++ b/src/metax_api/tests/api/rest/v2/views/datasets/write.py
@@ -582,6 +582,20 @@ class CatalogRecordApiWriteIdentifierUniqueness(CatalogRecordApiWriteCommon):
         self.assertEqual('preferred_identifier' in response.data['research_dataset'][0], True,
                          'The error should be about preferred_identifier already existing')
 
+    def test_remote_doi_dataset_is_validated_against_datacite_format(self):
+        # Remote input DOI ids need to take datasets for datacite validation
+        cr = {'research_dataset': self.cr_test_data['research_dataset']}
+        cr['research_dataset']['preferred_identifier'] = 'doi:10.5061/dryad.10188854'
+        cr['data_catalog'] = 3
+        cr['metadata_provider_org'] = 'metax'
+        cr['metadata_provider_user'] = 'metax'
+        cr['research_dataset'].pop('publisher', None)
+
+        response = self.client.post('/rest/v2/datasets', cr, format="json")
+        # Publisher value is required for datacite format, so this should return Http400
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual('a required value for datacite format' in response.data['detail'][0], True, response.data)
+
     #
     # helpers
     #

--- a/src/metax_api/utils/utils.py
+++ b/src/metax_api/utils/utils.py
@@ -106,6 +106,18 @@ def is_metax_generated_doi_identifier(identifier):
 
     return identifier.startswith('doi:{0}/'.format(settings.DATACITE.get('PREFIX')))
 
+def is_remote_doi_identifier(identifier):
+    """
+    Check whether given identifier is a remote doi identifier
+
+    :param identifier:
+    :return: boolean
+    """
+    if not identifier or not settings.DATACITE.get('PREFIX', False):
+        return False
+
+    if identifier.startswith('doi:') and not identifier.startswith('doi:{0}/'.format(settings.DATACITE.get('PREFIX'))):
+        return True
 
 def is_metax_generated_urn_identifier(identifier):
     """


### PR DESCRIPTION
- Add a check for identifiers from remote datasets (whether those are DOIs and not Metax-generated DOIs)
- Add a check that remote datasets with DOI are
validated against datacite