### PR TITLE
delete flake8 check from travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,6 @@ before_script:
 - sudo chown -R $USER:$USER src/log
 
 script:
-- cd src && flake8 .
 - python manage.py migrate metax_api
 - coverage run --source="." manage.py test metax_api
 - COVERALLS_REPO_TOKEN=$coveralls_token coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ before_script:
 - sudo chown -R $USER:$USER src/log
 
 script:
-- python manage.py migrate metax_api
+- cd src && python manage.py migrate metax_api
 - coverage run --source="." manage.py test metax_api
 - COVERALLS_REPO_TOKEN=$coveralls_token coveralls
 


### PR DESCRIPTION
flake8 fails CI-builds, this is not intended behavior from Python linter 